### PR TITLE
Change default project keymap

### DIFF
--- a/lua/lazyvim/plugins/extras/util/project.lua
+++ b/lua/lazyvim/plugins/extras/util/project.lua
@@ -16,7 +16,7 @@ return {
           end)
         end,
         keys = {
-          { "<leader>fp", "<Cmd>Telescope projects<CR>", desc = "Projects" },
+          { "<leader>p", "<Cmd>Telescope projects<CR>", desc = "Projects" },
         },
       },
     },


### PR DESCRIPTION
The current keymap conflicts with the `open neovim config` keymap, so users must either add their own override or type out the full command each time. This change proposes an unused keymap that's still intuitive. 

Thanks for your time and consideration!