### PR TITLE
feat(lang): add ansible support

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/ansible.lua
+++ b/lua/lazyvim/plugins/extras/lang/ansible.lua
@@ -1,0 +1,36 @@
+return {
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = function(_, opts)
+      if type(opts.ensure_installed) == "table" then
+        vim.list_extend(opts.ensure_installed, { "yaml" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason.nvim",
+    opts = function(_, opts)
+      opts.ensure_installed = opts.ensure_installed or {}
+      -- for ansiblels validation
+      vim.list_extend(opts.ensure_installed, { "ansible-lint" })
+    end,
+  },
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        ansiblels = {},
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-ansible",
+    keys = {
+      "<leader>tr",
+      function()
+        require("ansible").run()
+      end,
+      silent = true,
+    },
+  },
+}


### PR DESCRIPTION
Additionally I used to create such autocommand to set proper filetype on ansible files.

```lua
-- Set proper filetype for ansible files
vim.api.nvim_create_autocmd({ "BufNewFile", "BufRead" }, {
  pattern = {
    "*/playbooks/*.yml",
    "*/playbooks/*.yaml",
    "*/roles/*/tasks/*.yml",
    "*/roles/*/tasks/*.yaml",
    "*/roles/*/handlers/*.yml",
    "*/roles/*/handlers/*.yaml",
  },
  callback = function()
    vim.bo.filetype = "yaml.ansible"
  end,
})
```

Maybe there is any other way to set proper filetype.