### PR TITLE
feat(python): add semantic highlighting

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python-semshi.lua
+++ b/lua/lazyvim/plugins/extras/lang/python-semshi.lua
@@ -1,5 +1,3 @@
--- NOTE: You might need to open a Python file, then manually run `:UpdateRemotePlugins`
--- since the build command might be run when semshi has not been loaded due to lazyness
 return {
   -- "numiras/semshi",
   "wookayin/semshi", -- use a maintained fork
@@ -13,12 +11,11 @@ return {
     vim.g["semshi#update_delay_factor"] = 0.001
 
     -- This autocmd must be defined in init to take effect
-    vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" },
-      {
-        group = vim.api.nvim_create_augroup("SemanticHighlight", {}),
-        callback = function()
-          -- Only add style, inherit or link to the LSP's colors
-          vim.cmd [[
+    vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" }, {
+      group = vim.api.nvim_create_augroup("SemanticHighlight", {}),
+      callback = function()
+        -- Only add style, inherit or link to the LSP's colors
+        vim.cmd([[
             highlight! semshiGlobal gui=italic
             highlight! semshiImported gui=bold
             highlight! link semshiParameter @lsp.type.parameter
@@ -27,8 +24,8 @@ return {
             highlight! link semshiAttribute @attribute
             highlight! link semshiSelf @lsp.type.selfKeyword
             highlight! link semshiUnresolved @lsp.type.unresolvedReference
-            ]]
-        end
-      })
+            ]])
+      end,
+    })
   end,
 }

--- a/lua/lazyvim/plugins/extras/lang/python/semantic-highlight.lua
+++ b/lua/lazyvim/plugins/extras/lang/python/semantic-highlight.lua
@@ -1,0 +1,34 @@
+-- NOTE: You might need to open a Python file, then manually run `:UpdateRemotePlugins`
+-- since the build command might be run when semshi has not been loaded due to lazyness
+return {
+  -- "numiras/semshi",
+  "wookayin/semshi", -- use a maintained fork
+  ft = "python",
+  build = ":UpdateRemotePlugins",
+  init = function()
+    -- Disabled these features better provided by LSP or other more general plugins
+    vim.g["semshi#error_sign"] = false
+    vim.g["semshi#simplify_markup"] = false
+    vim.g["semshi#mark_selected_nodes"] = false
+    vim.g["semshi#update_delay_factor"] = 0.001
+
+    -- This autocmd must be defined in init to take effect
+    vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" },
+      {
+        group = vim.api.nvim_create_augroup("SemanticHighlight", {}),
+        callback = function()
+          -- Only add style, inherit or link to the LSP's colors
+          vim.cmd [[
+            highlight! semshiGlobal gui=italic
+            highlight! semshiImported gui=bold
+            highlight! link semshiParameter @lsp.type.parameter
+            highlight! link semshiParameterUnused DiagnosticUnnecessary
+            highlight! link semshiBuiltin @function.builtin
+            highlight! link semshiAttribute @attribute
+            highlight! link semshiSelf @lsp.type.selfKeyword
+            highlight! link semshiUnresolved @lsp.type.unresolvedReference
+            ]]
+        end
+      })
+  end,
+}


### PR DESCRIPTION
While cleaning up my config to use the new extras/lang/python, there is this one plugin that I think might be generally useful to many.

Since no python's lsp support semantic highlighting now or in the near future (pyright definitely won't), this is the best we can have for python.

The default color are hardcoded by semshi, so I either link it to matching semantic @lsp.... highlight group, or just add style and inherit the color defined by colorscheme.

Without semshi:
<img width="430" alt="Screenshot 2023-07-16 at 17 07 38" src="https://github.com/LazyVim/LazyVim/assets/12573521/aff99e35-59c7-48d6-b908-969c1582822a">

With semshi:
<img width="430" alt="Screenshot 2023-07-16 at 17 06 46" src="https://github.com/LazyVim/LazyVim/assets/12573521/799bf496-549c-40b6-bd00-4394edfa2be5">
