### PR TITLE
feat(lsp): add NullLsInfo binding

### DIFF
--- a/lua/lazyvim/plugins/lsp/keymaps.lua
+++ b/lua/lazyvim/plugins/lsp/keymaps.lua
@@ -14,6 +14,7 @@ function M.get()
     M._keys =  {
       { "<leader>cd", vim.diagnostic.open_float, desc = "Line Diagnostics" },
       { "<leader>cl", "<cmd>LspInfo<cr>", desc = "Lsp Info" },
+      { "<leader>cn", "<cmd>NullLsInfo<cr>", desc = "NullLs Info" },
       { "gd", "<cmd>Telescope lsp_definitions<cr>", desc = "Goto Definition", has = "definition" },
       { "gr", "<cmd>Telescope lsp_references<cr>", desc = "References" },
       { "gD", vim.lsp.buf.declaration, desc = "Goto Declaration" },


### PR DESCRIPTION
I know it is not possible to include every key binds that every user wants, but I found no way so far to hook into this function.