### PR TITLE
fix: correct eslint working directories setting

### DIFF
--- a/lua/lazyvim/plugins/extras/linting/eslint.lua
+++ b/lua/lazyvim/plugins/extras/linting/eslint.lua
@@ -8,7 +8,7 @@ return {
         eslint = {
           settings = {
             -- helps eslint find the eslintrc when it's placed in a subfolder instead of the cwd root
-            workingDirectory = { mode = "auto" },
+            workingDirectories = { mode = "auto" },
           },
         },
       },


### PR DESCRIPTION
The eslint LSP has changed one of the setting names from `workingDirectory` to `workingDirectories`.
See its documentation [here](https://github.com/microsoft/vscode-eslint/blob/17e79c0f7bcd38f3033d0fbc346a5607fbb4c60f/README.md?plain=1#L218).