### PR TITLE
refactor(clangd): remove CMakelists from clangd root_dir search

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -56,7 +56,6 @@ return {
           root_dir = function(fname)
             return require("lspconfig.util").root_pattern(
               "Makefile",
-              "CMakeLists.txt",
               "configure.ac",
               "configure.in",
               "config.h.in",


### PR DESCRIPTION
Hello,

I would like to remove the search for CMakelisits.txt in the clangd root directory, as discussed in #1165

The reason for this change is that projects following "modern" cmake convention contain multiple CMakelists.txt and are therefore not suitable for root directory detection.

Feel free to edit or comment