### PR TITLE
fix: rust dap installation

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -31,13 +31,17 @@ return {
 
   -- Ensure Rust debugger is installed
   {
-    "williamboman/mason.nvim",
+    "mfussenegger/nvim-dap",
     optional = true,
-    opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "codelldb" })
-      end
-    end,
+    dependencies = {
+      {
+        "williamboman/mason.nvim",
+        opts = function(_, opts)
+          opts.ensure_installed = opts.ensure_installed or {}
+          vim.list_extend(opts.ensure_installed, { "codelldb" })
+        end,
+      },
+    },
   },
 
   {


### PR DESCRIPTION
on a clean system `codelldb` was not installed automatically when importing the `rust.lua` extension. this PR provides a fix