### PR TITLE
Detect if using nvim-0.10 and use new inlay_hint.enable method

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -120,7 +120,7 @@ map("n", "<leader>ud", function() Util.toggle.diagnostics() end, { desc = "Toggl
 local conceallevel = vim.o.conceallevel > 0 and vim.o.conceallevel or 3
 map("n", "<leader>uc", function() Util.toggle("conceallevel", false, {0, conceallevel}) end, { desc = "Toggle Conceal" })
 if vim.lsp.buf.inlay_hint or vim.lsp.inlay_hint then
-  map( "n", "<leader>uh", function() Util.lsp.toggle_inline_hint() end, { desc = "Toggle Inlay Hints" })
+  map( "n", "<leader>uh", function() Util.toggle.inlay_hints() end, { desc = "Toggle Inlay Hints" })
 end
 map("n", "<leader>uT", function() if vim.b.ts_highlight then vim.treesitter.stop() else vim.treesitter.start() end end, { desc = "Toggle Treesitter Highlight" })
 

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -120,7 +120,7 @@ map("n", "<leader>ud", function() Util.toggle.diagnostics() end, { desc = "Toggl
 local conceallevel = vim.o.conceallevel > 0 and vim.o.conceallevel or 3
 map("n", "<leader>uc", function() Util.toggle("conceallevel", false, {0, conceallevel}) end, { desc = "Toggle Conceal" })
 if vim.lsp.inlay_hint then
-  map("n", "<leader>uh", function() vim.lsp.inlay_hint(0, nil) end, { desc = "Toggle Inlay Hints" })
+  map( "n", "<leader>uh", function() Util.lsp.toggle_inline_hint() end, { desc = "Toggle Inlay Hints" })
 end
 map("n", "<leader>uT", function() if vim.b.ts_highlight then vim.treesitter.stop() else vim.treesitter.start() end end, { desc = "Toggle Treesitter Highlight" })
 

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -119,7 +119,7 @@ map("n", "<leader>ul", function() Util.toggle.number() end, { desc = "Toggle Lin
 map("n", "<leader>ud", function() Util.toggle.diagnostics() end, { desc = "Toggle Diagnostics" })
 local conceallevel = vim.o.conceallevel > 0 and vim.o.conceallevel or 3
 map("n", "<leader>uc", function() Util.toggle("conceallevel", false, {0, conceallevel}) end, { desc = "Toggle Conceal" })
-if vim.lsp.inlay_hint then
+if vim.lsp.buf.inlay_hint or vim.lsp.inlay_hint then
   map( "n", "<leader>uh", function() Util.lsp.toggle_inline_hint() end, { desc = "Toggle Inlay Hints" })
 end
 map("n", "<leader>uT", function() if vim.b.ts_highlight then vim.treesitter.stop() else vim.treesitter.start() end end, { desc = "Toggle Treesitter Highlight" })

--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -120,7 +120,11 @@ return {
       if opts.inlay_hints.enabled and inlay_hint then
         Util.lsp.on_attach(function(client, buffer)
           if client.supports_method("textDocument/inlayHint") then
-            inlay_hint(buffer, true)
+            if vim.fn.has("nvim-0.10") == 1 then
+              inlay_hint.enable(buffer, true)
+            else
+              inlay_hint(buffer, true)
+            end
           end
         end)
       end

--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -115,16 +115,12 @@ return {
         vim.fn.sign_define(name, { text = icon, texthl = name, numhl = "" })
       end
 
-      local inlay_hint = vim.lsp.buf.inlay_hint or vim.lsp.inlay_hint
+      local inlay_hint = vim.lsp.buf.inlay_hint or vim.lsp.inlay_hint.enable
 
       if opts.inlay_hints.enabled and inlay_hint then
         Util.lsp.on_attach(function(client, buffer)
           if client.supports_method("textDocument/inlayHint") then
-            if vim.fn.has("nvim-0.10") == 1 then
-              inlay_hint.enable(buffer, true)
-            else
-              inlay_hint(buffer, true)
-            end
+            inlay_hint(buffer, true)
           end
         end)
       end

--- a/lua/lazyvim/util/lsp.lua
+++ b/lua/lazyvim/util/lsp.lua
@@ -122,4 +122,18 @@ function M.format(opts)
   end
 end
 
+---@param bufnr? number
+function M.toggle_inline_hint(bufnr)
+  bufnr = bufnr or 0
+  if vim.fn.has("nvim-0.10") then
+    if vim.lsp.inlay_hint.is_enabled() then
+      vim.lsp.inlay_hint.enable(bufnr, false)
+    else
+      vim.lsp.inlay_hint.enable(bufnr, true)
+    end
+  else
+    vim.lsp.inlay_hint(bufnr, nil)
+  end
+end
+
 return M

--- a/lua/lazyvim/util/lsp.lua
+++ b/lua/lazyvim/util/lsp.lua
@@ -125,12 +125,9 @@ end
 ---@param bufnr? number
 function M.toggle_inline_hint(bufnr)
   bufnr = bufnr or 0
-  if vim.fn.has("nvim-0.10") then
-    if vim.lsp.inlay_hint.is_enabled() then
-      vim.lsp.inlay_hint.enable(bufnr, false)
-    else
-      vim.lsp.inlay_hint.enable(bufnr, true)
-    end
+  local inlay_hint = vim.lsp.buf.inlay_hint or vim.lsp.inlay_hint
+  if inlay_hint.enable then
+    vim.lsp.inlay_hint.enable(bufnr, not inlay_hint.is_enabled())
   else
     vim.lsp.inlay_hint(bufnr, nil)
   end

--- a/lua/lazyvim/util/lsp.lua
+++ b/lua/lazyvim/util/lsp.lua
@@ -122,15 +122,4 @@ function M.format(opts)
   end
 end
 
----@param bufnr? number
-function M.toggle_inline_hint(bufnr)
-  bufnr = bufnr or 0
-  local inlay_hint = vim.lsp.buf.inlay_hint or vim.lsp.inlay_hint
-  if inlay_hint.enable then
-    vim.lsp.inlay_hint.enable(bufnr, not inlay_hint.is_enabled())
-  else
-    vim.lsp.inlay_hint(bufnr, nil)
-  end
-end
-
 return M

--- a/lua/lazyvim/util/toggle.lua
+++ b/lua/lazyvim/util/toggle.lua
@@ -53,6 +53,17 @@ function M.diagnostics()
   end
 end
 
+---@param bufnr? number
+function M.inlay_hints(bufnr)
+  bufnr = bufnr or 0
+  local inlay_hint = vim.lsp.buf.inlay_hint or vim.lsp.inlay_hint
+  if inlay_hint.enable then
+    vim.lsp.inlay_hint.enable(bufnr, not inlay_hint.is_enabled())
+  else
+    vim.lsp.inlay_hint(bufnr, nil)
+  end
+end
+
 setmetatable(M, {
   __call = function(m, ...)
     return m.option(...)


### PR DESCRIPTION
Neovim introduced a breaking change to how inlay-hints were handled in [448907ff](https://github.com/neovim/neovim/commit/448907f65d6709fa234d8366053e33311a01bdb9). Check to see if the user is using nightly and if so use the newly added `.enable` method.
