### PR TITLE
feat: add copilot icon

### DIFF
--- a/lua/lazyvim/config/init.lua
+++ b/lua/lazyvim/config/init.lua
@@ -30,6 +30,7 @@ local defaults = {
       Color = " ",
       Constant = " ",
       Constructor = " ",
+      Copilot = " ",
       Enum = " ",
       EnumMember = " ",
       Event = " ",


### PR DESCRIPTION
While setting up [copilot-cmp](https://github.com/zbirenbaum/copilot-cmp) I figured adding to the icons in LavyVim is the quickest way for me to get the icon support.

<img width="661" alt="Screenshot 2023-02-06 at 9 32 53 PM" src="https://user-images.githubusercontent.com/2036594/217141629-4e8b3701-e45d-444d-9c1b-efd4c6f413be.png">

Let me know if there's a simple way to extend the kinds icons if you don't think this is the right place to add it.