### PR TITLE
make argc if statement more readable

### DIFF
--- a/lua/lazyvim/config/init.lua
+++ b/lua/lazyvim/config/init.lua
@@ -79,7 +79,9 @@ function M.setup(opts)
     error("Exiting")
   end
 
-  if vim.fn.argc(-1) == 0 then
+  -- 
+  local file_argument = vim.fn.argc(-1) == 0
+  if file_argument then
     -- autocmds and keymaps can wait to load
     vim.api.nvim_create_autocmd("User", {
       group = vim.api.nvim_create_augroup("LazyVim", { clear = true }),


### PR DESCRIPTION
I was just skimming the code until I saw the vim.fn.argc snippet, I didn't know what was going on at first and did a quick google search
just declared a variable so that the reader knows whats going on