### PR TITLE
fix(which-key): remove duplicate which-key install

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -277,27 +277,33 @@ return {
   {
     "folke/which-key.nvim",
     event = "VeryLazy",
-    opts = {
-      plugins = { spelling = true },
-      defaults = {
-        mode = { "n", "v" },
-        ["g"] = { name = "+goto" },
-        ["gz"] = { name = "+surround" },
-        ["]"] = { name = "+next" },
-        ["["] = { name = "+prev" },
-        ["<leader><tab>"] = { name = "+tabs" },
-        ["<leader>b"] = { name = "+buffer" },
-        ["<leader>c"] = { name = "+code" },
-        ["<leader>f"] = { name = "+file/find" },
-        ["<leader>g"] = { name = "+git" },
-        ["<leader>gh"] = { name = "+hunks" },
-        ["<leader>q"] = { name = "+quit/session" },
-        ["<leader>s"] = { name = "+search" },
-        ["<leader>u"] = { name = "+ui" },
-        ["<leader>w"] = { name = "+windows" },
-        ["<leader>x"] = { name = "+diagnostics/quickfix" },
-      },
-    },
+    opts = function (_, opts)
+      if require("lazyvim.util").has("noice.nvim") then
+        opts.defaults["<leader>sn"] = { name = "+noice" }
+      end
+
+      return {
+        plugins = { spelling = true },
+        defaults = {
+          mode = { "n", "v" },
+          ["g"] = { name = "+goto" },
+          ["gz"] = { name = "+surround" },
+          ["]"] = { name = "+next" },
+          ["["] = { name = "+prev" },
+          ["<leader><tab>"] = { name = "+tabs" },
+          ["<leader>b"] = { name = "+buffer" },
+          ["<leader>c"] = { name = "+code" },
+          ["<leader>f"] = { name = "+file/find" },
+          ["<leader>g"] = { name = "+git" },
+          ["<leader>gh"] = { name = "+hunks" },
+          ["<leader>q"] = { name = "+quit/session" },
+          ["<leader>s"] = { name = "+search" },
+          ["<leader>u"] = { name = "+ui" },
+          ["<leader>w"] = { name = "+windows" },
+          ["<leader>x"] = { name = "+diagnostics/quickfix" },
+        },
+      }
+    end,
     config = function(_, opts)
       local wk = require("which-key")
       wk.setup(opts)

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -224,16 +224,6 @@ return {
     end,
   },
 
-  -- Displays a popup with possible key bindings of the command you started typing
-  {
-    "folke/which-key.nvim",
-    opts = function(_, opts)
-      if require("lazyvim.util").has("noice.nvim") then
-        opts.defaults["<leader>sn"] = { name = "+noice" }
-      end
-    end,
-  },
-
   -- Highly experimental plugin that completely replaces the UI for messages, cmdline and the popupmenu.
   {
     "folke/noice.nvim",


### PR DESCRIPTION
I noticed `which-key` plugin has been installed two times in separate files ([here](https://github.com/LazyVim/LazyVim/blob/7c5a458761fe7002c6603d602e8d130b9a62dd68/lua/lazyvim/plugins/ui.lua#L229) and [here](https://github.com/LazyVim/LazyVim/blob/7c5a458761fe7002c6603d602e8d130b9a62dd68/lua/lazyvim/plugins/editor.lua#L278)) so I merged those two into one config.