### PR TITLE
fix(copilot): use full name of nvim-cmp plugin

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/copilot.lua
+++ b/lua/lazyvim/plugins/extras/coding/copilot.lua
@@ -13,7 +13,7 @@ return {
 
   -- copilot cmp source
   {
-    "nvim-cmp",
+    "hrsh7th/nvim-cmp",
     dependencies = {
       {
         "zbirenbaum/copilot-cmp",


### PR DESCRIPTION
Otherwise, `:checkhealth` complains of:

> lazy.nvim
> - WARNING {nvim-cmp}: overriding <1>