### PR TITLE
chore: better dependency declaration for leap/flit

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -139,11 +139,10 @@ return {
     },
   },
 
-  -- easily jump to any location and enhanced f/t motions for Leap
+  -- enhanced 2-char search motions
   {
     "ggandor/leap.nvim",
     event = "VeryLazy",
-    dependencies = { { "ggandor/flit.nvim", opts = { labeled_modes = "nv" } } },
     config = function(_, opts)
       local leap = require("leap")
       for k, v in pairs(opts) do
@@ -151,6 +150,12 @@ return {
       end
       leap.add_default_mappings(true)
     end,
+  },
+  -- easily jump to any location and enhanced f/t motions for Leap
+  {
+    "ggandor/flit.nvim",
+    dependencies = { { "ggandor/leap.nvim" } },
+    opts = { labeled_modes = "nv" },
   },
 
   -- which-key


### PR DESCRIPTION
## What

Decouples plugin table entries for leap.nvim and flit.nvim

## Why

As `flit` depends on `leap` and `leap` should be a component on its own (and works as such), declarations are decoupled with a more apt  flit -> leap dependency declaration to make the intent and effect clearer.
