### PR TITLE
fix(mini.surround): user can change keybinds again

### DIFF
--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -92,20 +92,6 @@ return {
   -- surround
   {
     "echasnovski/mini.surround",
-    keys = function(plugin, keys)
-      -- Populate the keys based on the user's options
-      local opts = require("lazy.core.plugin").values(plugin, "opts", false)
-      local mappings = {
-        { opts.mappings.add, desc = "Add surrounding", mode = { "n", "v" } },
-        { opts.mappings.delete, desc = "Delete surrounding" },
-        { opts.mappings.find, desc = "Find right surrounding" },
-        { opts.mappings.find_left, desc = "Find left surrounding" },
-        { opts.mappings.highlight, desc = "Highlight surrounding" },
-        { opts.mappings.replace, desc = "Replace surrounding" },
-        { opts.mappings.update_n_lines, desc = "Update `MiniSurround.config.n_lines`" },
-      }
-      return vim.list_extend(mappings, keys)
-    end,
     opts = {
       mappings = {
         add = "gza", -- Add surrounding in Normal and Visual modes


### PR DESCRIPTION
This is related to this issue: https://github.com/LazyVim/LazyVim/issues/172

This `keys` function is preventing the user from changing `mini.surround` keybinds. I removed this and now the user can change the keybinds again.

It looks like this code was here so the keybinds correctly show up in WhichKey, but after removing them they still show up there like expected. Here is a screenshot:

![image](https://user-images.githubusercontent.com/30273418/216815519-45740121-7fc0-4d4a-8cb7-5e4375c84595.png)

The reason that it didn't work before is because the `plugin` parameter contains the `opt` **before** the user's custom keybinds. So it was still using the `gz...` mappings, instead of the user's custom mappings. This means that no matter what the user provided in `opts`, it would always use the old `opts.mappings`.