### PR TITLE
fix: add tsx treesitter to typescript lang module

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -4,7 +4,7 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
-      table.insert(opts.ensure_installed, "typescript")
+      vim.list_extend(opts.ensure_installed, { "typescript", "tsx" })
     end,
   },
 


### PR DESCRIPTION
After cleaning up my default treesitter modules (and move most into language specific plugins), I noticed that the typescript module is missing on the tsx parser (for typescript based jsx files)...