### PR TITLE
feat(telescope): add `<leader>sS` for `:Telescope lsp_workspace_symbols`

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -112,6 +112,24 @@ return {
         }),
         desc = "Goto Symbol",
       },
+      {
+        "<leader>sS",
+        Util.telescope("lsp_workspace_symbols", {
+          symbols = {
+            "Class",
+            "Function",
+            "Method",
+            "Constructor",
+            "Interface",
+            "Module",
+            "Struct",
+            "Trait",
+            "Field",
+            "Property",
+          },
+        }),
+        desc = "Goto Symbol (Workspace)",
+      },
     },
     opts = {
       defaults = {


### PR DESCRIPTION
I found myself often wanting to search trough the workspace symbols and i think this keymap makes the most sense, since there is already the same thing for document symbols with `<leader>ss`.
