### PR TITLE
fix(config): don't set options to their defaults

### DIFF
--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -5,24 +5,21 @@ vim.g.maplocalleader = " "
 
 local opt = vim.opt
 
-opt.autowrite = true -- enable auto write
-opt.clipboard = "unnamedplus" -- sync with system clipboard
-opt.cmdheight = 1
+opt.autowrite = true -- Enable auto write
+opt.clipboard = "unnamedplus" -- Sync with system clipboard
 opt.completeopt = "menu,menuone,noselect"
 opt.conceallevel = 3 -- Hide * markup for bold and italic
-opt.confirm = true -- confirm to save changes before exiting modified buffer
+opt.confirm = true -- Confirm to save changes before exiting modified buffer
 opt.cursorline = true -- Enable highlighting of the current line
 opt.expandtab = true -- Use spaces instead of tabs
 opt.formatoptions = "jcroqlnt" -- tcqj
 opt.grepformat = "%f:%l:%c:%m"
 opt.grepprg = "rg --vimgrep"
-opt.hidden = true -- Enable modified buffers in background
 opt.ignorecase = true -- Ignore case
 opt.inccommand = "nosplit" -- preview incremental substitute
-opt.joinspaces = false -- No double spaces with join after a dot
 opt.laststatus = 0
 opt.list = true -- Show some invisible characters (tabs...
-opt.mouse = "a" -- enable mouse mode
+opt.mouse = "a" -- Enable mouse mode
 opt.number = true -- Print line number
 opt.pumblend = 10 -- Popup blend
 opt.pumheight = 10 -- Maximum number of entries in a popup
@@ -31,7 +28,8 @@ opt.scrolloff = 4 -- Lines of context
 opt.sessionoptions = { "buffers", "curdir", "tabpages", "winsize" }
 opt.shiftround = true -- Round indent
 opt.shiftwidth = 2 -- Size of an indent
-opt.showmode = false -- dont show mode since we have a statusline
+opt.shortmess:append { W = true, I = true, c = true }
+opt.showmode = false -- Dont show mode since we have a statusline
 opt.sidescrolloff = 8 -- Columns of context
 opt.signcolumn = "yes" -- Always show the signcolumn, otherwise it would shift the text each time
 opt.smartcase = true -- Don't ignore case with capitals
@@ -44,15 +42,15 @@ opt.termguicolors = true -- True color support
 opt.timeoutlen = 300
 opt.undofile = true
 opt.undolevels = 10000
-opt.updatetime = 200 -- save swap file and trigger CursorHold
+opt.updatetime = 200 -- Save swap file and trigger CursorHold
 opt.wildmode = "longest:full,full" -- Command-line completion mode
-opt.winminwidth = 5 -- minimum window width
+opt.winminwidth = 5 -- Minimum window width
 opt.wrap = false -- Disable line wrap
 
 if vim.fn.has("nvim-0.9.0") == 1 then
   opt.splitkeep = "screen"
-  opt.shortmess = "filnxtToOFWIcC"
+  opt.shortmess:append { C = true }
 end
 
--- fix markdown indentation settings
+-- Fix markdown indentation settings
 vim.g.markdown_recommended_style = 0


### PR DESCRIPTION
Closes #119.

Note: I've set the viable `opt.shortmess` options outside of the `has("nvim-0.9.0")` feature gate as well, assuming they weren't left out intentionally.