### PR TITLE
fix(black): remove unknown blackd from conform

### DIFF
--- a/lua/lazyvim/plugins/extras/formatting/black.lua
+++ b/lua/lazyvim/plugins/extras/formatting/black.lua
@@ -18,7 +18,7 @@ return {
     optional = true,
     opts = {
       formatters_by_ft = {
-        ["python"] = { { "blackd", "black" } },
+        ["python"] = { "black" },
       },
     },
   },


### PR DESCRIPTION
conform.nvim doesn't actually have a config for `blackd`.

![Selection_001_03:04:04_361x77_20231009](https://github.com/LazyVim/LazyVim/assets/1026300/1e60ce99-f906-4a96-8bfc-6afa2ec0f62f)
