### PR TITLE
feat(autocmds): add checkhealth filetype to close_with_q list

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -51,6 +51,7 @@ vim.api.nvim_create_autocmd("FileType", {
     "spectre_panel",
     "startuptime",
     "tsplayground",
+    "checkhealth",
   },
   callback = function(event)
     vim.bo[event.buf].buflisted = false


### PR DESCRIPTION
Add `checkhealth` filetype to `close_with_q` autocmd list.