### PR TITLE
decouple mini.ai and which-key.nvim

### DIFF
--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -1,3 +1,5 @@
+local Util = require("lazyvim.util")
+
 return {
 
   -- snippets
@@ -147,34 +149,13 @@ return {
     },
   },
 
-  -- better text-objects
+  -- add mini.ai descriptions to which-key.nvim
   {
-    "echasnovski/mini.ai",
-    -- keys = {
-    --   { "a", mode = { "x", "o" } },
-    --   { "i", mode = { "x", "o" } },
-    -- },
-    event = "VeryLazy",
-    dependencies = { "nvim-treesitter-textobjects" },
-    opts = function()
-      local ai = require("mini.ai")
-      return {
-        n_lines = 500,
-        custom_textobjects = {
-          o = ai.gen_spec.treesitter({
-            a = { "@block.outer", "@conditional.outer", "@loop.outer" },
-            i = { "@block.inner", "@conditional.inner", "@loop.inner" },
-          }, {}),
-          f = ai.gen_spec.treesitter({ a = "@function.outer", i = "@function.inner" }, {}),
-          c = ai.gen_spec.treesitter({ a = "@class.outer", i = "@class.inner" }, {}),
-        },
-      }
-    end,
-    config = function(_, opts)
-      require("mini.ai").setup(opts)
-      -- register all text objects with which-key
-      if require("lazyvim.util").has("which-key.nvim") then
-        ---@type table<string, string|table>
+    "folke/which-key.nvim",
+    optional = true,
+    opts = function(_, opts)
+      local function mini_ai_to_which_key()
+        -- register all text objects with which-key
         local i = {
           [" "] = "Whitespace",
           ['"'] = 'Balanced "',
@@ -209,12 +190,38 @@ return {
           i[key] = vim.tbl_extend("force", { name = "Inside " .. name .. " textobject" }, ic)
           a[key] = vim.tbl_extend("force", { name = "Around " .. name .. " textobject" }, ac)
         end
-        require("which-key").register({
+        return {
           mode = { "o", "x" },
           i = i,
           a = a,
-        })
+        }
       end
+
+      if Util.has("mini.ai") then
+        opts.mini_ai = mini_ai_to_which_key()
+      end
+      return opts
+    end,
+  },
+
+  -- better text-objects
+  {
+    "echasnovski/mini.ai",
+    event = "VeryLazy",
+    dependencies = { "nvim-treesitter-textobjects" },
+    opts = function()
+      local ai = require("mini.ai")
+      return {
+        n_lines = 500,
+        custom_textobjects = {
+          o = ai.gen_spec.treesitter({
+            a = { "@block.outer", "@conditional.outer", "@loop.outer" },
+            i = { "@block.inner", "@conditional.inner", "@loop.inner" },
+          }, {}),
+          f = ai.gen_spec.treesitter({ a = "@function.outer", i = "@function.inner" }, {}),
+          c = ai.gen_spec.treesitter({ a = "@class.outer", i = "@class.inner" }, {}),
+        },
+      }
     end,
   },
 }

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -244,7 +244,6 @@ return {
     end,
   },
 
-  -- which-key
   {
     "folke/which-key.nvim",
     event = "VeryLazy",
@@ -268,11 +267,15 @@ return {
         ["<leader>w"] = { name = "+windows" },
         ["<leader>x"] = { name = "+diagnostics/quickfix" },
       },
+      mini_ai = nil, -- descriptions for mini.ai when enabled
     },
     config = function(_, opts)
       local wk = require("which-key")
       wk.setup(opts)
       wk.register(opts.defaults)
+      if opts.mini_ai then
+        wk.register(opts.mini_ai)
+      end
     end,
   },
 


### PR DESCRIPTION
At the moment, LazyVim "requires" which-key in mini.ai's config in coding.lua. As a consequence which-key cannot be loaded on demand using a key when mini.ai is also enabled.

I would like to load which-key using a key as I mostly do not need which-keys UI.
As an example:

` {
    "folke/which-key.nvim",
    enabled = true,
    event = function()
      return "RemoteReply"
    end,
    keys = {
      {
        "<leader>j",
        function()
          require("which-key")
        end,
        desc = "Which-key activation",
      },
    },
`

**Note:** I added event "RemoteReply" as a dummy event because I was unable to undo the configured "VeryLazy" event in editor.lua

The changes in this pull request follow the same approach as seen in extra/test and extra/dap: Add which-key to coding.lua using the optional keyword, and provide the options regarding mini.ai, to be applied in which-key's main definition in editor.lua
