### PR TITLE
feat(lang): add debug adapter plugin for go

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -15,6 +15,10 @@ return {
     opts = {
       servers = {
         gopls = {
+          keys = {
+            -- Workaround for the lack of a DAP strategy in neotest-go: https://github.com/nvim-neotest/neotest-go/issues/12
+            { "<leader>td", "<cmd>lua require('dap-go').debug_test()<CR>", desc = "Debug Nearest (Go)" },
+          },
           settings = {
             gopls = {
               gofumpt = true,
@@ -102,6 +106,10 @@ return {
           opts.ensure_installed = opts.ensure_installed or {}
           table.insert(opts.ensure_installed, "delve")
         end,
+      },
+      {
+        "leoluz/nvim-dap-go",
+        config = true,
       },
     },
   },


### PR DESCRIPTION
### Why this change?

I'm getting an error with `<leader>td`, when I want to debug a go test. See https://github.com/LazyVim/LazyVim/discussions/1107 for details.

It seems there is no debug adapter defined in the Go extras. I can work around this locally like so:

```lua
return {
  -- extend Go extras setup from lazy.lua, with DAP capability
  {
    "leoluz/nvim-dap-go",
    dependencies = {
      { "mfussenegger/nvim-dap" },
    },
    ft = { "go" },
    config = true,
    keys = {
      -- workaround, as nvim-dap-go does not have a DAP strategy set up for neotest
      -- see https://github.com/nvim-neotest/neotest-go/issues/12
      { "<leader>tg", "<cmd>lua require('dap-go').debug_test()<CR>", desc = "Debug Nearest (Go)" },
    },
  },
}
```

...but I figured it might be better to extend the go extras with this capability, hence this PR.

### What was changed?

- Add `nvim-dap-go` plugin.
- Add keymap override for `<leader>td` in gopls lspconfig.

I can now successfully debug go tests with `<leader>td`.

<img width="1600" alt="Screenshot 2023-07-13 at 15 36 59" src="https://github.com/LazyVim/LazyVim/assets/994357/cef74af5-da4f-478e-bcfa-f1eb952a1c25">

### Concerns, side-effects, notes etc

Even with the addition of `nvim-dap-go`, you cannot use `<leader>td` or `require("neotest").run.run({strategy = "dap"})` to debug a test, as neotest-go apparently does not implement a DAP strategy. Instead you have to invoke `require('dap-go').debug_test()`. It might be good to mention this in the [extras docs](https://github.com/LazyVim/lazyvim.github.io/blob/main/docs/plugins/extras/lang.go.md?plain=1#L5). Or can we reliably override the command executed by `<leader>td` but only for go buffers, perhaps?