### PR TITLE
prevent "nvim Undefined global `vim`."

### DIFF
--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -59,6 +59,10 @@ return {
               completion = {
                 callSnippet = "Replace",
               },
+              diagnostics = {
+                -- Get the language server to recognize the `vim` global
+                globals = { "vim", "require" },
+              },
             },
           },
         },


### PR DESCRIPTION
when create new lua-file:
…
vim.fn.…● nvim Undefined global `vim`.