### PR TITLE
feat(treesitter): use Python indents as they've improved greatly

### DIFF
--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -33,7 +33,7 @@ return {
     ---@type TSConfig
     opts = {
       highlight = { enable = true },
-      indent = { enable = true, disable = { "python" } },
+      indent = { enable = true },
       context_commentstring = { enable = true, enable_autocmd = false },
       ensure_installed = {
         "bash",


### PR DESCRIPTION
Thanks to https://github.com/nvim-treesitter/nvim-treesitter/pull/4524 being merged, Python indents are quite good now