### PR TITLE
fix leap nvim required by flit

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -216,6 +216,9 @@ return {
   -- easily jump to any location and enhanced f/t motions for Leap
   {
     "ggandor/flit.nvim",
+    enabled = function()
+      return require("lazyvim.util").has("leap")
+    end,
     keys = function()
       ---@type LazyKeys[]
       local ret = {}


### PR DESCRIPTION
step to reproduce:
- disable leap.nvim,
- add custom config for flash (not using one from the extras)
- open file type "f", error shown "module leap is missing"

```lua
return {
  {
    "ggandor/leap.nvim",
    enabled = false,
  },
  {
    "folke/flash.nvim",
    event = "VeryLazy",
    ---@type function
    keys = function()
      return {
        {
          "<a-m>",
          mode = { "n", "x", "o" },
          function()
            require("flash").jump()
          end,
        },
        {
          "<a-s>",
          mode = { "n", "x", "v" },
          function()
            require("flash").treesitter()
          end,
        },
      }
    end,
    opts = {}
  },
}

```