### PR TITLE
feat(lualine): use gitsigns for diff source

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -177,6 +177,16 @@ return {
                 modified = icons.git.modified,
                 removed = icons.git.removed,
               },
+              source = function()
+                local gitsigns = vim.b.gitsigns_status_dict
+                if gitsigns then
+                  return {
+                    added = gitsigns.added,
+                    modified = gitsigns.changed,
+                    removed = gitsigns.removed,
+                  }
+                end
+              end,
             },
           },
           lualine_y = {


### PR DESCRIPTION
We can use the git diff info from gitsigns in lualine. Anyway, it exists and can be configured to handle worktrees ($GIT_DIR other than .git)