### PR TITLE
Improve description of notify.dismiss() binding

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -8,7 +8,7 @@ return {
         function()
           require("notify").dismiss({ silent = true, pending = true })
         end,
-        desc = "Delete all Notifications",
+        desc = "Dismiss all Notifications",
       },
     },
     opts = {


### PR DESCRIPTION
I got confused by the description and thought it deleted the history of notifications so I never tried it. Went to add a keymap and it turned out this one did what I wanted already, but I think calling it "Dismiss" is more clear.