### PR TITLE
feat(neoconf): Move to separate plugin spec

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -466,11 +466,6 @@ If you rather use leap/flit instead, you can add the leap extra:
   {
     "folke/neoconf.nvim",
     cmd = "Neoconf",
-    config = function()
-      if Util.has("neoconf.nvim") then
-        local plugin = require("lazy.core.config").spec.plugins["neoconf.nvim"]
-        require("neoconf").setup(require("lazy.core.plugin").values(plugin, "opts", false))
-      end
-    end,
+    config = true,
   },
 }

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -461,4 +461,16 @@ If you rather use leap/flit instead, you can add the leap extra:
       { "<leader>sT", "<cmd>TodoTelescope keywords=TODO,FIX,FIXME<cr>", desc = "Todo/Fix/Fixme" },
     },
   },
+
+  -- Manages global and project-local settings.
+  {
+    "folke/neoconf.nvim",
+    cmd = "Neoconf",
+    config = function()
+      if Util.has("neoconf.nvim") then
+        local plugin = require("lazy.core.config").spec.plugins["neoconf.nvim"]
+        require("neoconf").setup(require("lazy.core.plugin").values(plugin, "opts", false))
+      end
+    end,
+  },
 }

--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -4,7 +4,7 @@ return {
     "neovim/nvim-lspconfig",
     event = { "BufReadPre", "BufNewFile" },
     dependencies = {
-      { "folke/neoconf.nvim", cmd = "Neoconf", config = false, dependencies = { "nvim-lspconfig" } },
+      { "folke/neoconf.nvim" },
       { "folke/neodev.nvim", opts = {} },
       "mason.nvim",
       "williamboman/mason-lspconfig.nvim",
@@ -90,10 +90,6 @@ return {
     config = function(_, opts)
       local Util = require("lazyvim.util")
 
-      if Util.has("neoconf.nvim") then
-        local plugin = require("lazy.core.config").spec.plugins["neoconf.nvim"]
-        require("neoconf").setup(require("lazy.core.plugin").values(plugin, "opts", false))
-      end
       -- setup autoformat
       require("lazyvim.plugins.lsp.format").setup(opts)
       -- setup formatting and keymaps


### PR DESCRIPTION
Moves neoconf to its own plugin spec so that neoconf can be used in an environment where LSP is not necessary.