### PR TITLE
Use rust-tools + potential bug fix

### DIFF
--- a/doc/LazyVim.txt
+++ b/doc/LazyVim.txt
@@ -1,4 +1,4 @@
-*LazyVim.txt*         For Neovim >= 0.8.0         Last change: 2023 January 09
+*LazyVim.txt*         For Neovim >= 0.8.0         Last change: 2023 January 10
 
 ==============================================================================
 Table of Contents                                  *LazyVim-table-of-contents*

--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -1,0 +1,58 @@
+return {
+
+  -- add c/c++ to treesitter
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = function(_, opts)
+      vim.list_extend(opts.ensure_installed, { "c", "cpp" })
+    end,
+  },
+
+  -- correctly setup lspconfig
+  {
+    "neovim/nvim-lspconfig",
+    dependencies = {
+      "p00f/clangd_extensions.nvim",
+      dependencies = {
+        "hrsh7th/cmp-nvim-lsp",
+      },
+    },
+    opts = {
+      -- make sure mason installs the server
+      servers = {
+        clangd = {},
+      },
+      setup = {
+        clangd = function(_, opts)
+          require("clangd_extensions").setup({
+            server = opts,
+            extensions = {
+              ast = {
+                --These require codicons (https://github.com/microsoft/vscode-codicons)
+                role_icons = {
+                  type = "",
+                  declaration = "",
+                  expression = "",
+                  specifier = "",
+                  statement = "",
+                  ["template argument"] = "",
+                },
+
+                kind_icons = {
+                  Compound = "",
+                  Recovery = "",
+                  TranslationUnit = "",
+                  PackExpansion = "",
+                  TemplateTypeParm = "",
+                  TemplateTemplateParm = "",
+                  TemplateParamObject = "",
+                },
+              },
+            },
+          })
+          return true
+        end,
+      },
+    },
+  },
+}

--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -1,0 +1,66 @@
+return {
+
+  -- add rust to treesitter
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = function(_, opts)
+      table.insert(opts.ensure_installed, "rust")
+    end,
+  },
+
+  -- correctly setup lspconfig for Rust 🚀
+  {
+    "neovim/nvim-lspconfig",
+    dependencies = {
+      "simrat39/rust-tools.nvim",
+      init = function()
+        require("lazyvim.util").on_attach(function(_, buffer)
+		  -- stylua: ignore
+		  vim.keymap.set("n", "<C-space>", "RustHoverActions", { buffer = buffer, desc = "Hover Actions (Rust)" })
+          vim.keymap.set("n", "<Leader>a", "RustCodeActionGroup", { buffer = buffer, desc = "Code Action (Rust)" })
+        end)
+      end,
+    },
+    opts = {
+      servers = {
+        rust_analyzer = {
+          settings = {
+            ["rust-analyzer"] = {
+              cargo = {
+                allFeatures = true,
+              },
+              checkOnSave = {
+                allFeatures = true,
+                command = "clippy",
+                extraArgs = { "--no-deps" },
+              },
+              procMacro = {
+                ignored = {
+                  ["async-trait"] = { "async_trait" },
+                  ["napi-derive"] = { "napi" },
+                  ["async-recursion"] = { "async_recursion" },
+                },
+              },
+            },
+          },
+        },
+      },
+      setup = {
+        rust_analyzer = function(_, opts)
+          local rust_opts = {
+            server = vim.tbl_deep_extend("force", {}, opts, opts.server or {}),
+            tools = { -- rust-tools options
+              -- options same as lsp hover / vim.lsp.util.open_floating_preview()
+              hover_actions = {
+                -- whether the hover action window gets automatically focused
+                auto_focus = true,
+              },
+            },
+          }
+          require("rust-tools").setup(rust_opts)
+          return true
+        end,
+      },
+    },
+  },
+}

--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -11,16 +11,7 @@ return {
   -- correctly setup lspconfig for Rust 🚀
   {
     "neovim/nvim-lspconfig",
-    dependencies = {
-      "simrat39/rust-tools.nvim",
-      init = function()
-        require("lazyvim.util").on_attach(function(_, buffer)
-		  -- stylua: ignore
-		  vim.keymap.set("n", "<C-space>", "RustHoverActions", { buffer = buffer, desc = "Hover Actions (Rust)" })
-          vim.keymap.set("n", "<Leader>a", "RustCodeActionGroup", { buffer = buffer, desc = "Code Action (Rust)" })
-        end)
-      end,
-    },
+    dependencies = { "simrat39/rust-tools.nvim" },
     opts = {
       servers = {
         rust_analyzer = {
@@ -47,6 +38,13 @@ return {
       },
       setup = {
         rust_analyzer = function(_, opts)
+          require("lazyvim.util").on_attach(function(client, buffer)
+            if client.name == "rust_analyzer" then
+			  -- stylua: ignore
+			  vim.keymap.set("n", "<leader>co", "RustHoverActions", { buffer = buffer, desc = "Hover Actions (Rust)" })
+              vim.keymap.set("n", "<leader>cR", "RustCodeActionGroup", { buffer = buffer, desc = "Code Action (Rust)" })
+            end
+          end)
           local rust_opts = {
             server = vim.tbl_deep_extend("force", {}, opts, opts.server or {}),
             tools = { -- rust-tools options

--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -70,6 +70,7 @@ return {
 
       local servers = opts.servers
       local capabilities = require("cmp_nvim_lsp").default_capabilities(vim.lsp.protocol.make_client_capabilities())
+      capabilities.offsetEncoding = { "utf-16" }
 
       require("mason-lspconfig").setup({ ensure_installed = vim.tbl_keys(servers) })
       require("mason-lspconfig").setup_handlers({


### PR DESCRIPTION
This PR adds rust-tools and is used when the detected client is named rust_analyzer. The reason for this is because rust-tools adds a lot of features and niceties similar to what vscode does. I would find beginners that write in Rust will greatly appreciate this QoL improvement.

On another note a small bug with c/c++ lsps is that there can be a flurry of notifs with "warning: multiple different client offset_encodings detected for buffer, this is not supported yet". The fix is to just make capabilities.offsetEncoding utf-16, this can really be discarded if you would think it could cause potential issues with something else..

Thanks again so much for your work on neovim plugin development!
Amaan