### PR TITLE
Add `ft` to Python keymaps, and fix "Markdown Preview" toggle description

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/markdown.lua
+++ b/lua/lazyvim/plugins/extras/lang/markdown.lua
@@ -54,7 +54,7 @@ return {
         "<leader>cp",
         ft = "markdown",
         "<cmd>MarkdownPreviewToggle<cr>",
-        desc = "Peek (Markdown Preview)",
+        desc = "Markdown Preview",
       },
     },
     config = function()

--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -65,8 +65,8 @@ return {
       "mfussenegger/nvim-dap-python",
       -- stylua: ignore
       keys = {
-        { "<leader>dPt", function() require('dap-python').test_method() end, desc = "Debug Method" },
-        { "<leader>dPc", function() require('dap-python').test_class() end, desc = "Debug Class" },
+        { "<leader>dPt", function() require('dap-python').test_method() end, desc = "Debug Method", ft = "python" },
+        { "<leader>dPc", function() require('dap-python').test_class() end, desc = "Debug Class", ft = "python" },
       },
       config = function()
         local path = require("mason-registry").get_package("debugpy"):get_install_path()


### PR DESCRIPTION
1. Add `ft = "python"` to the `nvim-dap-python` keymaps.
2. Remove "Peek" from the `MarkdownPreviewToggle` description.