### PR TITLE
Fix comments on autocmds and keymaps loading

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -1,4 +1,4 @@
--- This file is automatically loaded by plugins.init
+-- This file is automatically loaded by lazyvim.config.init
 
 local function augroup(name)
   return vim.api.nvim_create_augroup("lazyvim_" .. name, { clear = true })

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -1,4 +1,4 @@
--- This file is automatically loaded by lazyvim.plugins.config
+-- This file is automatically loaded by lazyvim.config.init
 
 local Util = require("lazyvim.util")
 


### PR DESCRIPTION
Very minor, but it seems that `autocmds.lua` and `keymaps.lua` are both loaded by the `config/init.lua` module, maybe the comments are out of date?