### PR TITLE
fix(indent-blankline): set `config.indent.tab_char`

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -168,7 +168,10 @@ return {
     "lukas-reineke/indent-blankline.nvim",
     event = { "BufReadPost", "BufNewFile" },
     opts = {
-      indent = { char = "│" },
+      indent = {
+        char = "│",
+        tab_char = "│",
+      },
       scope = { enabled = false },
       exclude = {
         filetypes = {


### PR DESCRIPTION
See lukas-reineke/indent-blankline.nvim#665.

Without patch:

![image](https://github.com/LazyVim/LazyVim/assets/38332081/60858ec7-e6a1-4158-a6aa-448ba9f5e25e)

With patch:

![image](https://github.com/LazyVim/LazyVim/assets/38332081/6f684f4b-931e-4854-ac36-f8d5d57a916f)