### PR TITLE
chore: fix LazyVim url in bug_report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
         -- install plugins
         local plugins = {
           "folke/tokyonight.nvim",
-          "folke/LazyVim",
+          "LazyVim/LazyVim",
           -- add any other plugins here
         }
         require("lazy").setup(plugins, {


### PR DESCRIPTION
The repro specifies:
```lua
local plugins = {
  "folke/tokyonight.nvim",
  "folke/LazyVim",
  -- add any other plugins here
}
```

Adding `import="lazyvim.plugins"` leads to the following error:
> lazy.nvim Two plugins with the same name and different url:

This PR changes "folke/LazyVim" into "LazyVim/LazyVim"

On a sidenote, specifying just "LazyVim/LazyVim" merely loads the `LazyVim` plugin itself. The options, autocommands, keymaps and plugins are not loaded.
In the bug reports, I am guessing that 90% contains an unused `repro` fragment.

I created a more flexible [repro](https://github.com/LazyVim/LazyVim/discussions/1493), but I don't think it is suitable for the end user.

Perhaps, adding `import=lazyvim.plugins` is worth considering. 

