### PR TITLE
perf: Gitsigns travels when using wrap=true

### DIFF
--- a/lua/lazyvim/util/ui.lua
+++ b/lua/lazyvim/util/ui.lua
@@ -120,13 +120,14 @@ function M.statuscolumn()
   -- They show when either number or relativenumber is true
   local is_num = vim.wo[win].number
   local is_relnum = vim.wo[win].relativenumber
-  if (is_num or is_relnum) and vim.v.virtnum == 0 then
-    if vim.v.relnum == 0 then
-      components[2] = is_num and "%l" or "%r" -- the current line
-    else
-      components[2] = is_relnum and "%r" or "%l" -- other lines
-    end
-    components[2] = "%=" .. components[2] .. " " -- right align
+  if is_num and is_relnum then
+    components[2] = '%=%{v:relnum?(v:virtnum>0?"":v:relnum):(v:virtnum>0?"":v:lnum)} '
+  elseif is_num and not is_relnum then
+    components[2] = '%=%{v:virtnum>0?"":v:lnum} '
+  elseif is_relnum and not is_num then
+    components[2] = '%=%{v:virtnum>0?"":v:relnum} '
+  else
+    components[2] = ""
   end
 
   return table.concat(components, "")


### PR DESCRIPTION
When using HTML and Markdown with the set.opt.wrap option set to 'true', **Gitsigns** in the _StatusColumn_ bar moves and doesn't stay in place.

**before:** _HTML_ and _Markdown_
![example01](https://github.com/LazyVim/LazyVim/assets/69793562/82c193ca-b02d-4ca3-b959-6234f00218fa)

![example02](https://github.com/LazyVim/LazyVim/assets/69793562/c90efa0a-bb09-43d8-a7ac-aae7044a275e)

**after:**
![example03](https://github.com/LazyVim/LazyVim/assets/69793562/808169e4-ca96-4030-990a-3dcf14bedaa5)
![example04](https://github.com/LazyVim/LazyVim/assets/69793562/adc7cf2c-a049-4157-a326-7fffa51d42e3)


