### PR TITLE
fix(cmp): properly set cmp group_index

### DIFF
--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -67,12 +67,12 @@ return {
             select = true,
           }), -- Accept currently selected item. Set `select` to `false` to only confirm explicitly selected items.
         }),
-        sources = cmp.config.sources({
-          { name = "nvim_lsp" },
-          { name = "luasnip" },
-          { name = "buffer" },
-          { name = "path" },
-        }),
+        sources = {
+          { name = "nvim_lsp", group_index = 1 },
+          { name = "luasnip", group_index = 1 },
+          { name = "buffer", group_index = 2 },
+          { name = "path", group_index = 2 },
+        },
         formatting = {
           format = function(_, item)
             local icons = require("lazyvim.config").icons.kinds

--- a/lua/lazyvim/plugins/extras/coding/codeium.lua
+++ b/lua/lazyvim/plugins/extras/coding/codeium.lua
@@ -17,9 +17,8 @@ return {
     },
     ---@param opts cmp.ConfigSchema
     opts = function(_, opts)
-      table.insert(opts.sources, 1, { name = "codeium", group_index = 2 })
+      table.insert(opts.sources, 1, { name = "codeium", group_index = 1 })
       opts.sorting = opts.sorting or require("cmp.config.default")().sorting
     end,
   },
-
 }

--- a/lua/lazyvim/plugins/extras/coding/copilot.lua
+++ b/lua/lazyvim/plugins/extras/coding/copilot.lua
@@ -70,7 +70,7 @@ return {
     },
     ---@param opts cmp.ConfigSchema
     opts = function(_, opts)
-      table.insert(opts.sources, 1, { name = "copilot", group_index = 2 })
+      table.insert(opts.sources, 1, { name = "copilot", group_index = 1 })
       opts.sorting = opts.sorting or require("cmp.config.default")().sorting
       table.insert(opts.sorting.comparators, 1, require("copilot_cmp.comparators").prioritize)
     end,


### PR DESCRIPTION
**nvim-cmp** has a `group_index` property that we used incorrectly in LazyVim, resulting in only showing entries from the first group that had entries.

This lead to several issues with different sources like copilot.

Probably fixes a number of issues at `copilot-cmp`:
- [ ] https://github.com/zbirenbaum/copilot-cmp/issues/93
- [ ] https://github.com/zbirenbaum/copilot-cmp/issues/75
- [ ] https://github.com/zbirenbaum/copilot-cmp/issues/86

# `group_index` docs

For instance, you can set the `buffer`'s source `group_index` to a larger number
  if you don't want to see `buffer` source items while `nvim-lsp` source is available:
```lua
    cmp.setup {
      sources = {
        { name = 'nvim_lsp', group_index = 1 },
        { name = 'buffer', group_index = 2 },
      }
    }
```

  You can also achieve this by using the built-in configuration helper like this:
```lua
    cmp.setup {
      sources = cmp.config.sources({
        { name = 'nvim_lsp' },
      }, {
        { name = 'buffer' },
      })
    }
```
