### PR TITLE
fix(lualine): add a space separator between progress & location

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -145,7 +145,7 @@ return {
             },
           },
           lualine_y = {
-            { "progress", separator = "", padding = { left = 1, right = 0 } },
+            { "progress", separator = " ", padding = { left = 1, right = 0 } },
             { "location", padding = { left = 0, right = 1 } },
           },
           lualine_z = {


### PR DESCRIPTION
Currently there is an issue for any file with more than 100 lines where the progress and location indicators are merged into a single word:

<img width="325" alt="Screenshot 2023-02-16 at 17 12 42" src="https://user-images.githubusercontent.com/84287187/219508462-5e2ff682-5ce6-4f96-a27a-c44937da3c48.png">

This change will fix this and insert at least one space in-between the two.