### PR TITLE
style(dashboard): remove unnecessary brackets from keys, including extras

### DIFF
--- a/lua/lazyvim/plugins/extras/util/project.lua
+++ b/lua/lazyvim/plugins/extras/util/project.lua
@@ -56,6 +56,10 @@ return {
         icon = " ",
         key = "p",
       }
+
+      projects.desc = projects.desc .. string.rep(" ", 43 - #projects.desc)
+      projects.key_format = "  %s"
+
       table.insert(opts.config.center, 3, projects)
     end,
   },

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -389,6 +389,11 @@ return {
         },
       }
 
+      for _, button in ipairs(opts.config.center) do
+        button.desc = button.desc .. string.rep(" ", 43 - #button.desc)
+        button.key_format = "  %s"
+      end
+
       -- close Lazy and re-open when the dashboard is ready
       if vim.o.filetype == "lazy" then
         vim.cmd.close()
@@ -401,13 +406,6 @@ return {
       end
 
       return opts
-    end,
-    config = function(_, opts)
-      for _, button in ipairs(opts.config.center) do
-        button.desc = button.desc .. string.rep(" ", 43 - #button.desc)
-        button.key_format = "  %s"
-      end
-      require("dashboard").setup(opts)
     end,
   },
 }

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -389,11 +389,6 @@ return {
         },
       }
 
-      for _, button in ipairs(opts.config.center) do
-        button.desc = button.desc .. string.rep(" ", 43 - #button.desc)
-        button.key_format = "  %s"
-      end
-
       -- close Lazy and re-open when the dashboard is ready
       if vim.o.filetype == "lazy" then
         vim.cmd.close()
@@ -406,6 +401,13 @@ return {
       end
 
       return opts
+    end,
+    config = function(_, opts)
+      for _, button in ipairs(opts.config.center) do
+        button.desc = button.desc .. string.rep(" ", 43 - #button.desc)
+        button.key_format = "  %s"
+      end
+      require("dashboard").setup(opts)
     end,
   },
 }


### PR DESCRIPTION

Referencing this [PR](https://github.com/LazyVim/LazyVim/pull/1791)

@folke,

The p from extras.util.project still contained the brackets.
