### PR TITLE
feat(clojure): add clojure support

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/clojure.lua
+++ b/lua/lazyvim/plugins/extras/lang/clojure.lua
@@ -1,0 +1,32 @@
+return {
+    "Olical/conjure",
+    ft = { "clojure", "fennel" }, -- etc
+    -- [Optional] cmp-conjure for cmp
+    dependencies = {
+      {
+        "PaterJason/cmp-conjure",
+        config = function()
+          local cmp = require("cmp")
+          local config = cmp.get_config()
+          table.insert(config.sources, {
+            name = "buffer",
+            option = {
+              sources = {
+                { name = "conjure" },
+              },
+            },
+          })
+          cmp.setup(config)
+        end,
+      },
+    },
+    config = function(_, opts)
+      require("conjure.main").main()
+      require("conjure.mapping")["on-filetype"]()
+    end,
+    init = function()
+      -- Set configuration options here
+      vim.g["conjure#debug"] = true
+    end,
+  }
+  


### PR DESCRIPTION
Add a minimal Clojure support. 

The config is taken from:
https://github.com/Olical/conjure

Not a Clojure expert here haha. 

The only change I made is I removed the Python support from the default configuration, such that it will only work for Clojure and won't interfere with any Python functionalities. Has been working well on my end.