### PR TITLE
fix(dap): load vscode launch files with jsonc parser

### DIFF
--- a/lua/lazyvim/plugins/extras/dap/core.lua
+++ b/lua/lazyvim/plugins/extras/dap/core.lua
@@ -25,8 +25,6 @@ return {
       },
       opts = {},
       config = function(_, opts)
-        -- setup dap config by VsCode launch.json file
-        -- require("dap.ext.vscode").load_launchjs()
         local dap = require("dap")
         local dapui = require("dapui")
         dapui.setup(opts)
@@ -80,6 +78,11 @@ return {
         },
       },
     },
+
+    -- VsCode launch.json parser
+    {
+      "folke/neoconf.nvim",
+    },
   },
 
   -- stylua: ignore
@@ -114,5 +117,10 @@ return {
         { text = sign[1], texthl = sign[2] or "DiagnosticInfo", linehl = sign[3], numhl = sign[3] }
       )
     end
+
+    -- setup dap config by VsCode launch.json file
+    local vscode = require("dap.ext.vscode")
+    vscode.json_decode = require("neoconf.json.jsonc").decode_jsonc
+    vscode.load_launchjs()
   end,
 }


### PR DESCRIPTION
This seems to be the proper fix for #1503. jsonc ensures compatibility with native vscode.

Ref: https://github.com/mfussenegger/nvim-dap/issues/964