### PR TITLE
fix(lang): add cmakelint to ensure installed list

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/cmake.lua
+++ b/lua/lazyvim/plugins/extras/lang/cmake.lua
@@ -30,7 +30,7 @@ return {
     "mason.nvim",
     opts = function(_, opts)
       opts.ensure_installed = opts.ensure_installed or {}
-      vim.list_extend(opts.ensure_installed, { "cmakelang" })
+      vim.list_extend(opts.ensure_installed, { "cmakelang", "cmakelint" })
     end,
   },
   {


### PR DESCRIPTION
1. mason/cmakelang install bin/cmake-lint
2. nvim-lint only recognize bin/cmakelint
3. mason/cmakelint install bin/cmakelint

so we need mason/cmakelint installed to using nvim-lint to perform formatting