### PR TITLE
fix(mini.hipatterns): use `extmark_opts` instead of soft deprecated `priority`

### DIFF
--- a/lua/lazyvim/plugins/extras/util/mini-hipatterns.lua
+++ b/lua/lazyvim/plugins/extras/util/mini-hipatterns.lua
@@ -67,7 +67,7 @@ M.plugin = {
             return hl
           end
         end,
-        priority = 2000,
+        extmark_opts = { priority = 2000 },
       }
     end
     require("mini.hipatterns").setup(opts)


### PR DESCRIPTION
'mini.hipatterns' now [implements `extmark_opts`](https://github.com/echasnovski/mini.nvim/blob/35e29f7d680cfeb496415cadadd8c1f68db759b9/doc/mini-hipatterns.txt#L286-L291) for more possibilities of adding highlights (like highlighting whole line, adding signs, overlayed/right-aligned/inline virtual text, etc.). The `priority` highlighter options is silently soft deprecated with soon to issue `notify_once()` if user uses it. Decided to make a good did and not annoy many people using it through LazyVim :)

Notes:
- This would require 'mini.hipatterns' with at least [this commit](https://github.com/echasnovski/mini.hipatterns/commit/245497df55a180a289de00510c2ffe5b7bbaa5b2).
- The `gen_highlighter.hex_color()` will continue to use `priority` as it won't export much configuration via `extmark_opts`.