### PR TITLE
feat(toggle-diagnostics): change logic based on `vim.diagnostic.is_di…

### DIFF
--- a/lua/lazyvim/util/toggle.lua
+++ b/lua/lazyvim/util/toggle.lua
@@ -41,10 +41,10 @@ function M.number()
   end
 end
 
-local enabled = true
+local status = vim.diagnostic.is_disabled()
 function M.diagnostics()
-  enabled = not enabled
-  if enabled then
+  status = not status
+  if not status then
     vim.diagnostic.enable()
     Util.info("Enabled diagnostics", { title = "Diagnostics" })
   else

--- a/lua/lazyvim/util/toggle.lua
+++ b/lua/lazyvim/util/toggle.lua
@@ -41,9 +41,15 @@ function M.number()
   end
 end
 
-local enabled = not vim.diagnostic.is_disabled()
+local enabled = true
 function M.diagnostics()
+  -- if this Neovim version supports checking if diagnostics are enabled
+  -- then use that for the current state
+  if vim.diagnostic.is_disabled then
+    enabled = not vim.diagnostic.is_disabled()
+  end
   enabled = not enabled
+
   if enabled then
     vim.diagnostic.enable()
     Util.info("Enabled diagnostics", { title = "Diagnostics" })

--- a/lua/lazyvim/util/toggle.lua
+++ b/lua/lazyvim/util/toggle.lua
@@ -41,10 +41,10 @@ function M.number()
   end
 end
 
-local status = vim.diagnostic.is_disabled()
+local enabled = not vim.diagnostic.is_disabled()
 function M.diagnostics()
-  status = not status
-  if not status then
+  enabled = not enabled
+  if enabled then
     vim.diagnostic.enable()
     Util.info("Enabled diagnostics", { title = "Diagnostics" })
   else


### PR DESCRIPTION
…sabled`

After discussion in #2215, I thought maybe it would be beneficial if we could change the logic of the `toggle-diagnostics` function based on if the user has disabled diagnostics in his own configuration.