### PR TITLE
Adds copy file name command to Neo-Tree with 'Y' binding

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -57,10 +57,16 @@ return {
         bind_to_cwd = false,
         follow_current_file = { enabled = true },
         use_libuv_file_watcher = true,
+        commands = {
+          copy_file_name = function(state)
+            local node = state.tree:get_node()
+            vim.fn.setreg("*", node.name, "c")
+          end,
       },
       window = {
         mappings = {
           ["<space>"] = "none",
+          ["Y"] = "copy_file_name",
         },
       },
       default_component_configs = {


### PR DESCRIPTION
I was missing an easy way to copy the file name from within the Neo-Tree window. I think others might find this useful and wanted to contribute :)

This PR simply adds the suggestion [here](https://github.com/nvim-neo-tree/neo-tree.nvim/issues/359#issuecomment-1164667350).

Thank you!