### PR TITLE
fix(telescope): use dynamic workspace symbols

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -122,7 +122,7 @@ return {
       },
       {
         "<leader>sS",
-        Util.telescope("lsp_workspace_symbols", {
+        Util.telescope("lsp_dynamic_workspace_symbols", {
           symbols = {
             "Class",
             "Function",


### PR DESCRIPTION
`lsp_workspace_symbols` may fail or return nothing when query is empty. Use the new `lsp_dynamic_workspace_symbols` to dynamically query symbols in the workspace.

Related: https://github.com/nvim-telescope/telescope.nvim/issues/964
Fixes: https://github.com/LazyVim/LazyVim/issues/576