### PR TITLE
Add ruff-format formatter in extras

### DIFF
--- a/lua/lazyvim/plugins/extras/formatting/ruff_format.lua
+++ b/lua/lazyvim/plugins/extras/formatting/ruff_format.lua
@@ -1,0 +1,26 @@
+return {
+  {
+    "williamboman/mason.nvim",
+    opts = function(_, opts)
+      table.insert(opts.ensure_installed, "ruff")
+    end,
+  },
+  {
+    "nvimtools/none-ls.nvim",
+    optional = true,
+    opts = function(_, opts)
+      local nls = require("null-ls")
+      opts.sources = opts.sources or {}
+      table.insert(opts.sources, nls.builtins.formatting.ruff_format)
+    end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        ["python"] = { "ruff_format" },
+      },
+    },
+  },
+}


### PR DESCRIPTION
Ruff can be used as a drop-in replacement for Black. This code seems to work to integrate it into the LazyVim environment as an alternative to Black, but I'm not sure if everything here makes sense, especially the Mason part.