### PR TITLE
feat(elixir): Add credo if none-ls is used

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/elixir.lua
+++ b/lua/lazyvim/plugins/extras/lang/elixir.lua
@@ -29,4 +29,24 @@ return {
       },
     },
   },
+  {
+    "nvimtools/none-ls.nvim",
+    optional = true,
+    opts = function(_, opts)
+      local nls = require("null-ls")
+      opts.sources = opts.sources or {}
+      vim.list_extend(opts.sources, {
+        nls.builtins.diagnostics.credo,
+      })
+    end,
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        elixir = { "credo" },
+      },
+    },
+  },
 }


### PR DESCRIPTION
(sorry, sent the PR without the description by mistake)

Credo is the de-facto linter for Elixir. I was not aware that null-ls already had Credo as a builtin before, so that's an easy addition for folks already using null-ls.

btw, LazyVim was recently mentioned in ElixirForum:
https://elixirforum.com/t/neovim-elixir-setup-configuration-from-scratch-guide/46310/35
