### PR TITLE
feat(eslint): make eslint primary formatter

### DIFF
--- a/lua/lazyvim/plugins/extras/linting/eslint.lua
+++ b/lua/lazyvim/plugins/extras/linting/eslint.lua
@@ -20,7 +20,7 @@ return {
 
           local formatter = require("lazyvim.util").lsp.formatter({
             name = "eslint: lsp",
-            primary = false,
+            primary = true,
             priority = 200,
             filter = "eslint",
           })


### PR DESCRIPTION
## Summary
This change makes the eslint formatter the only formatter when using the eslint extra, however this code should probably be more configurable than this but I'm raising it here anyway to highlight the problem.

## Problem
Using the eslint extra and saving a typescript file in a project that uses eslint to format (via `prettier/prettier` rules) the formatting of `EslintFixAll` and `tsserver` (LSP) overlap and `tsserver` often wins, which causes eslint failures.
![CleanShot 2023-10-18 at 23 03 45](https://github.com/LazyVim/LazyVim/assets/4092035/e3d54f12-e6b9-4444-8436-045e61cacb3c)

I previously disabled this by manually disabling the formatting provider of tsserver but this no longer works.
```lua
{
  "neovim/nvim-lspconfig",
  opts = {
    servers = {
      tsserver = {
        -- redacted for brevity
      }
    },
    setup = {
      tsserver = function(_, opts)
        opts.capabilities.documentFormattingProvider = false
      end,
    },
  },
}
```

## Other ideas
- Enable configuration of the `primary` and `priority` fields in the eslint formatter.
- When multiple formatters exist, call each synchronously and ensure the last one is the main one.
- Support for disabling formatting of specific LSP servers.