### PR TITLE
fix(lang_java): fixes #1215 other two entries of `vim.fs.joinpath` as…

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -86,9 +86,9 @@ return {
                 local jdtls_cache_dir = vim.fn.stdpath("cache") .. "/jdtls/" .. project_name
                 vim.list_extend(cmd, {
                   "-configuration",
-                  vim.fs.joinpath(jdtls_cache_dir, "config"),
+                  jdtls_cache_dir .. "/config",
                   "-data",
-                  vim.fs.joinpath(jdtls_cache_dir, "workspace"),
+                  jdtls_cache_dir .. "/workspace",
                 })
               end
               local jdtls_base_config = {


### PR DESCRIPTION
… well that were not changed in #1213