### PR TITLE
fix: update treesitter ensure_installed

### DIFF
--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -38,7 +38,7 @@ return {
       ensure_installed = {
         "bash",
         "c",
-        "help",
+        "vimdoc",
         "html",
         "javascript",
         "json",


### PR DESCRIPTION
Renamed the module "help" to "vimdoc" due to naming changes in the treesitter project.
https://github.com/nvim-treesitter/nvim-treesitter/pull/4593