### PR TITLE
fix: #1413 mini.ai disable tag textobject

### DIFF
--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -164,6 +164,11 @@ return {
       return {
         n_lines = 500,
         custom_textobjects = {
+          -- opt-out: using neovim's text object selection for tags:
+          t = false,
+          -- opt-in: use the following override in the "opts" function of your spec:
+          -- opts.custom_textobjects.t = nil -- opt-in to mini.ai's tag textobject
+
           o = ai.gen_spec.treesitter({
             a = { "@block.outer", "@conditional.outer", "@loop.outer" },
             i = { "@block.inner", "@conditional.inner", "@loop.inner" },


### PR DESCRIPTION
### Resources:
[PR: feat(coding)!: Move mini.ai to extras. Add default textobjects to treesitter #1434](https://github.com/LazyVim/LazyVim/pull/1434)
[bug: textobject-based tag block selection breaks with mini.ai enabled #1413](https://github.com/LazyVim/LazyVim/issues/1413)
[bug: vat/vit yit/yat etc don't work as intended #1217](https://github.com/LazyVim/LazyVim/issues/1217)
[mini.ai: tag selection breaks when tag contains an underscore #474](https://github.com/echasnovski/mini.nvim/issues/474)

### Motivation:

All thoughts leading to this PR can be found in #1413.
This PR fixes issues #1413 and #1217, providing an alternative to PR #1434

### Approach:
The difference between this PR and PR #1434: Plugin `mini.ai` will not be moved to extras.
The `tag textobject` provided by `mini.ai` is disabled. `Neovim`'s default will be used.
The user can opt-in by overriding the `opts` function of the spec:

```lua
{
  "echasnovski/mini.ai",
  opts = function(_, opts)
    opts.custom_textobjects.t = nil -- opt-in to mini.ai's tag textobject
  end,
}
```

If the user opts-in, extra configuration to properly use the `tag textobject` is also needed.
The user can choose the best approach for his requirements.

### Alternatives considered:
Instead of disabling, add extra config to `LazyVim`'s spec, using the suggestions in this [comment](https://github.com/echasnovski/mini.nvim/issues/474#issuecomment-1712526964) of [mini.nvim#474](https://github.com/echasnovski/mini.nvim/issues/474)

An example can be found in my [repo](https://github.com/abeldekat/starter/tree/miniai_fix_tag), using `LazyVim starter`.

Note that the alternative using `treesitter` does not work inside strings and comments.
As `xml` is quite commonly used in other languages to manipulate data, I don't think this alternative is a solution to the problem.
 
### Testing:
The user is able to opt-in.




