### PR TITLE
help was renamed to vimdoc

### DIFF
--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -38,7 +38,7 @@ return {
       ensure_installed = {
         "bash",
         "c",
-        "help",
+        "vimdoc",
         "html",
         "javascript",
         "json",


### PR DESCRIPTION
help was renamed to vimdoc in treesister, making the loading LazyVim producing the following issue:

`Installation not possible: ...vim/lazy/nvim-treesitter/lua/nvim-treesitter/install.lua:86: Parser not available for language "help"`