### PR TITLE
fix(alpha): use `AlphaFooter` highlight for footer section

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -253,9 +253,9 @@ return {
         button.opts.hl = "AlphaButtons"
         button.opts.hl_shortcut = "AlphaShortcut"
       end
-      dashboard.section.footer.opts.hl = "Type"
       dashboard.section.header.opts.hl = "AlphaHeader"
       dashboard.section.buttons.opts.hl = "AlphaButtons"
+      dashboard.section.footer.opts.hl = "AlphaFooter"
       dashboard.opts.layout[1].val = 8
       return dashboard
     end,


### PR DESCRIPTION
I _think_ `AlphaFooter` should be used instead of `Type` for the footer highlight, especially since [`tokyonight` specifically defines `AlphaFooter` alongside the other alpha highlights](https://github.com/folke/tokyonight.nvim/blob/467d889ba82a74e26821c812aa8e70d7dff04c6c/lua/tokyonight/theme.lua#LL398C8-L398C8).