### PR TITLE
feat(project): add to mini.starter

### DIFF
--- a/lua/lazyvim/plugins/extras/util/project.lua
+++ b/lua/lazyvim/plugins/extras/util/project.lua
@@ -27,4 +27,17 @@ return {
       table.insert(dashboard.section.buttons.val, 4, button)
     end,
   },
+  {
+    "echasnovski/mini.starter",
+    opts = function(_, opts)
+      local items = {
+        {
+          name = "Projects",
+          action = "Telescope projects",
+          section = string.rep(" ", 22) .. "Telescope",
+        },
+      }
+      vim.list_extend(opts.items, items)
+    end,
+  },
 }


### PR DESCRIPTION
I am unsure where to put this, as it sort of belongs to two extras.
What I added here will cause mini.starter to always be loaded if you include the projects extra, right?