### PR TITLE
fix(Editor): Set keybindings to correct telescope `find_files` expected behaviour

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -95,8 +95,8 @@ return {
       { "<leader><space>", Util.telescope("files"), desc = "Find Files (root dir)" },
       -- find
       { "<leader>fb", "<cmd>Telescope buffers<cr>", desc = "Buffers" },
-      { "<leader>ff", Util.telescope("files"), desc = "Find Files (root dir)" },
-      { "<leader>fF", Util.telescope("files", { cwd = false }), desc = "Find Files (cwd)" },
+      { "<leader>ff", Util.telescope("files", { cwd = false }), desc = "Find Files (root dir)" },
+      { "<leader>fF", Util.telescope("files"), desc = "Find Files (cwd)" },
       { "<leader>fr", "<cmd>Telescope oldfiles<cr>", desc = "Recent" },
       { "<leader>fR", Util.telescope("oldfiles", { cwd = vim.loop.cwd() }), desc = "Recent (cwd)" },
       -- git


### PR DESCRIPTION
Hello,

## Description

This PR sets the expected behaviour according to the keybinding descriptions for telescope `find_files` calls.

The current implementation seems to call `find_files` within current working directory when pressing `<leader>ff` and pressing `<leader>fF` invokes `find_files` in root directory.

## Impacted lines in current implementation

https://github.com/LazyVim/LazyVim/blob/566049aa4a26a86219dd1ad1624f9a1bf18831b6/lua/lazyvim/plugins/editor.lua#L98
https://github.com/LazyVim/LazyVim/blob/566049aa4a26a86219dd1ad1624f9a1bf18831b6/lua/lazyvim/plugins/editor.lua#L99

## Example in my configuration

https://github.com/bamdadsabbagh/config-nvim/blob/1ee03ce6a818c05c2640e3ffc712653f40fe8959/lua/plugins/telescope.lua#L9
https://github.com/bamdadsabbagh/config-nvim/blob/1ee03ce6a818c05c2640e3ffc712653f40fe8959/lua/plugins/telescope.lua#L10