### PR TITLE
Update project.lua

### DIFF
--- a/lua/lazyvim/plugins/extras/util/project.lua
+++ b/lua/lazyvim/plugins/extras/util/project.lua
@@ -12,7 +12,7 @@ return {
           require("telescope").load_extension("projects")
         end,
         keys = {
-          { "<leader>fp", "<Cmd>Telescope projects<CR>", desc = "Projects" },
+          { "<leader>fp", "<Cmd>Telescope project<CR>", desc = "Projects" },
         },
       },
     },


### PR DESCRIPTION
When directly inputting "Telescope projects" in the command mode, an error will be reported, and the error message is "[telescope.run_command]: Unknown command". If the character 's' in word "projects" is removed, the command will be executed successfully and will not affect the execution of < leader >fp