### PR TITLE
feat(nvim): extend j/k enhancements to up/down arrows

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -7,7 +7,9 @@ local map = Util.safe_keymap_set
 
 -- better up/down
 map({ "n", "x" }, "j", "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = true })
+map({ "n", "x" }, "<Down>", "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = true })
 map({ "n", "x" }, "k", "v:count == 0 ? 'gk' : 'k'", { expr = true, silent = true })
+map({ "n", "x" }, "<Up>", "v:count == 0 ? 'gk' : 'k'", { expr = true, silent = true })
 
 -- Move to window using the <ctrl> hjkl keys
 map("n", "<C-h>", "<C-w>h", { desc = "Go to left window", remap = true })


### PR DESCRIPTION
Some of us using alternate keyboard layouts (e.g. Colemak-DH) may rely on arrows instead of `j/k`. This extends the `j/k` enhancements for soft-wrapped lines navigation to the `<Up>/<Down>` arrows as well.

I'm a total vim noob, any reason I shouldn't do this?