### PR TITLE
feat(coding)!: Move mini.ai to extras. Add default textobjects to treesitter

### DIFF
--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -150,74 +150,27 @@ return {
     },
   },
 
-  -- Better text-objects
+  -- disable old installations of mini.ai. Optional so it doesn't appear under disabled plugins
   {
     "echasnovski/mini.ai",
-    -- keys = {
-    --   { "a", mode = { "x", "o" } },
-    --   { "i", mode = { "x", "o" } },
-    -- },
-    event = "VeryLazy",
-    dependencies = { "nvim-treesitter-textobjects" },
-    opts = function()
-      local ai = require("mini.ai")
-      return {
-        n_lines = 500,
-        custom_textobjects = {
-          o = ai.gen_spec.treesitter({
-            a = { "@block.outer", "@conditional.outer", "@loop.outer" },
-            i = { "@block.inner", "@conditional.inner", "@loop.inner" },
-          }, {}),
-          f = ai.gen_spec.treesitter({ a = "@function.outer", i = "@function.inner" }, {}),
-          c = ai.gen_spec.treesitter({ a = "@class.outer", i = "@class.inner" }, {}),
-        },
-      }
-    end,
-    config = function(_, opts)
-      require("mini.ai").setup(opts)
-      -- register all text objects with which-key
-      require("lazyvim.util").on_load("which-key.nvim", function()
-        ---@type table<string, string|table>
-        local i = {
-          [" "] = "Whitespace",
-          ['"'] = 'Balanced "',
-          ["'"] = "Balanced '",
-          ["`"] = "Balanced `",
-          ["("] = "Balanced (",
-          [")"] = "Balanced ) including white-space",
-          [">"] = "Balanced > including white-space",
-          ["<lt>"] = "Balanced <",
-          ["]"] = "Balanced ] including white-space",
-          ["["] = "Balanced [",
-          ["}"] = "Balanced } including white-space",
-          ["{"] = "Balanced {",
-          ["?"] = "User Prompt",
-          _ = "Underscore",
-          a = "Argument",
-          b = "Balanced ), ], }",
-          c = "Class",
-          f = "Function",
-          o = "Block, conditional, loop",
-          q = "Quote `, \", '",
-          t = "Tag",
-        }
-        local a = vim.deepcopy(i)
-        for k, v in pairs(a) do
-          a[k] = v:gsub(" including.*", "")
+    enabled = function()
+      vim.schedule(function()
+        local Config = require("lazy.core.config")
+        if Config.spec.disabled["mini.ai"] then
+          require("lazy.core.util").warn(
+            [[ `mini.ai` has been moved to extras:
+The core config for nvim-treesitter now contains textobjects
+for `select`, `move` and `swap`.
+If you want to keep using mini.ai, you can add the mini-ai extra:
+`lazyvim.plugins.extras.coding.mini-ai`
+By doing so, your original mini.ai setup remains unchanged.
+]],
+            { title = "LazyVim" }
+          )
         end
-
-        local ic = vim.deepcopy(i)
-        local ac = vim.deepcopy(a)
-        for key, name in pairs({ n = "Next", l = "Last" }) do
-          i[key] = vim.tbl_extend("force", { name = "Inside " .. name .. " textobject" }, ic)
-          a[key] = vim.tbl_extend("force", { name = "Around " .. name .. " textobject" }, ac)
-        end
-        require("which-key").register({
-          mode = { "o", "x" },
-          i = i,
-          a = a,
-        })
       end)
+      return false
     end,
+    optional = true,
   },
 }

--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -150,20 +150,19 @@ return {
     },
   },
 
