### PR TITLE
feat(treesitter): allow run TSUpdateSync from command line

### DIFF
--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -4,6 +4,7 @@ return {
     version = false, -- last release is way too old and doesn't work on Windows
     build = ":TSUpdate",
     event = { "BufReadPost", "BufNewFile" },
+    cmd = { "TSUpdateSync" },
     dependencies = {
       {
         "nvim-treesitter/nvim-treesitter-textobjects",


### PR DESCRIPTION
Use a script to keep the neovim updated is really useful, but is not
possible by default because TSUpdateSync is not on `cmd` commands.

```sh
nvim --headless "+Lazy! sync" "+TSUpdateSync" +qa
```
