### PR TITLE
Improve Telescope mappings

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -133,6 +133,23 @@ return {
             ["<C-Up>"] = function(...)
               return require("telescope.actions").cycle_history_prev(...)
             end,
+            ["<C-n>"] = function(...)
+              return require("telescope.actions").cycle_history_next(...)
+            end,
+            ["<C-p>"] = function(...)
+              return require("telescope.actions").cycle_history_prev(...)
+            end,
+            ["<C-j>"] = function(...)
+              return require("telescope.actions").move_selection_next(...)
+            end,
+            ["<C-k>"] = function(...)
+              return require("telescope.actions").move_selection_previous(...)
+            end,
+          },
+          n = {
+            ["q"] = function(...)
+              return require("telescope.actions").close(...)
+            end,
           },
         },
       },


### PR DESCRIPTION
- Adds `<C-j>`/`<C-k>` in insert mode to scroll in results list
- Adds `<C-n>`/`<C-p>` in insert mode to scroll in preview
  - Maybe `<C-b>`/`<C-f>` or `<C-u>`/`<C-d>` could be used?
- Adds `q` in normal mode to quit

> Inspired by AstroNvim