### PR TITLE
Fix the mason-nvim-dap setting name

### DIFF
--- a/lua/lazyvim/plugins/extras/dap/core.lua
+++ b/lua/lazyvim/plugins/extras/dap/core.lua
@@ -53,7 +53,7 @@ return {
       opts = {
         -- Makes a best effort to setup the various debuggers with
         -- reasonable debug configurations
-        automatic_setup = true,
+        automatic_installation = true,
 
         -- You can provide additional configuration to the handlers,
         -- see mason-nvim-dap README for more information


### PR DESCRIPTION
The `mason-nvim-dap` setting name is `automatic_installation`, rather than `automatic_setup`.

https://github.com/jay-babu/mason-nvim-dap.nvim#default-configuration