### PR TITLE
Disable `document_symbols` in Neo-tree

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -37,7 +37,7 @@ return {
       end
     end,
     opts = {
-      sources = { "filesystem", "buffers", "git_status", "document_symbols" },
+      sources = { "filesystem", "buffers", "git_status" },
       open_files_do_not_replace_types = { "terminal", "Trouble", "qf", "Outline" },
       filesystem = {
         bind_to_cwd = false,


### PR DESCRIPTION
When we enable document_symbols, the Neo-tree window "jumps" around when opening files and when the Neo-tree window has a lot of expanded directories and files.

I've created a bug in upstream with a config.lua that reproduces the problem:
https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1025 