### PR TITLE
Improved Telescope mappings in normal and insert mode

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -133,6 +133,23 @@ return {
             ["<C-Up>"] = function(...)
               return require("telescope.actions").cycle_history_prev(...)
             end,
+            ["<C-j>"] = function(...)
+              return require("telescope.actions").move_selection_next(...)
+            end,
+            ["<C-k>"] = function(...)
+              return require("telescope.actions").move_selection_previous(...)
+            end,
+            ["<C-n>"] = function(...)
+              return require("telescope.actions").preview_scrolling_down(...)
+            end,
+            ["<C-p>"] = function(...)
+              return require("telescope.actions").preview_scrolling_up(...)
+            end,
+          },
+          n = {
+            ["q"] = function(...)
+              return require("telescope.actions").close(...)
+            end,
           },
         },
       },


### PR DESCRIPTION
I saw @Cretezy 's pull request and realized I made the same modifications in my own config, but with `move_selection_next` and `move_selection_previous` instead of `cycle_history`. So, this PR
- In `insert` mode
  - Adds `<C-j>`/`<C-k>` to scroll in results list
  - Adds `<C-n>`/`<C-p>`  to scroll in preview
- In `normal` mode
  - Adds `q` to quit