### PR TITLE
feat(fold): expand fold to previous line when reopen buffer

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -42,6 +42,7 @@ vim.api.nvim_create_autocmd("BufReadPost", {
     local lcount = vim.api.nvim_buf_line_count(buf)
     if mark[1] > 0 and mark[1] <= lcount then
       pcall(vim.api.nvim_win_set_cursor, 0, mark)
+      vim.cmd("normal! zv")
     end
   end,
 })


### PR DESCRIPTION
Modified the last_loc autocommand to always reveal the current line if it's in a fold.
Not a problem with current setting of foldlevel=99 but it's a bit more convenient when use with default foldlevel to a low value.