### PR TITLE
fix(extras): Extend conform and nvim-lint formatters/linters dynamically

### DIFF
--- a/lua/lazyvim/plugins/extras/formatting/black.lua
+++ b/lua/lazyvim/plugins/extras/formatting/black.lua
@@ -17,10 +17,10 @@ return {
   {
     "stevearc/conform.nvim",
     optional = true,
-    opts = {
-      formatters_by_ft = {
-        ["python"] = { "black" },
-      },
-    },
+    opts = function(_, opts)
+      opts.formatters_by_ft.python = opts.formatters_by_ft.python or {}
+      table.insert(opts.formatters_by_ft.python, "black")
+      return opts
+    end,
   },
 }

--- a/lua/lazyvim/plugins/extras/formatting/prettier.lua
+++ b/lua/lazyvim/plugins/extras/formatting/prettier.lua
@@ -17,8 +17,20 @@ return {
   {
     "stevearc/conform.nvim",
     optional = true,
-    opts = {
-      formatters_by_ft = {
+    opts = function(_, opts)
+      --- Extend the conform plugin config and add given formatters
+      ---@param tbl table<string, conform.FormatterUnit[]> Table of filetype to formatters mappings
+      local function add_formatters(tbl)
+        for ft, formatters in pairs(tbl) do
+          if opts.formatters_by_ft[ft] == nil then
+            opts.formatters_by_ft[ft] = formatters
+          else
+            vim.list_extend(opts.formatters_by_ft[ft], formatters)
+          end
+        end
+      end
+
+      add_formatters({
         ["javascript"] = { "prettier" },
         ["javascriptreact"] = { "prettier" },
         ["typescript"] = { "prettier" },
@@ -35,7 +47,7 @@ return {
         ["markdown.mdx"] = { "prettier" },
         ["graphql"] = { "prettier" },
         ["handlebars"] = { "prettier" },
-      },
-    },
+      })
+    end,
   },
 }

--- a/lua/lazyvim/plugins/extras/lang/cmake.lua
+++ b/lua/lazyvim/plugins/extras/lang/cmake.lua
@@ -20,11 +20,11 @@ return {
   {
     "mfussenegger/nvim-lint",
     optional = true,
-    opts = {
-      linters_by_ft = {
-        cmake = { "cmakelint" },
-      },
-    },
+    opts = function(_, opts)
+      opts.linters_by_ft.cmake = opts.linters_by_ft.cmake or {}
+      table.insert(opts.linters_by_ft.cmake, "cmakelint")
+      return opts
+    end,
   },
   {
     "mason.nvim",

--- a/lua/lazyvim/plugins/extras/lang/docker.lua
+++ b/lua/lazyvim/plugins/extras/lang/docker.lua
@@ -27,11 +27,11 @@ return {
   {
     "mfussenegger/nvim-lint",
     optional = true,
-    opts = {
-      linters_by_ft = {
-        dockerfile = { "hadolint" },
-      },
-    },
+    opts = function(_, opts)
+      opts.linters_by_ft.dockerfile = opts.linters_by_ft.dockerfile or {}
+      table.insert(opts.linters_by_ft.dockerfile, "hadolint")
+      return opts
+    end,
   },
   {
     "neovim/nvim-lspconfig",

--- a/lua/lazyvim/plugins/extras/lang/elixir.lua
+++ b/lua/lazyvim/plugins/extras/lang/elixir.lua
@@ -49,9 +49,10 @@ return {
       if vim.fn.executable("credo") == 0 then
         return
       end
-      opts.linters_by_ft = {
-        elixir = { "credo" },
-      }
+
+      opts.linters_by_ft.elixir = opts.linters_by_ft.elixir or {}
+      table.insert(opts.linters_by_ft.elixir, "credo")
+      return opts
     end,
   },
 }

--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -114,11 +114,11 @@ return {
   {
     "stevearc/conform.nvim",
     optional = true,
-    opts = {
-      formatters_by_ft = {
-        go = { "goimports", "gofumpt" },
-      },
-    },
+    opts = function(_, opts)
+      opts.formatters_by_ft.go = opts.formatters_by_ft.go or {}
+      vim.table_extend(opts.formatters_by_ft.go, { "goimports", "gofumpt" })
+      return opts
+    end,
   },
   {
     "mfussenegger/nvim-dap",

--- a/lua/lazyvim/plugins/extras/lang/markdown.lua
+++ b/lua/lazyvim/plugins/extras/lang/markdown.lua
@@ -27,11 +27,11 @@ return {
   {
     "mfussenegger/nvim-lint",
     optional = true,
-    opts = {
-      linters_by_ft = {
-        markdown = { "markdownlint" },
-      },
-    },
+    opts = function(_, opts)
+      opts.linters_by_ft.markdown = opts.linters_by_ft.markdown or {}
+      table.insert(opts.linters_by_ft.markdown, "markdownlint")
+      return opts
+    end,
   },
   {
     "neovim/nvim-lspconfig",

--- a/lua/lazyvim/plugins/extras/lang/omnisharp.lua
+++ b/lua/lazyvim/plugins/extras/lang/omnisharp.lua
@@ -20,17 +20,18 @@ return {
   {
     "stevearc/conform.nvim",
     optional = true,
-    opts = {
-      formatters_by_ft = {
-        cs = { "csharpier" },
-      },
-      formatters = {
+    opts = function(_, opts)
+      opts.formatters_by_ft.cs = opts.formatters_by_ft.cs or {}
+      table.insert(opts.formatters_by_ft.cs, "csharpier")
+
+      opts.formatters = {
         csharpier = {
           command = "dotnet-csharpier",
           args = { "--write-stdout" },
         },
-      },
-    },
+      }
+      return opts
+    end,
   },
   {
     "williamboman/mason.nvim",

--- a/lua/lazyvim/plugins/extras/lang/terraform.lua
+++ b/lua/lazyvim/plugins/extras/lang/terraform.lua
@@ -38,22 +38,28 @@ return {
   {
     "mfussenegger/nvim-lint",
     optional = true,
-    opts = {
-      linters_by_ft = {
-        terraform = { "terraform_validate" },
-        tf = { "terraform_validate" },
-      },
-    },
+    opts = function(_, opts)
+      opts.linters_by_ft.terraform = opts.linters_by_ft.terraform or {}
+      table.insert(opts.linters_by_ft.terraform, "terraform_validate")
+
+      opts.linters_by_ft.tf = opts.linters_by_ft.tf or {}
+      table.insert(opts.linters_by_ft.tf, "terraform_validate")
+      return opts
+    end,
   },
   {
     "stevearc/conform.nvim",
     optional = true,
-    opts = {
-      formatters_by_ft = {
-        terraform = { "terraform_fmt" },
-        tf = { "terraform_fmt" },
-        ["terraform-vars"] = { "terraform_fmt" },
-      },
-    },
+    opts = function(_, opts)
+      opts.formatters_by_ft.terraform = opts.formatters_by_ft.terraform or {}
+      table.insert(opts.formatters_by_ft.terraform, "terraform_fmt")
+
+      opts.formatters_by_ft.tf = opts.formatters_by_ft.tf or {}
+      table.insert(opts.formatters_by_ft.tf, "terraform_fmt")
+
+      opts.formatters_by_ft["terraform-vars"] = opts.formatters_by_ft["terraform-vars"] or {}
+      table.insert(opts.formatters_by_ft["terraform-vars"], "terraform_fmt")
+      return opts
+    end,
   },
 }


### PR DESCRIPTION
In many of the lang and formatter extras, the settings for `nvim-lint` and `conform.nvim` hard-code the `formatters_by_ft` or `linters_by_ft`  for the affected filetypes in opts. This could however potentially mean that once multiple extras are added that would both add a linter/formatter for the same filetype, they would start overwriting each other. (as far as I know, lazy.nvim won't merge lists).

This change fixes this and instead extends the list of formatters/linters for given filetype dynamically, using `vim.list_extend` or `table.insert`.