### PR TITLE
feat(typescript): remove unused imports

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -32,6 +32,19 @@ return {
               end,
               desc = "Organize Imports",
             },
+            {
+              "<leader>cR",
+              function()
+                vim.lsp.buf.code_action({
+                  apply = true,
+                  context = {
+                    only = { "source.removeUnused.ts" },
+                    diagnostics = {},
+                  },
+                })
+              end,
+              desc = "Remove Unused Imports",
+            },
           },
           settings = {
             typescript = {


### PR DESCRIPTION
Previously used typescript.nvim for this (`:TypescriptRemoveUnused` or somesuch)

Not sure if `<leader>cR` is the best binding but it seems reasonable. I like caps for stuff that's destructive.