### PR TITLE
fix(lsp): supports_method for checking inlay hint support

### DIFF
--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -123,7 +123,7 @@ return {
 
       if opts.inlay_hints.enabled and inlay_hint then
         Util.on_attach(function(client, buffer)
-          if client.server_capabilities.inlayHintProvider then
+          if client.supports_method('textDocument/inlayHint') then
             inlay_hint(buffer, true)
           end
         end)


### PR DESCRIPTION
Updates the check for inlay hints support to use `supports_method` instead of `client.server_capabilities`, given that with dynamic registration checking for static server capabilities isn't enough:
<img width="788" alt="image" src="https://github.com/LazyVim/LazyVim/assets/62502207/7ec68aa8-5f27-4cfe-a977-06d00f52eda2">
