### PR TITLE
fix(format): eslint should respect autoformat

### DIFF
--- a/lua/lazyvim/plugins/extras/linting/eslint.lua
+++ b/lua/lazyvim/plugins/extras/linting/eslint.lua
@@ -16,6 +16,11 @@ return {
         eslint = function()
           vim.api.nvim_create_autocmd("BufWritePre", {
             callback = function(event)
+              if not require("lazyvim.plugins.lsp.format").enabled() then
+                -- exit early if autoformat is not enabled
+                return
+              end
+
               local client = vim.lsp.get_active_clients({ bufnr = event.buf, name = "eslint" })[1]
               if client then
                 local diag = vim.diagnostic.get(event.buf, { namespace = vim.lsp.diagnostic.get_namespace(client.id) })

--- a/lua/lazyvim/plugins/lsp/format.lua
+++ b/lua/lazyvim/plugins/lsp/format.lua
@@ -5,6 +5,10 @@ local M = {}
 ---@type PluginLspOpts
 M.opts = nil
 
+function M.enabled()
+  return M.opts.autoformat
+end
+
 function M.toggle()
   if vim.b.autoformat == false then
     vim.b.autoformat = nil


### PR DESCRIPTION
The eslint extra will autoformat if there are any diagnostics associated with eslint, but it does not currently respect the stateful autoformat setting (toggled via `<leader>uf`).