### PR TITLE
feat(lang): add null-ls tools to mason's ensure_installed

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -100,7 +100,7 @@ return {
         "mason.nvim",
         opts = function(_, opts)
           opts.ensure_installed = opts.ensure_installed or {}
-          table.insert(opts.ensure_installed, "delve")
+          vim.list_extend(opts.ensure_installed, { "gomodifytags", "impl", "gofumpt", "goimports-reviser", "delve" })
         end,
       },
     },


### PR DESCRIPTION
@jyuan0 [noticed](https://github.com/LazyVim/LazyVim/pull/1115#issuecomment-1634975850) the null-ls sources are not installed by Mason. Figured I'd fix this in a separate PR.