### PR TITLE
fix(python): make venv-selector `dap_enabled` conditional on `nvim-dap-python`

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -61,15 +61,19 @@ return {
   {
     "linux-cultist/venv-selector.nvim",
     cmd = "VenvSelect",
-    opts = {
-      name = {
-        "venv",
-        ".venv",
-        "env",
-        ".env",
-      },
-      dap_enabled = true, -- Ensure that the venv selector affect PythonPath in nvim-dap as well!
-    },
+    opts = function(_, opts)
+      if require("lazyvim.util").has("nvim-dap-python") then
+        opts.dap_enabled = true
+      end
+      return vim.tbl_deep_extend("force", opts, {
+        name = {
+          "venv",
+          ".venv",
+          "env",
+          ".env",
+        },
+      })
+    end,
     keys = { { "<leader>cv", "<cmd>:VenvSelect<cr>", desc = "Select VirtualEnv" } },
   },
 }


### PR DESCRIPTION
Fixes #1528 kind of. It makes sense that if you want to debug, you'd also need to install `DAP Core`, but this PR is mostly so that venv-selector `dap_enabled` option is in accordance with `nvim-dap` spec in Python extra configuration and since the latter is `optional`, I believe it makes sense that `dap_enabled` should also be conditional on the existence of `nvim-dap-python`.