### PR TITLE
fix: #1194 use cmakelang instead of cmakelint

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/cmake.lua
+++ b/lua/lazyvim/plugins/extras/lang/cmake.lua
@@ -21,7 +21,7 @@ return {
     "mason.nvim",
     opts = function(_, opts)
       opts.ensure_installed = opts.ensure_installed or {}
-      vim.list_extend(opts.ensure_installed, { "cmakelint" })
+      vim.list_extend(opts.ensure_installed, { "cmakelang" })
     end,
   },
   {


### PR DESCRIPTION
use `cmakelang` instead of  `cmakelint`, closes #1194