### PR TITLE
esc closes telescope without intermediate normal mode

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/flash.lua
+++ b/lua/lazyvim/plugins/extras/editor/flash.lua
@@ -67,7 +67,7 @@ return {
       opts.defaults = vim.tbl_deep_extend("force", opts.defaults or {}, {
         mappings = {
           n = { s = flash },
-          i = { ["<c-s>"] = flash },
+          i = { ["<c-s>"] = flash, ["<esc>"] = require("telescope.actions").close },
         },
       })
     end,


### PR DESCRIPTION
Hey @folke!!

Reduces 1 `<Esc>` keypress while exiting telescope.