### PR TITLE
feat(keymaps): Get rename command from inc_rename configuration

### DIFF
--- a/lua/lazyvim/plugins/lsp/keymaps.lua
+++ b/lua/lazyvim/plugins/lsp/keymaps.lua
@@ -49,8 +49,8 @@ function M.get()
       M._keys[#M._keys + 1] = {
         "<leader>cr",
         function()
-          require("inc_rename")
-          return ":IncRename " .. vim.fn.expand("<cword>")
+          local inc_rename = require("inc_rename")
+          return ":" .. inc_rename.config.cmd_name .. " " .. vim.fn.expand("<cword>")
         end,
         expr = true,
         desc = "Rename",


### PR DESCRIPTION
Gets the rename command from the inc_rename module (when installed), rather than assuming the default `IncRename`, allowing the user to modify the inc_rename options without having to create a new keymap.