### PR TITLE
feat(python): add more venv names

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -61,7 +61,14 @@ return {
   {
     "linux-cultist/venv-selector.nvim",
     cmd = "VenvSelect",
-    opts = {},
+    opts = {
+      name = {
+        "venv",
+        ".venv",
+        "env",
+        ".env",
+      },
+    },
     keys = { { "<leader>cv", "<cmd>:VenvSelect<cr>", desc = "Select VirtualEnv" } },
   },
 }


### PR DESCRIPTION
By default `venv-selector` only set virtual environment name to the `venv`. To be more versatile I've added more name possibilities.