### PR TITLE
feat(catppuccin): enable mason integration

### DIFF
--- a/lua/lazyvim/plugins/colorscheme.lua
+++ b/lua/lazyvim/plugins/colorscheme.lua
@@ -20,6 +20,7 @@ return {
         illuminate = true,
         indent_blankline = { enabled = true },
         lsp_trouble = true,
+        mason = true,
         mini = true,
         native_lsp = {
           enabled = true,


### PR DESCRIPTION
Since LazyVim pre-bundles mason.nvim, it is safe (and makes sense) for the mason integration of catppuccin to be enabled. Otherwise, the colors in the mason popup window clash with everything else.