### PR TITLE
Update keymaps.lua  

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -15,6 +15,10 @@ local function map(mode, lhs, rhs, opts)
   end
 end
 
+-- Esc Alternative Insert -> Normal
+map("i", "jk", "<ESC>", { desc = "For Insert -> Normal" })
+map("i", "kj", "<ESC>", { desc = "For Insert -> Normal" })
+
 -- better up/down
 map("n", "j", "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = true })
 map("n", "k", "v:count == 0 ? 'gk' : 'k'", { expr = true, silent = true })


### PR DESCRIPTION
// Title: Added key combination for transitioning from insert mode to normal mode

// Description //
Hello Lazy Vim maintainers,

I hope this message finds you well. I have made a contribution to the Lazy Vim GitHub repository and I would like to submit a pull request for your review and consideration.

In this pull request, I have added a new key combination that allows users to easily transition from insert mode to normal mode. This key combination provides a more efficient and streamlined editing experience for Lazy Vim users.

I have implemented the key combination in a clean and concise manner, ensuring compatibility with existing mappings and minimizing conflicts. The code changes are well-documented, making it easy for other developers to understand and maintain.

I kindly request you to review the changes and consider merging them into the main branch of the repository. I have tested the functionality locally and believe it will be a valuable addition to the Lazy Vim project.

Thank you for your time and consideration. I look forward to your feedback and any further guidance on the next steps for this contribution.

Best regards,
BalaVignesh






