### PR TITLE
fix(autocmds): jump to last loc in buffer

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -38,7 +38,7 @@ vim.api.nvim_create_autocmd("BufReadPost", {
     local mark = vim.api.nvim_buf_get_mark(buf, '"')
     local lcount = vim.api.nvim_buf_line_count(buf)
     if mark[1] > 0 and mark[1] <= lcount then
-      pcall(vim.api.nvim_win_set_cursor, buf, mark)
+      pcall(vim.api.nvim_win_set_cursor, 0, mark)
     end
   end,
 })


### PR DESCRIPTION
vim.api.nvim_win_set_cursor is expecting a window handle but was being passed the current buffer's handle instead