### PR TITLE
Improve summary documentation of deps

### DIFF
--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -99,7 +99,10 @@ return {
     opts = {},
   },
 
-  -- surround
+  -- Fast and feature-rich surround actions. For text that includes
+  -- surrounding characters like brackets or quotes, this allows you
+  -- to select the text inside, change or modify the surrounding characters,
+  -- and more.
   {
     "echasnovski/mini.surround",
     keys = function(_, keys)
@@ -147,7 +150,7 @@ return {
     },
   },
 
-  -- better text-objects
+  -- Better text-objects
   {
     "echasnovski/mini.ai",
     -- keys = {

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -227,7 +227,9 @@ If you rather use leap/flit instead, you can add the leap extra:
   },
   { "ggandor/flit.nvim", enabled = false, optional = true },
 
-  -- Add Flash
+  -- Flash enhances the built-in search functionality by showing labels
+  -- at the end of each match, letting you quickly jump to a specific
+  -- location.
   {
     "folke/flash.nvim",
     event = "VeryLazy",
@@ -276,7 +278,8 @@ If you rather use leap/flit instead, you can add the leap extra:
     end,
   },
 
-  -- which-key
+  -- which-key helps you remember key bindings by showing a popup
+  -- with the active keybindings of the command you started typing.
   {
     "folke/which-key.nvim",
     event = "VeryLazy",
@@ -308,7 +311,9 @@ If you rather use leap/flit instead, you can add the leap extra:
     end,
   },
 
-  -- git signs
+  -- git signs highlights text that has changed since the list
+  -- git commit, and also lets you interactively stage & unstage
+  -- hunks in a commit.
   {
     "lewis6991/gitsigns.nvim",
     event = { "BufReadPre", "BufNewFile" },
@@ -345,7 +350,9 @@ If you rather use leap/flit instead, you can add the leap extra:
     },
   },
 
-  -- references
+  -- Automatically highlights other instances of the word under your cursor.
+  -- This works with LSP, Treesitter, and regexp matching to find the other
+  -- instances.
   {
     "RRethy/vim-illuminate",
     event = { "BufReadPost", "BufNewFile" },
@@ -434,7 +441,8 @@ If you rather use leap/flit instead, you can add the leap extra:
     },
   },
 
-  -- todo comments
+  -- Finds and lists all of the TODO, HACK, BUG, etc comment
+  -- in your project and loads them into a browsable list.
   {
     "folke/todo-comments.nvim",
     cmd = { "TodoTrouble", "TodoTelescope" },

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -49,7 +49,8 @@ return {
     end,
   },
 
-  -- bufferline
+  -- This is what powers LazyVim's fancy-looking
+  -- tabs, which include filetype icons and close buttons.
   {
     "akinsho/bufferline.nvim",
     event = "VeryLazy",
@@ -186,7 +187,9 @@ return {
     },
   },
 
-  -- active indent guide and indent text objects
+  -- Active indent guide and indent text objects. When you're browsing
+  -- code, this highlights the current level of indentation, and animates
+  -- the highlighting.
   {
     "echasnovski/mini.indentscope",
     version = false, -- wait till new 0.7.0 release to put it back on semver
@@ -331,7 +334,9 @@ return {
     end,
   },
 
-  -- lsp symbol navigation for lualine
+  -- lsp symbol navigation for lualine. This shows where
+  -- in the code structure you are - within functions, classes,
+  -- etc - in the statusline.
   {
     "SmiteshP/nvim-navic",
     lazy = true,


### PR DESCRIPTION
This adds more detailed documentation strings to LazyVim's dependencies. As far as I can tell, the documentation for these on the website is generated from these docstrings.

This is just trying to add enough description so that people know what more of the plugins do without needing to click through to their individual sites.