### PR TITLE
fix: Can't display search icon on dashboard in iTerm2

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/alpha.lua
+++ b/lua/lazyvim/plugins/extras/ui/alpha.lua
@@ -23,7 +23,7 @@ return {
       dashboard.section.header.val = vim.split(logo, "\n")
       -- stylua: ignore
       dashboard.section.buttons.val = {
-        dashboard.button("f", " " .. " Find file",       "<cmd> Telescope find_files <cr>"),
+        dashboard.button("f", " " .. " Find file",       "<cmd> Telescope find_files <cr>"),
         dashboard.button("n", " " .. " New file",        "<cmd> ene <BAR> startinsert <cr>"),
         dashboard.button("r", " " .. " Recent files",    "<cmd> Telescope oldfiles <cr>"),
         dashboard.button("g", " " .. " Find text",       "<cmd> Telescope live_grep <cr>"),


### PR DESCRIPTION
<img width="462" alt="截屏2023-12-01 20 43 25" src="https://github.com/LazyVim/LazyVim/assets/33391732/96df7558-3274-4a90-8bb8-56604d81857f">
