### PR TITLE
feat(go): add gofumpt formatter with conform/none-ls

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -92,12 +92,14 @@ return {
   {
     "nvimtools/none-ls.nvim",
     optional = true,
-    {
-      "williamboman/mason.nvim",
-      opts = function(_, opts)
-        opts.ensure_installed = opts.ensure_installed or {}
-        vim.list_extend(opts.ensure_installed, { "gomodifytags", "impl" })
-      end,
+    dependencies = {
+      {
+        "williamboman/mason.nvim",
+        opts = function(_, opts)
+          opts.ensure_installed = opts.ensure_installed or {}
+          vim.list_extend(opts.ensure_installed, { "gomodifytags", "impl" })
+        end,
+      },
     },
     opts = function(_, opts)
       local nls = require("null-ls")
@@ -123,7 +125,7 @@ return {
     optional = true,
     dependencies = {
       {
-        "mason.nvim",
+        "williamboman/mason.nvim",
         opts = function(_, opts)
           opts.ensure_installed = opts.ensure_installed or {}
           vim.list_extend(opts.ensure_installed, { "delve" })

--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -105,6 +105,7 @@ return {
         nls.builtins.code_actions.gomodifytags,
         nls.builtins.code_actions.impl,
         nls.builtins.formatting.goimports,
+        nls.builtins.formatting.gofumpt,
       })
     end,
   },
@@ -113,7 +114,7 @@ return {
     optional = true,
     opts = {
       formatters_by_ft = {
-        go = { "goimports" },
+        go = { "goimports", "gofumpt" },
       },
     },
   },

--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -83,8 +83,22 @@ return {
   },
   -- Ensure Go tools are installed
   {
+    "williamboman/mason.nvim",
+    opts = function(_, opts)
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "goimports", "gofumpt" })
+    end,
+  },
+  {
     "nvimtools/none-ls.nvim",
     optional = true,
+    {
+      "williamboman/mason.nvim",
+      opts = function(_, opts)
+        opts.ensure_installed = opts.ensure_installed or {}
+        vim.list_extend(opts.ensure_installed, { "gomodifytags", "impl" })
+      end,
+    },
     opts = function(_, opts)
       local nls = require("null-ls")
       opts.sources = vim.list_extend(opts.sources or {}, {
@@ -111,7 +125,7 @@ return {
         "mason.nvim",
         opts = function(_, opts)
           opts.ensure_installed = opts.ensure_installed or {}
-          vim.list_extend(opts.ensure_installed, { "gomodifytags", "impl", "goimports", "delve" })
+          vim.list_extend(opts.ensure_installed, { "delve" })
         end,
       },
       {


### PR DESCRIPTION
After https://github.com/LazyVim/LazyVim/pull/1535 and https://github.com/LazyVim/LazyVim/pull/1549, some formatters (i.e.: `gofumpt`) were removed from the `conform.nvim` and `none-ls.nvim` configurations in `extras.lang.go` because they were already already handled by the LSP `gopls`.

With the release of LazyVim 10.0.0, only one formatter can be active at a time so `gopls` is no longer taking care of running `gofumpt` when `conform` or `none-ls` are active.

This PR adds it back to the `conform.nvim` and `none-ls.nvim` configurations so people using any of the two can use `gofumpt`. This PR also makes sure packages are only installed when strictly necessary: for example, `delve` is only needed when `nvim-dap` is available and `gomodifytags` and `impl` are not supported by conform since they are code actions, so they are only installed when using `none-ls`.