### PR TITLE
fix(go): add workaround to get semantic token highlighting

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -22,6 +22,28 @@ return {
           },
         },
       },
+      setup = {
+        gopls = function()
+          -- workaround for gopls not supporting semantictokensprovider
+          -- https://github.com/golang/go/issues/54531#issuecomment-1464982242
+          require("lazyvim.util").on_attach(function(client, _)
+            if client.name == "gopls" then
+              if not client.server_capabilities.semanticTokensProvider then
+                local semantic = client.config.capabilities.textDocument.semanticTokens
+                client.server_capabilities.semanticTokensProvider = {
+                  full = true,
+                  legend = {
+                    tokenTypes = semantic.tokenTypes,
+                    tokenModifiers = semantic.tokenModifiers,
+                  },
+                  range = true,
+                }
+              end
+            end
+          end)
+          -- end workaround
+        end,
+      },
     },
   },
   {


### PR DESCRIPTION
Add a work around based on this comment: https://github.com/golang/go/issues/54531#issuecomment-1464982242
Related to #811