### PR TITLE
fix: add title to Spectre panel in edgy

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/edgy.lua
+++ b/lua/lazyvim/plugins/extras/ui/edgy.lua
@@ -49,7 +49,7 @@ return {
               return vim.bo[buf].buftype == "help"
             end,
           },
-          { ft = "spectre_panel", size = { height = 0.4 } },
+          { title = "Spectre", ft = "spectre_panel", size = { height = 0.4 } },
           { title = "Neotest Output", ft = "neotest-output-panel", size = { height = 15 } },
         },
         left = {


### PR DESCRIPTION
Title could also be `Search/Replace`, because the Spectre panel shows *Nvim Spectre* in the panel as well.