### PR TITLE
feat(java): support vscode launch json in Java

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -199,6 +199,7 @@ return {
               -- custom init for Java debugger
               require("jdtls").setup_dap(opts.dap)
               require("jdtls.dap").setup_dap_main_class_configs()
+              -- setup dap config by VsCode launch.json file
               require("dap.ext.vscode").load_launchjs()
 
               -- Java Test require Java debugger to work

--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -199,6 +199,7 @@ return {
               -- custom init for Java debugger
               require("jdtls").setup_dap(opts.dap)
               require("jdtls.dap").setup_dap_main_class_configs()
+              require("dap.ext.vscode").load_launchjs()
 
               -- Java Test require Java debugger to work
               if opts.test and mason_registry.is_installed("java-test") then


### PR DESCRIPTION
Support setup nvim-dap config in Java by launch.json, if there is no `.vscode/launch.json`, nothing will happen, so no side effect

It's convenient to generate dap configurations by VsCode

Related: https://github.com/mfussenegger/nvim-dap/pull/48