### PR TITLE
fix(rust): explicitly enable nvim-cmp source registration for crates

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -7,7 +7,11 @@ return {
       {
         "Saecki/crates.nvim",
         event = { "BufRead Cargo.toml" },
-        config = true,
+        opts = {
+          src = {
+            cmp = { enabled = true },
+          },
+        },
       },
     },
     ---@param opts cmp.ConfigSchema


### PR DESCRIPTION
For https://github.com/Saecki/crates.nvim/commit/57c448bffacba1d7970afc2823b9d30e7cecf516:

```
* fix!: nvim-cmp source registration

BREAKING CHANGE: the nvim-cmp source isn't automatically registered
anymore. Instead enable it in setup.
require("crates").setup {
    src = {
        cmp = {
            enabled = true
        },
    },
}
```
