### PR TITLE
feat: Enable flash.nvim highlight on catppuccin integration

### DIFF
--- a/lua/lazyvim/plugins/colorscheme.lua
+++ b/lua/lazyvim/plugins/colorscheme.lua
@@ -16,6 +16,7 @@ return {
       integrations = {
         alpha = true,
         cmp = true,
+        flash = true,
         gitsigns = true,
         illuminate = true,
         indent_blankline = { enabled = true },


### PR DESCRIPTION
Since flash.nvim has already been the default one, and catppuccin already support it