### PR TITLE
fix(autocmd): remove query from q-to-quit autocmd

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -48,7 +48,6 @@ vim.api.nvim_create_autocmd("FileType", {
     "man",
     "notify",
     "qf",
-    "query", -- :InspectTree
     "spectre_panel",
     "startuptime",
     "tsplayground",


### PR DESCRIPTION
Query files aren't just the special window to edit/inspect tree-sitter queries, but also any file in queries/**.scm is considered one. I noticed this bug persisting for a while probably via an autocmd where switching buffers then going back would have the file removed from my bufferline at the top. 

You can reproduce this by cloning any tree-sitter parser and fiddling around with a queries file, then swapping buffers or going back to a query buffer, it sort-of becomes in this weird stuck state (well when using the keybinds I'm familiar with navigation at least), and I have to close and reopen the buffer to fix it.

Thanks!