### PR TITLE
Add support for PHP Lang

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/php-above-81.lua
+++ b/lua/lazyvim/plugins/extras/lang/php-above-81.lua
@@ -1,0 +1,88 @@
+return {
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = function(_, opts)
+      vim.list_extend(opts.ensure_installed, {
+        "php",
+      })
+    end,
+  },
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        intelephense = {
+          cmd = { "intelephense", "--stdio" },
+          filetypes = { "php" },
+          root_dir = require("lspconfig.util").root_pattern("composer.json", ".git"),
+        },
+        phpactor = {
+          cmd = { "phpactor", "language-server" },
+          filetypes = { "php" },
+          root_dir = require("lspconfig.util").root_pattern("composer.json", ".git"),
+        },
+      },
+    },
+  },
+  -- Ensure PHP tools are installed
+  {
+    "williamboman/mason.nvim",
+    opts = function(_, opts)
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "intelephense", "phpactor", "phpcbf" })
+    end,
+  },
+  {
+    "nvimtools/none-ls.nvim",
+    optional = true,
+    dependencies = {
+      {
+        "williamboman/mason.nvim",
+        opts = function(_, opts)
+          opts.ensure_installed = opts.ensure_installed or {}
+          vim.list_extend(opts.ensure_installed, { "phpcbf" })
+        end,
+      },
+    },
+    opts = function(_, opts)
+      local nls = require("null-ls")
+      opts.sources = vim.list_extend(opts.sources or {}, {
+        nls.builtins.formatting.phpcbf,
+      })
+    end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        php = { "phpcbf" },
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-dap",
+    optional = true,
+    dependencies = {
+      {
+        "williamboman/mason.nvim",
+        opts = function(_, opts)
+          opts.ensure_installed = opts.ensure_installed or {}
+          vim.list_extend(opts.ensure_installed, { "php-debug-adapter" })
+        end,
+      },
+    },
+  },
+  {
+    "nvim-neotest/neotest",
+    optional = true,
+    dependencies = {
+      "olimorris/neotest-phpunit",
+    },
+    opts = {
+      adapters = {
+        ["neotest-phpunit"] = {},
+      },
+    },
+  },
+}

--- a/lua/lazyvim/plugins/extras/lang/php-under-81.lua
+++ b/lua/lazyvim/plugins/extras/lang/php-under-81.lua
@@ -1,0 +1,83 @@
+return {
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = function(_, opts)
+      vim.list_extend(opts.ensure_installed, {
+        "php",
+      })
+    end,
+  },
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        intelephense = {
+          cmd = { "intelephense", "--stdio" },
+          filetypes = { "php" },
+          root_dir = require("lspconfig.util").root_pattern("composer.json", ".git"),
+        },
+      },
+    },
+  },
+  -- Ensure PHP tools are installed
+  {
+    "williamboman/mason.nvim",
+    opts = function(_, opts)
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "intelephense", "phpcbf" })
+    end,
+  },
+  {
+    "nvimtools/none-ls.nvim",
+    optional = true,
+    dependencies = {
+      {
+        "williamboman/mason.nvim",
+        opts = function(_, opts)
+          opts.ensure_installed = opts.ensure_installed or {}
+          vim.list_extend(opts.ensure_installed, { "phpcbf" })
+        end,
+      },
+    },
+    opts = function(_, opts)
+      local nls = require("null-ls")
+      opts.sources = vim.list_extend(opts.sources or {}, {
+        nls.builtins.formatting.phpcbf,
+      })
+    end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        php = { "phpcbf" },
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-dap",
+    optional = true,
+    dependencies = {
+      {
+        "williamboman/mason.nvim",
+        opts = function(_, opts)
+          opts.ensure_installed = opts.ensure_installed or {}
+          vim.list_extend(opts.ensure_installed, { "php-debug-adapter" })
+        end,
+      },
+    },
+  },
+  {
+    "nvim-neotest/neotest",
+    optional = true,
+    dependencies = {
+      "olimorris/neotest-phpunit",
+    },
+    opts = {
+      adapters = {
+        ["neotest-phpunit"] = {},
+      },
+    },
+  },
+}


### PR DESCRIPTION
# Extra lang for PHP

## PHP 8.1 and below

Usage of intelephense as LSP, with phpcbf as formatter

## PHP 8.1 and above

Usage of intelephense and phpactor as LSP, with phpcbf as formatter

## Debugger
Both use php-debuger-adapter