### PR TITLE
feat(bufferline): use `mini.bufremove` to close a buffer

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -59,6 +59,10 @@ return {
     },
     opts = {
       options = {
+        -- stylua: ignore
+        close_command = function(n) require("mini.bufremove").delete(n, true) end,
+        -- stylua: ignore
+        right_mouse_command = function(n) require("mini.bufremove").delete(n, true) end,
         diagnostics = "nvim_lsp",
         always_show_bufferline = false,
         diagnostics_indicator = function(_, _, diag)

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -60,9 +60,9 @@ return {
     opts = {
       options = {
         -- stylua: ignore
-        close_command = function(n) require("mini.bufremove").delete(n, true) end,
+        close_command = function(n) require("mini.bufremove").delete(n, false) end,
         -- stylua: ignore
-        right_mouse_command = function(n) require("mini.bufremove").delete(n, true) end,
+        right_mouse_command = function(n) require("mini.bufremove").delete(n, false) end,
         diagnostics = "nvim_lsp",
         always_show_bufferline = false,
         diagnostics_indicator = function(_, _, diag)


### PR DESCRIPTION
Use `mini.bufremove` to close buffers without breaking window layout in commands such as `BufferLineCloseLeft`, `BufferLineCloseRight`.