### PR TITLE
fix/indent-blankline-setup

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -170,6 +170,9 @@ return {
       show_trailing_blankline_indent = false,
       show_current_context = false,
     },
+    config = function(_, opts)
+      require("indent_blankline").setup(opts)
+    end,
   },
 
   -- active indent guide and indent text objects


### PR DESCRIPTION
The setup function for indent-blankline is ```require("indent_blankline").setup(opts)```, so it was not being called for me with the default configuration.