### PR TITLE
fix(keymaps): better up/down keymaps description

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -6,10 +6,10 @@ local Util = require("lazyvim.util")
 local map = Util.safe_keymap_set
 
 -- better up/down
-map({ "n", "x" }, "j", "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = true })
-map({ "n", "x" }, "<Down>", "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = true })
-map({ "n", "x" }, "k", "v:count == 0 ? 'gk' : 'k'", { expr = true, silent = true })
-map({ "n", "x" }, "<Up>", "v:count == 0 ? 'gk' : 'k'", { expr = true, silent = true })
+map({ "n", "x" }, "j", "v:count == 0 ? 'gj' : 'j'", { desc = "Down", expr = true, silent = true })
+map({ "n", "x" }, "<Down>", "v:count == 0 ? 'gj' : 'j'", { desc = "Down", expr = true, silent = true })
+map({ "n", "x" }, "k", "v:count == 0 ? 'gk' : 'k'", { desc = "Up", expr = true, silent = true })
+map({ "n", "x" }, "<Up>", "v:count == 0 ? 'gk' : 'k'", { desc = "Up", expr = true, silent = true })
 
 -- Move to window using the <ctrl> hjkl keys
 map("n", "<C-h>", "<C-w>h", { desc = "Go to left window", remap = true })


### PR DESCRIPTION
j/k are shown correctly but I added a description anyways for consistency
![image](https://github.com/LazyVim/LazyVim/assets/29847057/02455f03-a619-4d69-84b8-f652e04af195)
