### PR TITLE
fix(clangd): vim.fn.input accept only 1 argument

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -134,7 +134,11 @@ return {
             request = "launch",
             name = "Launch file",
             program = function()
-              return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+              return vim.fn.input({
+                prompt = "Path to executable: ",
+                default = vim.fn.getcwd() .. "/",
+                completion = "file",
+              })
             end,
             cwd = "${workspaceFolder}",
           },


### PR DESCRIPTION
Fix the lua_ls redundant-parameter's error:

```
1. This function expects a maximum of 1 argument(s) but instead it is receiving 3. [redundant-parameter]
```
