### PR TITLE
fix: add description for "gw" keymap

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -64,8 +64,7 @@ map(
   { desc = "Redraw / clear hlsearch / diff update" }
 )
 
-map("n", "gw", "*N")
-map("x", "gw", "*N")
+map({ "n", "x" }, "gw", "*N", { desc = "Highlight under cursor" })
 
 -- https://github.com/mhinz/vim-galore#saner-behavior-of-n-and-n
 map("n", "n", "'Nn'[v:searchforward]", { expr = true, desc = "Next search result" })


### PR DESCRIPTION
Noticed that this didn't have a description. Thought I could something simple 🙂 

Also, I think there might be a bug (or intentional?) with the web rendered keymaps. There is an early return that causes any keymap without a description to not be built into https://lazyvim.org/keymaps. That means this keymap (`gw`) - although custom - was not in the listed keymaps.

See: inside the `map` function that overrides `vim.keymap.set`

Early return: [build.lua#18-20](https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/util/build.lua#L18-L20)
```lua
if not (opts and opts.desc) then
  return
end
```

Later down: [build.lua#25](https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/util/build.lua#L25)
```lua
local desc = opts and opts.desc or ""
```

Nothing urgent, enjoy your holiday!