### PR TITLE
Fix(keymaps): change `v` mode to `x` mode for `save file`

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -82,7 +82,7 @@ map("i", ".", ".<c-g>u")
 map("i", ";", ";<c-g>u")
 
 -- save file
-map({ "i", "v", "n", "s" }, "<C-s>", "<cmd>w<cr><esc>", { desc = "Save file" })
+map({ "i", "x", "n", "s" }, "<C-s>", "<cmd>w<cr><esc>", { desc = "Save file" })
 
 --keywordprg
 map("n", "<leader>K", "<cmd>norm! K<cr>", { desc = "Keywordprg" })


### PR DESCRIPTION
While trying to disable `<C-s>` entirely by `vim.keymap.del({ "i", "v","n", "s" }, "<C-s>")` in my own `keymaps.lua`, I got an error on reopening Neovim `No such mapping`. After tinkering around a bit, I changed `v` to `x`, since `v` incorporates both `x` and `s` and the error stopped occuring.