### PR TITLE
refactor: update clangd root detection

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -53,14 +53,19 @@ return {
           keys = {
             { "<leader>cR", "<cmd>ClangdSwitchSourceHeader<cr>", desc = "Switch Source/Header (C/C++)" },
           },
-          root_dir = function(...)
-            -- using a root .clang-format or .clang-tidy file messes up projects, so remove them
+          root_dir = function(fname)
             return require("lspconfig.util").root_pattern(
-              "compile_commands.json",
-              "compile_flags.txt",
+              "Makefile",
+              "CMakeLists.txt",
               "configure.ac",
-              ".git"
-            )(...)
+              "configure.in",
+              "config.h.in",
+              "meson.build",
+              "meson_options.txt",
+              "build.ninja"
+            )(fname) or require("lspconfig.util").root_pattern("compile_commands.json", "compile_flags.txt")(
+              fname
+            ) or require("lspconfig.util").find_git_ancestor(fname)
           end,
           capabilities = {
             offsetEncoding = { "utf-16" },


### PR DESCRIPTION
It'd be nice if there was a precedence associated w/ the ordering of arguments, but I don't think there is and it seems to match the most nested dir. That's not ideal for a lot of projects, like [tree-sitter](https://github.com/tree-sitter/tree-sitter) where compile_flags.txt is in `lib/`

Suggestions welcome!