### PR TITLE
fix: remove unintentional `<lt>nop>` mapping

### DIFF
--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -60,7 +60,7 @@ return {
         keymaps = {
           init_selection = "<C-space>",
           node_incremental = "<C-space>",
-          scope_incremental = "<nop>",
+          scope_incremental = false,
           node_decremental = "<bs>",
         },
       },


### PR DESCRIPTION
There is quite a noticable amount of lag for the visual mode `<lt>` mapping because of the `<lt>nop>` mapping made by treesitter. (`<lt>` is escaped `<`)

Before:

![Kapture 2023-04-21 at 02 10 54](https://user-images.githubusercontent.com/38332081/233566570-f0978dd4-d082-46b5-b09e-e30ff7c3b359.gif)

After:

![Kapture 2023-04-21 at 02 13 18](https://user-images.githubusercontent.com/38332081/233567071-6c25f5e0-e64d-46a2-8afb-3b614d96146b.gif)

[Relevant mapping code is here](https://github.com/nvim-treesitter/nvim-treesitter/blob/b0338a056525e83d88aaa76e8cf396af07410bed/lua/nvim-treesitter/incremental_selection.lua)