-  -- disable old installations of mini.ai. Optional so it doesn't appear under disabled plugins
+  -- mini.ai has been moved from coding to extras.
+  -- if the config of the user contains mini.ai without the extra:
+  -- warn and disable
   {
     "echasnovski/mini.ai",
-    enabled = function()
+    enabled = function() -- the extra must override this function.
       vim.schedule(function()
         local Config = require("lazy.core.config")
         if Config.spec.disabled["mini.ai"] then
           require("lazy.core.util").warn(
-            [[ `mini.ai` has been moved to extras:
-The core config for nvim-treesitter now contains textobjects
-for `select`, `move` and `swap`.
-If you want to keep using mini.ai, you can add the mini-ai extra:
+            [[ `mini.ai` has been moved to **extras**.
+Please add the `mini.ai` **extra** to your config:
 `lazyvim.plugins.extras.coding.mini-ai`
-By doing so, your original mini.ai setup remains unchanged.
 ]],
             { title = "LazyVim" }
           )
@@ -171,6 +170,6 @@ By doing so, your original mini.ai setup remains unchanged.
       end)
       return false
     end,
-    optional = true,
+    optional = true, -- only warn if the config of the user contains mini.ai
   },
 }

--- a/lua/lazyvim/plugins/extras/coding/mini-ai.lua
+++ b/lua/lazyvim/plugins/extras/coding/mini-ai.lua
@@ -74,8 +74,10 @@ return {
         n_lines = 500,
         custom_textobjects = {
 
-          -- see: https://github.com/echasnovski/mini.nvim/issues/474
-          t = false, -- for now, fallback to neovim's builtin tag.
+          -- opt-out: using neovim's text object selection for tags:
+          t = false,
+          -- opt-in: use the following override in the "opts" function of your spec:
+          -- opts.custom_textobjects.t = nil -- opt-in to mini.ai's tag textobject
 
           o = ai.gen_spec.treesitter({
             a = { "@block.outer", "@conditional.outer", "@loop.outer" },

--- a/lua/lazyvim/plugins/extras/coding/mini-ai.lua
+++ b/lua/lazyvim/plugins/extras/coding/mini-ai.lua
@@ -1,0 +1,139 @@
+local load_textobjects = false
+
+---@param langs table<string>
+---@return table<string>
+local function dedup(langs)
+  -- TODO: move this utility function to a better location
+  ---@type table<string, boolean>
+  local added = {}
+  return vim.tbl_filter(function(lang)
+    if added[lang] then
+      return false
+    end
+    added[lang] = true
+    return true
+  end, langs)
+end
+
+return {
+
+  {
+    "nvim-treesitter/nvim-treesitter",
+    dependencies = {
+      {
+        "nvim-treesitter/nvim-treesitter-textobjects",
+        init = function()
+          -- disable rtp plugin, as we only need its queries for mini.ai
+          -- In case other textobject modules are enabled, we will load them
+          -- once nvim-treesitter is loaded
+          require("lazy.core.loader").disable_rtp_plugin("nvim-treesitter-textobjects")
+          load_textobjects = true
+        end,
+      },
+    },
+    opts = function(_, opts)
+      -- override the default textobjects, set in plugins/treesitter.lua
+      -- when using this extra, the user is expected to add textobjects
+      -- on a need-to-have basis
+      opts.textobjects = nil
+    end,
+    ---@param opts TSConfig
+    config = function(_, opts) -- override config in plugins/treesitter.lua
+      if type(opts.ensure_installed) == "table" then
+        opts.ensure_installed = dedup(opts.ensure_installed)
+      end
+      require("nvim-treesitter.configs").setup(opts)
+
+      if load_textobjects then
+        -- PERF: no need to load the plugin, if we only need its queries for mini.ai
+        if opts.textobjects then
+          for _, mod in ipairs({ "move", "select", "swap", "lsp_interop" }) do
+            if opts.textobjects[mod] and opts.textobjects[mod].enable then
+              local Loader = require("lazy.core.loader")
+              Loader.disabled_rtp_plugins["nvim-treesitter-textobjects"] = nil
+              local plugin = require("lazy.core.config").plugins["nvim-treesitter-textobjects"]
+              require("lazy.core.loader").source_runtime(plugin.dir, "plugin")
+              break
+            end
+          end
+        end
+      end
+    end,
+  },
+
+  -- Better text-objects
+  {
+    "echasnovski/mini.ai",
+    enabled = true,
+    -- keys = {
+    --   { "a", mode = { "x", "o" } },
+    --   { "i", mode = { "x", "o" } },
+    -- },
+    event = "VeryLazy",
+    dependencies = { "nvim-treesitter-textobjects" },
+    opts = function()
+      local ai = require("mini.ai")
+      return {
+        n_lines = 500,
+        custom_textobjects = {
+
+          -- see: https://github.com/echasnovski/mini.nvim/issues/474
+          t = false, -- for now, fallback to neovim's builtin tag.
+
+          o = ai.gen_spec.treesitter({
+            a = { "@block.outer", "@conditional.outer", "@loop.outer" },
+            i = { "@block.inner", "@conditional.inner", "@loop.inner" },
+          }, {}),
+          f = ai.gen_spec.treesitter({ a = "@function.outer", i = "@function.inner" }, {}),
+          c = ai.gen_spec.treesitter({ a = "@class.outer", i = "@class.inner" }, {}),
+        },
+      }
+    end,
+    config = function(_, opts)
+      require("mini.ai").setup(opts)
+      -- register all text objects with which-key
+      require("lazyvim.util").on_load("which-key.nvim", function()
+        ---@type table<string, string|table>
+        local i = {
+          [" "] = "Whitespace",
+          ['"'] = 'Balanced "',
+          ["'"] = "Balanced '",
+          ["`"] = "Balanced `",
+          ["("] = "Balanced (",
+          [")"] = "Balanced ) including white-space",
+          [">"] = "Balanced > including white-space",
+          ["<lt>"] = "Balanced <",
+          ["]"] = "Balanced ] including white-space",
+          ["["] = "Balanced [",
+          ["}"] = "Balanced } including white-space",
+          ["{"] = "Balanced {",
+          ["?"] = "User Prompt",
+          _ = "Underscore",
+          a = "Argument",
+          b = "Balanced ), ], }",
+          c = "Class",
+          f = "Function",
+          o = "Block, conditional, loop",
+          q = "Quote `, \", '",
+          t = "Tag",
+        }
+        local a = vim.deepcopy(i)
+        for k, v in pairs(a) do
+          a[k] = v:gsub(" including.*", "")
+        end
+
+        local ic = vim.deepcopy(i)
+        local ac = vim.deepcopy(a)
+        for key, name in pairs({ n = "Next", l = "Last" }) do
+          i[key] = vim.tbl_extend("force", { name = "Inside " .. name .. " textobject" }, ic)
+          a[key] = vim.tbl_extend("force", { name = "Around " .. name .. " textobject" }, ac)
+        end
+        require("which-key").register({
+          mode = { "o", "x" },
+          i = i,
+          a = a,
+        })
+      end)
+    end,
+  },
+}

--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -1,18 +1,3 @@
----@param langs table<string>
----@return table<string>
-local function dedup(langs)
-  -- TODO: move this utility function to a better location
-  ---@type table<string, boolean>
-  local added = {}
-  return vim.tbl_filter(function(lang)
-    if added[lang] then
-      return false
-    end
-    added[lang] = true
-    return true
-  end, langs)
-end
-
 return {
   -- Treesitter is a new parser generator tool that we can
   -- use in Neovim to power faster and more accurate
@@ -123,7 +108,15 @@ return {
     ---@param opts TSConfig
     config = function(_, opts)
       if type(opts.ensure_installed) == "table" then
-        opts.ensure_installed = dedup(opts.ensure_installed)
+        ---@type table<string, boolean>
+        local added = {}
+        opts.ensure_installed = vim.tbl_filter(function(lang)
+          if added[lang] then
+            return false
+          end
+          added[lang] = true
+          return true
+        end, opts.ensure_installed)
       end
       require("nvim-treesitter.configs").setup(opts)
     end,

--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -1,4 +1,18 @@
-local load_textobjects = false
+---@param langs table<string>
+---@return table<string>
+local function dedup(langs)
+  -- TODO: move this utility function to a better location
+  ---@type table<string, boolean>
+  local added = {}
+  return vim.tbl_filter(function(lang)
+    if added[lang] then
+      return false
+    end
+    added[lang] = true
+    return true
+  end, langs)
+end
+
 return {
   -- Treesitter is a new parser generator tool that we can
   -- use in Neovim to power faster and more accurate
@@ -8,18 +22,7 @@ return {
     version = false, -- last release is way too old and doesn't work on Windows
     build = ":TSUpdate",
     event = { "BufReadPost", "BufNewFile" },
-    dependencies = {
-      {
-        "nvim-treesitter/nvim-treesitter-textobjects",
-        init = function()
-          -- disable rtp plugin, as we only need its queries for mini.ai
-          -- In case other textobject modules are enabled, we will load them
-          -- once nvim-treesitter is loaded
-          require("lazy.core.loader").disable_rtp_plugin("nvim-treesitter-textobjects")
-          load_textobjects = true
-        end,
-      },
-    },
+    dependencies = { "nvim-treesitter/nvim-treesitter-textobjects" },
     cmd = { "TSUpdateSync" },
     keys = {
       { "<c-space>", desc = "Increment selection" },
@@ -59,36 +62,70 @@ return {
           node_decremental = "<bs>",
         },
       },
+      textobjects = {
+        select = {
+          enable = true,
+          lookahead = true,
+          keymaps = {
+            ["ak"] = { query = "@block.outer", desc = "around block" },
+            ["ik"] = { query = "@block.inner", desc = "inside block" },
+            ["ac"] = { query = "@class.outer", desc = "around class" },
+            ["ic"] = { query = "@class.inner", desc = "inside class" },
+            ["a?"] = { query = "@conditional.outer", desc = "around conditional" },
+            ["i?"] = { query = "@conditional.inner", desc = "inside conditional" },
+            ["af"] = { query = "@function.outer", desc = "around function " },
+            ["if"] = { query = "@function.inner", desc = "inside function " },
+            ["al"] = { query = "@loop.outer", desc = "around loop" },
+            ["il"] = { query = "@loop.inner", desc = "inside loop" },
+            ["aa"] = { query = "@parameter.outer", desc = "around argument" },
+            ["ia"] = { query = "@parameter.inner", desc = "inside argument" },
+          },
+        },
+        move = {
+          enable = true,
+          set_jumps = true,
+          goto_next_start = {
+            ["]k"] = { query = "@block.outer", desc = "Next block start" },
+            ["]f"] = { query = "@function.outer", desc = "Next function start" },
+            ["]a"] = { query = "@parameter.inner", desc = "Next argument start" },
+          },
+          goto_next_end = {
+            ["]K"] = { query = "@block.outer", desc = "Next block end" },
+            ["]F"] = { query = "@function.outer", desc = "Next function end" },
+            ["]A"] = { query = "@parameter.inner", desc = "Next argument end" },
+          },
+          goto_previous_start = {
+            ["[k"] = { query = "@block.outer", desc = "Previous block start" },
+            ["[f"] = { query = "@function.outer", desc = "Previous function start" },
+            ["[a"] = { query = "@parameter.inner", desc = "Previous argument start" },
+          },
+          goto_previous_end = {
+            ["[K"] = { query = "@block.outer", desc = "Previous block end" },
+            ["[F"] = { query = "@function.outer", desc = "Previous function end" },
+            ["[A"] = { query = "@parameter.inner", desc = "Previous argument end" },
+          },
+        },
+        swap = {
+          enable = true,
+          swap_next = {
+            [">K"] = { query = "@block.outer", desc = "Swap next block" },
+            [">F"] = { query = "@function.outer", desc = "Swap next function" },
+            [">A"] = { query = "@parameter.inner", desc = "Swap next argument" },
+          },
+          swap_previous = {
+            ["<K"] = { query = "@block.outer", desc = "Swap previous block" },
+            ["<F"] = { query = "@function.outer", desc = "Swap previous function" },
+            ["<A"] = { query = "@parameter.inner", desc = "Swap previous argument" },
+          },
+        },
+      },
     },
     ---@param opts TSConfig
     config = function(_, opts)
       if type(opts.ensure_installed) == "table" then
-        ---@type table<string, boolean>
-        local added = {}
-        opts.ensure_installed = vim.tbl_filter(function(lang)
-          if added[lang] then
-            return false
-          end
-          added[lang] = true
-          return true
-        end, opts.ensure_installed)
+        opts.ensure_installed = dedup(opts.ensure_installed)
       end
       require("nvim-treesitter.configs").setup(opts)
-
-      if load_textobjects then
-        -- PERF: no need to load the plugin, if we only need its queries for mini.ai
-        if opts.textobjects then
-          for _, mod in ipairs({ "move", "select", "swap", "lsp_interop" }) do
-            if opts.textobjects[mod] and opts.textobjects[mod].enable then
-              local Loader = require("lazy.core.loader")
-              Loader.disabled_rtp_plugins["nvim-treesitter-textobjects"] = nil
-              local plugin = require("lazy.core.config").plugins["nvim-treesitter-textobjects"]
-              require("lazy.core.loader").source_runtime(plugin.dir, "plugin")
-              break
-            end
-          end
-        end
-      end
     end,
   },
 }


### PR DESCRIPTION
### Resources:

[bug: textobject-based tag block selection breaks with mini.ai enabled #1413](https://github.com/LazyVim/LazyVim/issues/1413)
[bug: vat/vit yit/yat etc don't work as intended #1217](https://github.com/LazyVim/LazyVim/issues/1217)
[mini.ai: tag selection breaks when tag contains an underscore #474](https://github.com/echasnovski/mini.nvim/issues/474)

### Motivation:

All thoughts leading to this PR can be found in #1413.
An alternative for this PR is also provided: [mini.ai disable tag textobject](https://github.com/LazyVim/LazyVim/pull/1444)

Quoting myself:

> Quoting my reply to @madjxatw:
>
> > I don't think the plugin should be disabled by default, as @madjxatw suggested
>
> For completeness: I changed my mind. My preference would be to have treesitter-textobjects fully configured in the core of LazyVim, and _opt-in_ to mini.ai in extras.
>
> Mini.ai is a high quality, powerful plugin. However, "it enhances some builtin textobjects". There are benefits to this approach, but also some disadvantages, as [stated](https://github.com/echasnovski/mini.nvim/issues/156#issuecomment-1308429031) by the author.
>
> I was considering a pull request for `LazyVim`, preventing mini.ai from taking over the `tag` textobject:
>
> ```lua
> {
>     "echasnovski/mini.ai",
>     opts = function(_, opts)
>       opts.custom_textobjects = {
>         t = false, -- fallback to neovim for tags
>       }
>     end,
> }
> ```
>
> That would fix this issue, and also the issue referenced [here](https://github.com/LazyVim/LazyVim/issues/1413#issuecomment-1705238732)
>
> However, there might be more enhancements up for debate. As an example, consider:
>
> `local msg = "hello world"`
>
> Position the cursor on the "w", and press `vi"`. Now, the cursor is positioned on the first word, the letter "h". Without mini.ai, the cursor would be positioned on the last word, the letter "d".

Also:
> In the end, the main motivation is the enhanced builtin textobjects, because of the changes to the core behavior of neovim's textobjects. In my personal opinion, for a setup like LazyVim, that should be opt-in.

### Approach

I used the same approach as chosen in the change from `leap.nvim` to `flash.nvim`, in this [commit](https://github.com/LazyVim/LazyVim/commit/ae759b947b1ef16d9814fcddfcafe2cdd767bc6a).
This PR is also breaking.
Users should add the `extra` to their config, in order to opt-in to `mini.ai`.  In that case, all newly added `textobjects` in `lazyvim.plugins.treesitter` are overwritten.

In case this PR is accepted, I can also write a PR for the website


### Additional changes

I disabled the `tag` textobject of `mini.ai`:

```lua
opts.custom_textobjects = {
  -- opt-out: using neovim's text object selection for tags:
  t = false,
  -- opt-in: use the following override in the "opts" function of your spec:
  -- opts.custom_textobjects.t = nil -- opt-in to mini.ai's tag textobject
```

This fixes issues #1413 and #1217

### Testing

I tested the following scenario's, using this [setup](https://github.com/abeldekat/starter/tree/miniai_to_extras):

1. No mini.ai in config. The new textobjects are working.
2. mini.ai in config, having enabled = false. Warning does not appear, as expected
3. mini.ai in config, having enabled = true. Warning does not appear!
4. mini.ai in config, but not installed. Warning appears as expected
5. mini.ai in config, and installed. Warning appears, the UI of `lazy.nvim` offers to clean.
6. mini.ai in config, added extra.
7. mini.ai in config, added extra, modified config to use `mini.ai`'s `tag` `textobject`.
8. mini.ai in config, added extra, added `swap` textobjects to treesitter

The third test case fails, because the user has set the enabled property explicitly to true.
As a consequence, his `mini.ai` spec will lack `LazyVim`'s `mini.ai`. I think this scenario would also have failed when switching from `leap` to `flash`. 

### Related discussions:
[broken text object in tsx files](https://github.com/LazyVim/LazyVim/discussions/1341)
[Deleting inside Tag](https://github.com/LazyVim/LazyVim/discussions/778)
[visually select jsx html tags](https://github.com/LazyVim/LazyVim/discussions/500)