### PR TITLE
mini-starter: add Session restore to starter menu

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/mini-starter.lua
+++ b/lua/lazyvim/plugins/extras/ui/mini-starter.lua
@@ -35,6 +35,7 @@ return {
           new_section("Lazy",         "Lazy",                 "Config"),
           new_section("New file",     "ene | startinsert",    "Built-in"),
           new_section("Quit",         "qa",                   "Built-in"),
+          new_section("Session restore", [[lua require("persistence").load()]], "Session"),
         },
         content_hooks = {
           starter.gen_hook.adding_bullet(pad .. "░ ", false),


### PR DESCRIPTION
This mirrors the menu item added in alpha-nvim. I named this "Session restore" rather than "Restore session", since mini.starter uses the first letter of the item as the shortcut key.  This way it doesn't conflict with "Recent files".

<img width="778" alt="image" src="https://user-images.githubusercontent.com/1112/224576124-9e030754-9d26-4b57-9323-cbf656a3f7da.png">
