### PR TITLE
feat(black): added an extra for black with null-ls

### DIFF
--- a/lua/lazyvim/plugins/extras/formatting/black.lua
+++ b/lua/lazyvim/plugins/extras/formatting/black.lua
@@ -1,0 +1,15 @@
+return {
+  {
+    "williamboman/mason.nvim",
+    opts = function(_, opts)
+      table.insert(opts.ensure_installed, "black")
+    end,
+  },
+  {
+    "jose-elias-alvarez/null-ls.nvim",
+    opts = function(_, opts)
+      local nls = require("null-ls")
+      table.insert(opts.sources, nls.builtins.formatting.black)
+    end,
+  },
+}

--- a/lua/lazyvim/plugins/extras/formatting/black.lua
+++ b/lua/lazyvim/plugins/extras/formatting/black.lua
@@ -6,10 +6,20 @@ return {
     end,
   },
   {
-    "jose-elias-alvarez/null-ls.nvim",
+    "nvimtools/none-ls.nvim",
+    optional = true,
     opts = function(_, opts)
       local nls = require("null-ls")
       table.insert(opts.sources, nls.builtins.formatting.black)
     end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        ["python"] = { { "blackd", "black" } },
+      },
+    },
   },
 }


### PR DESCRIPTION
Just like [prettier format](https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/plugins/extras/formatting/prettier.lua), it would be nice if there was a similar one for black.