### PR TITLE
feat(telescope): add `<leader>fR` for `:Telescope resume`

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -73,7 +73,6 @@ return {
       { "<leader>ff", Util.telescope("files"), desc = "Find Files (root dir)" },
       { "<leader>fF", Util.telescope("files", { cwd = false }), desc = "Find Files (cwd)" },
       { "<leader>fr", "<cmd>Telescope oldfiles<cr>", desc = "Recent" },
-      { "<leader>fR", "<cmd>Telescope resume<cr>", desc = "Resume" },
       -- git
       { "<leader>gc", "<cmd>Telescope git_commits<CR>", desc = "commits" },
       { "<leader>gs", "<cmd>Telescope git_status<CR>", desc = "status" },
@@ -91,6 +90,7 @@ return {
       { "<leader>sM", "<cmd>Telescope man_pages<cr>", desc = "Man Pages" },
       { "<leader>sm", "<cmd>Telescope marks<cr>", desc = "Jump to Mark" },
       { "<leader>so", "<cmd>Telescope vim_options<cr>", desc = "Options" },
+      { "<leader>sR", "<cmd>Telescope resume<cr>", desc = "Resume" },
       { "<leader>sw", Util.telescope("grep_string"), desc = "Word (root dir)" },
       { "<leader>sW", Util.telescope("grep_string", { cwd = false }), desc = "Word (cwd)" },
       { "<leader>uC", Util.telescope("colorscheme", { enable_preview = true }), desc = "Colorscheme with preview" },

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -73,6 +73,7 @@ return {
       { "<leader>ff", Util.telescope("files"), desc = "Find Files (root dir)" },
       { "<leader>fF", Util.telescope("files", { cwd = false }), desc = "Find Files (cwd)" },
       { "<leader>fr", "<cmd>Telescope oldfiles<cr>", desc = "Recent" },
+      { "<leader>fR", "<cmd>Telescope resume<cr>", desc = "Resume" },
       -- git
       { "<leader>gc", "<cmd>Telescope git_commits<CR>", desc = "commits" },
       { "<leader>gs", "<cmd>Telescope git_status<CR>", desc = "status" },


### PR DESCRIPTION
I've recently switched to LazyVim and really liked many of the out-of-the-box defaults. One keybind I would like though is a way to quickly call `Telescope resume`. I thought `<leader>fR` might be a good place for it. Let me know what you think.

Thanks!