### PR TITLE
feat(extras): Enable project-specific plugin specs using local .lazy.lua

### DIFF
--- a/lua/lazyvim/plugins/extras/lazyrc.lua
+++ b/lua/lazyvim/plugins/extras/lazyrc.lua
@@ -1,0 +1,20 @@
+--[[
+This extra allows for project-specific plugin specs.
+
+File .lazy.lua:
+  is read when present in the current working directory
+  should return a plugin spec
+  has to be manually trusted for each instance of the file
+
+This extra should be the last plugin spec parsed by lazy.nvim
+
+See:
+  :h 'exrc'
+  :h :trust
+--]]
+local filepath = vim.fn.fnamemodify(".lazy.lua", ":p")
+local file = vim.secure.read(filepath)
+if not file then
+  return {}
+end
+return loadstring(file)()

--- a/lua/lazyvim/plugins/extras/lazyrc.lua
+++ b/lua/lazyvim/plugins/extras/lazyrc.lua
@@ -1,12 +1,12 @@
 --[[
-This extra allows for project-specific plugin specs.
+Enable project-specific plugin specs.
 
 File .lazy.lua:
   is read when present in the current working directory
   should return a plugin spec
   has to be manually trusted for each instance of the file
 
-This extra should be the last plugin spec parsed by lazy.nvim
+This extra should be the last plugin spec added to lazy.nvim
 
 See:
   :h 'exrc'
@@ -17,4 +17,23 @@ local file = vim.secure.read(filepath)
 if not file then
   return {}
 end
+
+vim.api.nvim_create_autocmd("User", {
+  pattern = "VeryLazy",
+  once = true,
+  callback = function()
+    local Config = require("lazy.core.config")
+    local Util = require("lazyvim.util")
+    local lazyrc_idx = Util.plugin.extra_idx("lazyrc")
+
+    if lazyrc_idx and lazyrc_idx ~= #Config.spec.modules then
+      Util.warn({
+        "The `lazyrc` extra must be the last plugin spec added to **lazy.nvim**. ",
+        "",
+        "Add `{ import = 'lazyvim.plugins.extras.lazyrc' }` to file `config.lazy`. ",
+        "Do not use the `LazyExtras` command. ",
+      }, { title = "LazyVim", once = true })
+    end
+  end,
+})
 return loadstring(file)()

--- a/lua/lazyvim/plugins/xtras.lua
+++ b/lua/lazyvim/plugins/xtras.lua
@@ -2,6 +2,7 @@ local Config = require("lazyvim.config")
 
 -- Some extras need to be loaded before others
 local prios = {
+  ["lazyvim.plugins.extras.lazyrc"] = 1000,
   ["lazyvim.plugins.extras.editor.aerial"] = 100,
   ["lazyvim.plugins.extras.editor.symbols-outline"] = 100,
   ["lazyvim.plugins.extras.test.core"] = 1,

--- a/lua/lazyvim/plugins/xtras.lua
+++ b/lua/lazyvim/plugins/xtras.lua
@@ -2,7 +2,6 @@ local Config = require("lazyvim.config")
 
 -- Some extras need to be loaded before others
 local prios = {
-  ["lazyvim.plugins.extras.lazyrc"] = 1000,
   ["lazyvim.plugins.extras.editor.aerial"] = 100,
   ["lazyvim.plugins.extras.editor.symbols-outline"] = 100,
   ["lazyvim.plugins.extras.test.core"] = 1,


### PR DESCRIPTION
The motivation for this PR can be found in this [discussion](https://github.com/LazyVim/LazyVim/discussions/1878), started by @fredrikaverpil.

Quote:

> I really wish I could add some sort of lazy.nvim override in the project's .nvim.lua. Doesn't seem possible to me though.

It is possible to configure project-specific settings using a local `.nvim.lua`. However, out of the box,`.nvim.lua` cannot add to the spec used by `lazy.nvim`.

This [comment](https://github.com/LazyVim/LazyVim/discussions/1878#discussioncomment-7667560) describes a solution using the local `.nvim.lua` to bootstrap `lazy.nvim`.
That approach has the following drawbacks:

1. The user has to slightly modify the structure of his config
2. The `setup` function for `lazy.nvim` can now be in several places
3. Local `.nvim.lua`, a generic `exrc`, becomes `lazy.nvim` specific.

I propose the following extra:

`lazyvim.plugins.extras.lazyrc.lua`
```lua
--[[
Enable project-specific plugin specs.

File .lazy.lua:
  is read when present in the current working directory
  should return a plugin spec
  has to be manually trusted for each instance of the file

This extra should be the last plugin spec added to lazy.nvim

See:
  :h 'exrc'
  :h :trust
--]]
local filepath = vim.fn.fnamemodify(".lazy.lua", ":p")
local file = vim.secure.read(filepath)
if not file then
  return {}
end
return loadstring(file)()
```

Users can easily add the code snippet above into their own configuration.

I think this could be a valuable extra for `LazyVim`. If this PR is accepted I can also add the necessary documentation for the website in the `extras` chapter.

