### PR TITLE
feat(lang): add tex support

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -36,6 +36,14 @@ return {
         end,
       })
 
+      vim.api.nvim_create_autocmd({ "FileType" }, {
+        group = vim.api.nvim_create_augroup("lazyvim_vimtex_keymap", { clear = true }),
+        pattern = { "bib", "tex" },
+        callback = function()
+          vim.keymap.set("n", "<LocalLeader>ld", "<plug>(vimtex-doc-package)", { silent = true })
+        end,
+      })
+
       vim.g.vimtex_complete_enabled = 0 -- use texlab for completion
       vim.g.vimtex_mappings_disable = { ["n"] = { "K" } } -- disable `K` as it conflicts with LSP hover
       vim.g.vimtex_quickfix_method = vim.fn.executable("pplatex") == 1 and "pplatex" or "latexlog"

--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -41,15 +41,7 @@ return {
     optional = true,
     opts = {
       servers = {
-        texlab = {
-          settings = {
-            texlab = {
-              chktex = {
-                onOpenAndSave = true,
-              },
-            },
-          },
-        },
+        texlab = {},
       },
     },
   },

--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -26,10 +26,7 @@ return {
   {
     "lervag/vimtex",
     version = "*",
-    ft = { "bib", "tex" },
-    keys = {
-      { "<LocalLeader>ld", "<Cmd>VimtexDocPackage<CR>", desc = "Open Documentation" },
-    },
+    lazy = false, -- lazy-loading will disable inverse search
     config = function()
       vim.opt.conceallevel = 2
       vim.g.vimtex_complete_enabled = 0 -- use texlab for completion

--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -44,7 +44,6 @@ return {
         end,
       })
 
-      vim.g.vimtex_complete_enabled = 0 -- use texlab for completion
       vim.g.vimtex_mappings_disable = { ["n"] = { "K" } } -- disable `K` as it conflicts with LSP hover
       vim.g.vimtex_quickfix_method = vim.fn.executable("pplatex") == 1 and "pplatex" or "latexlog"
     end,

--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -1,9 +1,10 @@
 return {
   {
     "folke/which-key.nvim",
+    optional = true,
     opts = {
       defaults = {
-        ["<LocalLeader>l"] = { name = "+vimtex" },
+        ["<localLeader>l"] = { name = "+vimtex" },
       },
     },
   },
@@ -25,7 +26,6 @@ return {
 
   {
     "lervag/vimtex",
-    version = "*",
     lazy = false, -- lazy-loading will disable inverse search
     config = function()
       vim.api.nvim_create_autocmd({ "FileType" }, {
@@ -33,14 +33,6 @@ return {
         pattern = { "bib", "tex" },
         callback = function()
           vim.wo.conceallevel = 2
-        end,
-      })
-
-      vim.api.nvim_create_autocmd({ "FileType" }, {
-        group = vim.api.nvim_create_augroup("lazyvim_vimtex_keymap", { clear = true }),
-        pattern = { "bib", "tex" },
-        callback = function()
-          vim.keymap.set("n", "<Leader>K", "<plug>(vimtex-doc-package)", { desc = "Vimtex Docs", silent = true })
         end,
       })
 
@@ -55,7 +47,11 @@ return {
     optional = true,
     opts = {
       servers = {
-        texlab = {},
+        texlab = {
+          keys = {
+            { "<Leader>K", "<plug>(vimtex-doc-package)", desc = "Vimtex Docs", silent = true },
+          },
+        },
       },
     },
   },

--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -1,0 +1,61 @@
+return {
+  {
+    "folke/which-key.nvim",
+    opts = {
+      defaults = {
+        ["<LocalLeader>l"] = { name = "+vimtex" },
+      },
+    },
+  },
+
+  -- Add BibTeX/LaTeX to treesitter
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = function(_, opts)
+      if type(opts.ensure_installed) == "table" then
+        vim.list_extend(opts.ensure_installed, { "bibtex", "latex" })
+      end
+      if type(opts.highlight.disable) == "table" then
+        vim.list_extend(opts.highlight.disable, { "latex" })
+      else
+        opts.highlight.disable = { "latex" }
+      end
+    end,
+  },
+
+  {
+    "lervag/vimtex",
+    version = "*",
+    ft = { "bib", "tex" },
+    keys = {
+      { "<LocalLeader>ld", "<Cmd>VimtexDocPackage<CR>", desc = "Open Documentation" },
+    },
+    config = function()
+      vim.opt.conceallevel = 2
+      vim.g.vimtex_complete_enabled = 0 -- use texlab for completion
+      vim.g.vimtex_mappings_disable = { ["n"] = { "K" } } -- disable `K` as the confilict to LSP hover
+      vim.g.vimtex_quickfix_method = vim.fn.executable("pplatex") == 1 and "pplatex" or "latexlog"
+
+      vim.g.vimtex_view_method = vim.fn.has("mac") == 1 and "skim" or "zathura"
+    end,
+  },
+
+  -- Correctly setup lspconfig for LaTeX 🚀
+  {
+    "neovim/nvim-lspconfig",
+    optional = true,
+    opts = {
+      servers = {
+        texlab = {
+          settings = {
+            texlab = {
+              chktex = {
+                onOpenAndSave = true,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -40,7 +40,7 @@ return {
         group = vim.api.nvim_create_augroup("lazyvim_vimtex_keymap", { clear = true }),
         pattern = { "bib", "tex" },
         callback = function()
-          vim.keymap.set("n", "<LocalLeader>ld", "<plug>(vimtex-doc-package)", { silent = true })
+          vim.keymap.set("n", "<Leader>K", "<plug>(vimtex-doc-package)", { desc = "Vimtex Docs", silent = true })
         end,
       })
 

--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -35,8 +35,6 @@ return {
       vim.g.vimtex_complete_enabled = 0 -- use texlab for completion
       vim.g.vimtex_mappings_disable = { ["n"] = { "K" } } -- disable `K` as it conflicts with LSP hover
       vim.g.vimtex_quickfix_method = vim.fn.executable("pplatex") == 1 and "pplatex" or "latexlog"
-
-      vim.g.vimtex_view_method = vim.fn.has("mac") == 1 and "skim" or "zathura"
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -33,7 +33,7 @@ return {
     config = function()
       vim.opt.conceallevel = 2
       vim.g.vimtex_complete_enabled = 0 -- use texlab for completion
-      vim.g.vimtex_mappings_disable = { ["n"] = { "K" } } -- disable `K` as the confilict to LSP hover
+      vim.g.vimtex_mappings_disable = { ["n"] = { "K" } } -- disable `K` as it conflicts with LSP hover
       vim.g.vimtex_quickfix_method = vim.fn.executable("pplatex") == 1 and "pplatex" or "latexlog"
 
       vim.g.vimtex_view_method = vim.fn.has("mac") == 1 and "skim" or "zathura"

--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -28,7 +28,14 @@ return {
     version = "*",
     lazy = false, -- lazy-loading will disable inverse search
     config = function()
-      vim.opt.conceallevel = 2
+      vim.api.nvim_create_autocmd({ "FileType" }, {
+        group = vim.api.nvim_create_augroup("lazyvim_vimtex_conceal", { clear = true }),
+        pattern = { "bib", "tex" },
+        callback = function()
+          vim.wo.conceallevel = 2
+        end,
+      })
+
       vim.g.vimtex_complete_enabled = 0 -- use texlab for completion
       vim.g.vimtex_mappings_disable = { ["n"] = { "K" } } -- disable `K` as it conflicts with LSP hover
       vim.g.vimtex_quickfix_method = vim.fn.executable("pplatex") == 1 and "pplatex" or "latexlog"


### PR DESCRIPTION
Here it is the support for `bib` and `tex` files mainly based on plugin [vimtex](https://github.com/lervag/vimtex) and LSP server [texlab](https://github.com/latex-lsp/texlab).

Some noticeable points are listed here:
1. Although treesitter provides highlights for `tex` files, vimtex renders better using conceal function. So I disabled the treesitter highlight for `tex` files. It will not affect the text-object function provided by treesitter.
2. For a better rendering result, vimtex requires to set `conceallevel` to 2 as written in line 34. It works fine without touching `<leader>uc`, which is defined in `config/keymaps.lua` as follows.
```lua
local conceallevel = vim.o.conceallevel > 0 and vim.o.conceallevel or 3
map("n", "<leader>uc", function() Util.toggle("conceallevel", false, {0, conceallevel}) end, { desc = "Toggle Conceal" })
```
So I am wondering if it is possible to set the default value of `conceallevel` to 2.