### PR TITLE
Do not jump on invocation of *

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -165,3 +165,6 @@ map("n", "<leader><tab><tab>", "<cmd>tabnew<cr>", { desc = "New Tab" })
 map("n", "<leader><tab>]", "<cmd>tabnext<cr>", { desc = "Next Tab" })
 map("n", "<leader><tab>d", "<cmd>tabclose<cr>", { desc = "Close Tab" })
 map("n", "<leader><tab>[", "<cmd>tabprevious<cr>", { desc = "Previous Tab" })
+
+-- Do not jump on invocation of *
+vim.keymap.set("n", "*", ":keepjumps normal! mi*`i<Cr>")


### PR DESCRIPTION
I had this in my configuration before switching to lazyvim and pulled it in to my lazyvim configuration. I figure it might be useful for other folks as well.