### PR TITLE
feat(go): add go lang extras

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -37,10 +37,14 @@ return {
     dependencies = {
       "nvim-neotest/neotest-go",
     },
-    opts = {
-      adapter_config = {
-        ["neotest-go"] = {},
-      },
-    },
+    -- Add custom options for neotest-go in nvim-neotest opts.adapter_config["neotest-go"]
+    opts = function(_, opts)
+      opts.adapters = vim.list_extend(opts.adapters, { require("neotest-go") })
+      opts.adapter_config = {
+        ["neotest-go"] = {
+          -- I.e. set opts.adapter_config["neotest-go"].args = { "-tags=integration" }
+        },
+      }
+    end,
   },
 }

--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -1,0 +1,44 @@
+return {
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = function(_, opts)
+      vim.list_extend(opts.ensure_installed, {
+        "go",
+        "gomod",
+        "gowork",
+      })
+    end,
+  },
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        gopls = {},
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-dap",
+    optional = true,
+    dependencies = {
+      {
+        "mason.nvim",
+        opts = {
+          ensure_installed = { "delve" },
+        },
+      },
+    },
+  },
+  {
+    "nvim-neotest/neotest",
+    optional = true,
+    dependencies = {
+      "nvim-neotest/neotest-go",
+    },
+    opts = function(_, opts)
+      opts.adapters = vim.list_extend(opts.adapters or {}, {
+        require("neotest-go"),
+      })
+    end,
+  },
+}

--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -13,7 +13,9 @@ return {
     "neovim/nvim-lspconfig",
     opts = {
       servers = {
-        gopls = {},
+        gopls = {
+          semanticTokens = true,
+        },
       },
     },
   },
@@ -35,10 +37,10 @@ return {
     dependencies = {
       "nvim-neotest/neotest-go",
     },
-    opts = function(_, opts)
-      opts.adapters = vim.list_extend(opts.adapters or {}, {
-        require("neotest-go"),
-      })
-    end,
+    opts = {
+      adapter_config = {
+        ["neotest-go"] = {},
+      },
+    },
   },
 }

--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -6,6 +6,7 @@ return {
         "go",
         "gomod",
         "gowork",
+        "gosum",
       })
     end,
   },
@@ -37,14 +38,13 @@ return {
     dependencies = {
       "nvim-neotest/neotest-go",
     },
-    -- Add custom options for neotest-go in nvim-neotest opts.adapter_config["neotest-go"]
-    opts = function(_, opts)
-      opts.adapters = vim.list_extend(opts.adapters, { require("neotest-go") })
-      opts.adapter_config = {
+    opts = {
+      adapters = {
         ["neotest-go"] = {
-          -- I.e. set opts.adapter_config["neotest-go"].args = { "-tags=integration" }
+          -- Here we can set options for neotest-go, e.g.
+          -- args = { "-tags=integration" }
         },
-      }
-    end,
+      },
+    },
   },
 }


### PR DESCRIPTION
Just adding this as it is what I use daily.
I stripped some of my configuration; `null-ls` sources like `gofumpt` and `golangci-lint` as they are subjective, similar to `prettier`.

Also a build tag argument that is passed both to `gopls` and to `neotest-go`, I am unsure how to make it nice to add such a thing.
I personally use the `-tags=integration` argument to ensure `neotest` will run all tests and so that `gopls` wont complain about missing packages, in integration test files.

It is easy to add it to `gopls`:
```lua
  {
    "neovim/nvim-lspconfig",
    opts = {
      servers = {
        gopls = {
          cmd_env = {
            GOFLAGS = "-tags=integration",
          },
        },
      },
    },
  }
```

But it is harder to add to `neotest-go`, as you cannot just merge - so I assume this will result in a list of test adapters with two `neotest-go` instances, which probably isn't good.. Any ideas?
```lua
  {
    "nvim-neotest/neotest",
    dependencies = {
      "nvim-neotest/neotest-go",
    },
    opts = function(_, opts)
      opts.adapters = vim.list_extend(opts.adapters or {}, {
        require("neotest-go")({
          args = { "-tags=integration" },
        }),
      })
    end,
  }
```