### PR TITLE
exclude filetype mason in indent-blankline.nvim

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -169,7 +169,7 @@ return {
     opts = {
       -- char = "▏",
       char = "│",
-      filetype_exclude = { "help", "alpha", "dashboard", "neo-tree", "Trouble", "lazy" },
+      filetype_exclude = { "help", "alpha", "dashboard", "neo-tree", "Trouble", "lazy", "mason" },
       show_trailing_blankline_indent = false,
       show_current_context = false,
     },


### PR DESCRIPTION
Similar to https://github.com/LazyVim/LazyVim/pull/16
Excludes mason in indent-blankline.nvim