### PR TITLE
feat(catppuccin): better look

### DIFF
--- a/lua/lazyvim/plugins/colorscheme.lua
+++ b/lua/lazyvim/plugins/colorscheme.lua
@@ -12,5 +12,53 @@ return {
     "catppuccin/nvim",
     lazy = true,
     name = "catppuccin",
+    opts = {
+      flavour = "mocha",
+      integrations = {
+        cmp = true,
+        dashboard = true,
+        gitsigns = true,
+        illuminate = true,
+        indent_blankline = { enabled = true },
+        lsp_trouble = true,
+        markdown = true,
+        mason = true,
+        mini = true,
+        native_lsp = {
+          enabled = true,
+          virtual_text = {
+            errors = { "italic" },
+            hints = { "italic" },
+            warnings = { "italic" },
+            information = { "italic" },
+          },
+          underlines = {
+            errors = { "undercurl" },
+            hints = { "undercurl" },
+            warnings = { "undercurl" },
+            information = { "undercurl" },
+          },
+        },
+        navic = { enabled = true },
+        neotree = true,
+        noice = true,
+        notify = true,
+        semantic_tokens = true,
+        telescope = true,
+        treesitter = true,
+        treesitter_context = true,
+        which_key = true,
+      },
+      custom_highlights = function(c)
+        return {
+          -- Use tokyonight style leap highlights.
+          LeapMatch = { fg = c.pink, bold = true },
+          LeapLabelPrimary = { fg = c.green, bold = true },
+          LeapLabelSecondary = { fg = c.blue, bold = true },
+          LeapBackdrop = { fg = c.overlay0 },
+          NavicText = { fg = c.text, bg = c.none },
+        }
+      end,
+    },
   },
 }

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -250,12 +250,12 @@ return {
         dashboard.button("q", " " .. " Quit", ":qa<CR>"),
       }
       for _, button in ipairs(dashboard.section.buttons.val) do
-        button.opts.hl = "AlphaButtons"
-        button.opts.hl_shortcut = "AlphaShortcut"
+        button.opts.hl = "DashboardCenter"
+        button.opts.hl_shortcut = "DashboardShortCut"
       end
-      dashboard.section.header.opts.hl = "AlphaHeader"
-      dashboard.section.buttons.opts.hl = "AlphaButtons"
-      dashboard.section.footer.opts.hl = "AlphaFooter"
+      dashboard.section.header.opts.hl = "DashboardHeader"
+      dashboard.section.buttons.opts.hl = "DashboardCenter"
+      dashboard.section.footer.opts.hl = "DashboardFooter"
       dashboard.opts.layout[1].val = 8
       return dashboard
     end,


### PR DESCRIPTION
This PR enables catppuccin integrations for used plugins and changes the highlight groups of alpha-nvim to `Dashboard*` (which look the same as `Alpha*` in tokyonight and are supported by many colorschemes).