### PR TITLE
refactor(treesitter)!: rename help to vimdoc

### DIFF
--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -38,7 +38,6 @@ return {
       ensure_installed = {
         "bash",
         "c",
-        "help",
         "html",
         "javascript",
         "json",
@@ -53,6 +52,7 @@ return {
         "tsx",
         "typescript",
         "vim",
+        "vimdoc",
         "yaml",
       },
       incremental_selection = {


### PR DESCRIPTION
Following nvim-ts and soon neovim