### PR TITLE
fix(test): add missing neotest dependencies

### DIFF
--- a/lua/lazyvim/plugins/extras/test/core.lua
+++ b/lua/lazyvim/plugins/extras/test/core.lua
@@ -10,6 +10,11 @@ return {
   },
   {
     "nvim-neotest/neotest",
+    dependencies = {
+      "nvim-lua/plenary.nvim",
+      "nvim-treesitter/nvim-treesitter",
+      "antoinemadec/FixCursorHold.nvim",
+    },
     opts = {
       -- Can be a list of adapters like what neotest expects,
       -- or a list of adapter names,


### PR DESCRIPTION
There are some dependencies defined in the [installation section of the Neotest documentation](https://github.com/nvim-neotest/neotest#installation), which are missing here in the test extra. On my machine, the test extra wasn't working without these dependencies defined, so I went ahead and thought I could create a PR to fix this. 

I just started learning LazyVim today, so I am not totally sure if my reasoning is right here 😄  