### PR TITLE
fix(keymaps): remove redundant ':' on lazy keymap

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -89,7 +89,7 @@ map("v", "<", "<gv")
 map("v", ">", ">gv")
 
 -- lazy
-map("n", "<leader>l", "<cmd>:Lazy<cr>", { desc = "Lazy" })
+map("n", "<leader>l", "<cmd>Lazy<cr>", { desc = "Lazy" })
 
 -- new file
 map("n", "<leader>fn", "<cmd>enew<cr>", { desc = "New File" })


### PR DESCRIPTION
Super minor. Just removing `:` in the Lazy keymap since it has `<cmd>`:
```
map("n", "<leader>l", "<cmd>:Lazy<cr>", { desc = "Lazy" })
```
I'm assuming removing `:` is preferable.
