### PR TITLE
feat: use trouble quicklist / loclist if available

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -91,13 +91,8 @@ map("n", "<leader>l", "<cmd>:Lazy<cr>", { desc = "Lazy" })
 -- new file
 map("n", "<leader>fn", "<cmd>enew<cr>", { desc = "New File" })
 
-if Util.has("trouble.nvim") then
-  map("n", "<leader>xl", "<cmd>Trouble loclist<cr>", { desc = "Open Location List (Trouble)" })
-  map("n", "<leader>xq", "<cmd>Trouble quickfix<cr>", { desc = "Open Quickfix List (Trouble)" })
-else
-  map("n", "<leader>xl", "<cmd>lopen<cr>", { desc = "Open Location List" })
-  map("n", "<leader>xq", "<cmd>copen<cr>", { desc = "Open Quickfix List" })
-end
+map("n", "<leader>xl", "<cmd>lopen<cr>", { desc = "Location List" })
+map("n", "<leader>xq", "<cmd>copen<cr>", { desc = "Quickfix List" })
 
 -- stylua: ignore start
 

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -91,8 +91,13 @@ map("n", "<leader>l", "<cmd>:Lazy<cr>", { desc = "Lazy" })
 -- new file
 map("n", "<leader>fn", "<cmd>enew<cr>", { desc = "New File" })
 
-map("n", "<leader>xl", "<cmd>lopen<cr>", { desc = "Open Location List" })
-map("n", "<leader>xq", "<cmd>copen<cr>", { desc = "Open Quickfix List" })
+if Util.has("trouble.nvim") then
+  map("n", "<leader>xl", "<cmd>Trouble loclist<cr>", { desc = "Open Location List (Trouble)" })
+  map("n", "<leader>xq", "<cmd>Trouble quickfix<cr>", { desc = "Open Quickfix List (Trouble)" })
+else
+  map("n", "<leader>xl", "<cmd>lopen<cr>", { desc = "Open Location List" })
+  map("n", "<leader>xq", "<cmd>copen<cr>", { desc = "Open Quickfix List" })
+end
 
 -- stylua: ignore start
 

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -262,6 +262,8 @@ return {
     keys = {
       { "<leader>xx", "<cmd>TroubleToggle document_diagnostics<cr>", desc = "Document Diagnostics (Trouble)" },
       { "<leader>xX", "<cmd>TroubleToggle workspace_diagnostics<cr>", desc = "Workspace Diagnostics (Trouble)" },
+      { "<leader>xL", "<cmd>TroubleToggle loclist<cr>", desc = "Location List (Trouble)" },
+      { "<leader>xQ", "<cmd>TroubleToggle quickfix<cr>", desc = "Quickfix List (Trouble)" },
     },
   },
 


### PR DESCRIPTION
If `trouble.nvim` is available: use the quicklist / loclist feature of it, otherwise fallback to the buildin ones.