### PR TITLE
fix(tabnine): run `:CmpTabnineHub` automatically on build

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/tabnine.lua
+++ b/lua/lazyvim/plugins/extras/coding/tabnine.lua
@@ -5,10 +5,12 @@ return {
   {
     "nvim-cmp",
     dependencies = {
-      -- Add TabNine support, make sure you run :CmpTabnineHub after installation.
       {
         "tzachar/cmp-tabnine",
-        build = Util.is_win() and "pwsh -noni .\\install.ps1" or "./install.sh",
+        build = {
+          Util.is_win() and "pwsh -noni .\\install.ps1" or "./install.sh",
+          ":CmpTabnineHub",
+        },
         dependencies = "hrsh7th/nvim-cmp",
         opts = {
           max_lines = 1000,


### PR DESCRIPTION
add the `:CmpTabnineHub` command to the build process, similar to copilot and codeium