### PR TITLE
fix(extras/lang/python): Add nvim-treesitter as dependency of neotest in extras/lang/python.lua

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -47,6 +47,7 @@ return {
     optional = true,
     dependencies = {
       "nvim-neotest/neotest-python",
+      "nvim-treesitter/nvim-treesitter",
     },
     opts = {
       adapters = {


### PR DESCRIPTION
neotest couldn't find any python tests
so added nvim-treesitter as a dependency and it worked well