### PR TITLE
fix(typescript): don't hardcode values in lua table

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -13,62 +13,59 @@ return {
   -- correctly setup lspconfig
   {
     "neovim/nvim-lspconfig",
-    opts = {
-      -- make sure mason installs the server
-      servers = {
-        ---@type lspconfig.options.tsserver
-        tsserver = {
-          keys = {
-            {
-              "<leader>co",
-              function()
-                vim.lsp.buf.code_action({
-                  apply = true,
-                  context = {
-                    only = { "source.organizeImports.ts" },
-                    diagnostics = {},
-                  },
-                })
-              end,
-              desc = "Organize Imports",
-            },
-            {
-              "<leader>cR",
-              function()
-                vim.lsp.buf.code_action({
-                  apply = true,
-                  context = {
-                    only = { "source.removeUnused.ts" },
-                    diagnostics = {},
-                  },
-                })
-              end,
-              desc = "Remove Unused Imports",
-            },
+    opts = function(_, opts)
+      opts.servers.tsserver = {
+        keys = {
+          {
+            "<leader>co",
+            function()
+              vim.lsp.buf.code_action({
+                apply = true,
+                context = {
+                  only = { "source.organizeImports.ts" },
+                  diagnostics = {},
+                },
+              })
+            end,
+            desc = "Organize Imports",
           },
-          settings = {
-            typescript = {
-              format = {
-                indentSize = vim.o.shiftwidth,
-                convertTabsToSpaces = vim.o.expandtab,
-                tabSize = vim.o.tabstop,
-              },
-            },
-            javascript = {
-              format = {
-                indentSize = vim.o.shiftwidth,
-                convertTabsToSpaces = vim.o.expandtab,
-                tabSize = vim.o.tabstop,
-              },
-            },
-            completions = {
-              completeFunctionCalls = true,
-            },
+          {
+            "<leader>cR",
+            function()
+              vim.lsp.buf.code_action({
+                apply = true,
+                context = {
+                  only = { "source.removeUnused.ts" },
+                  diagnostics = {},
+                },
+              })
+            end,
+            desc = "Remove Unused Imports",
           },
         },
-      },
-    },
+        settings = {
+          typescript = {
+            format = {
+              indentSize = vim.o.shiftwidth,
+              convertTabsToSpaces = vim.o.expandtab,
+              tabSize = vim.o.tabstop,
+            },
+          },
+          javascript = {
+            format = {
+              indentSize = vim.o.shiftwidth,
+              convertTabsToSpaces = vim.o.expandtab,
+              tabSize = vim.o.tabstop,
+            },
+          },
+          completions = {
+            completeFunctionCalls = true,
+          },
+        },
+      }
+    end,
   },
+
   {
     "mfussenegger/nvim-dap",
     optional = true,

--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -14,7 +14,10 @@ return {
   {
     "neovim/nvim-lspconfig",
     opts = {
+      -- make sure mason installs the server
       servers = {
+        ---@type lspconfig.options.tsserver
+        ---@diagnostic disable-next-line: missing-fields
         tsserver = {
           keys = {
             {

--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -13,57 +13,40 @@ return {
   -- correctly setup lspconfig
   {
     "neovim/nvim-lspconfig",
-    opts = function(_, opts)
-      opts.servers.tsserver = {
-        keys = {
-          {
-            "<leader>co",
-            function()
-              vim.lsp.buf.code_action({
-                apply = true,
-                context = {
-                  only = { "source.organizeImports.ts" },
-                  diagnostics = {},
-                },
-              })
-            end,
-            desc = "Organize Imports",
-          },
-          {
-            "<leader>cR",
-            function()
-              vim.lsp.buf.code_action({
-                apply = true,
-                context = {
-                  only = { "source.removeUnused.ts" },
-                  diagnostics = {},
-                },
-              })
-            end,
-            desc = "Remove Unused Imports",
-          },
-        },
-        settings = {
-          typescript = {
-            format = {
-              indentSize = vim.o.shiftwidth,
-              convertTabsToSpaces = vim.o.expandtab,
-              tabSize = vim.o.tabstop,
+    opts = {
+      servers = {
+        tsserver = {
+          keys = {
+            {
+              "<leader>co",
+              function()
+                vim.lsp.buf.code_action({
+                  apply = true,
+                  context = {
+                    only = { "source.organizeImports.ts" },
+                    diagnostics = {},
+                  },
+                })
+              end,
+              desc = "Organize Imports",
+            },
+            {
+              "<leader>cR",
+              function()
+                vim.lsp.buf.code_action({
+                  apply = true,
+                  context = {
+                    only = { "source.removeUnused.ts" },
+                    diagnostics = {},
+                  },
+                })
+              end,
+              desc = "Remove Unused Imports",
             },
           },
-          javascript = {
-            format = {
-              indentSize = vim.o.shiftwidth,
-              convertTabsToSpaces = vim.o.expandtab,
-              tabSize = vim.o.tabstop,
-            },
-          },
-          completions = {
-            completeFunctionCalls = true,
-          },
         },
-      }
-    end,
+      },
+    },
   },
 
   {

--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -17,7 +17,6 @@ return {
       -- make sure mason installs the server
       servers = {
         ---@type lspconfig.options.tsserver
-        ---@diagnostic disable-next-line: missing-fields
         tsserver = {
           keys = {
             {
@@ -45,6 +44,12 @@ return {
                 })
               end,
               desc = "Remove Unused Imports",
+            },
+          },
+          ---@diagnostic disable-next-line: missing-fields
+          settings = {
+            completions = {
+              completeFunctionCalls = true,
             },
           },
         },


### PR DESCRIPTION
This started as an attempt from me to change the `shiftwidth` value for `.js` files in order for the `tsserver` to format the files using the new value.

However, that didn't seem to work. I tried to make the change both in `after/ftplugin/javascript.lua` and with an auto command on `FileType/BufReadPost` events. None of them worked, `tsserver` continued to format with the value of `shiftwidth` it would read from `options.lua`. I didn't want to change the top-level value of `shiftwidth` in `options.lua` (as I generally prefer it that way for the rest of my LazyVim usage). The other way would be to manually override the values of `tsserver` format settings in my personal `lspconfig` configuration.

My first attempt (first commit) was to change the `opts` into a function, so that the values wouldn't be evaluated when the module loaded, but instead defer the evaluation until `lspconfig` loaded. 

That was successful at first glance, when I noticed that although the auto commands would work as expected, the `after/ftplugin` files still wouldn't. Changes in settings would only take effect when invoking Neovim with args (thus `LazyFile` would be delayed executed on `User` event), but not when invoking Neovim without args (`LazyFile` would then be aliased to `BufReadPost` according to the [docs](https://github.com/LazyVim/LazyVim/blob/879e29504d43e9f178d967ecc34d482f902e5a91/lua/lazyvim/util/plugin.lua#L71-L73)). 

Further trying to bisect the awkward behavior for `after/ftplugin/javascript.lua` with and without args, I found out that commenting out the `indentSize` in `tsserver` format settings, allowed formatting correctly based on `shiftwidth` no matter where it was set. Trying to figure out this behavior led me to this [comment](https://github.com/stevearc/conform.nvim/issues/102#issuecomment-1837141104) in `conform`'s repo which stated that LSP servers are aware of the `tabsize` and further digging led to these [lines](https://github.com/neovim/neovim/blob/master/runtime/lua/vim/lsp/util.lua#L2083-L2110) in Neovim code, which seems to back up the user's claims in the `conform`'s issue that I had found. 

So, my final attempt (2nd commit) was to simply remove the format settings from Typescript extra and let `tsserver` figure out the correct `tabsize` from `shiftwidth` that the user is setting. [This](https://github.com/LazyVim/LazyVim/commit/eb92903342a7ac12185c62bb63b5caa4c80ce7dc) is the commit where Folke introduced this change, but I could not understand the reason why (from the message of the commit or that it wasn't really linked to any issue that might solve a problem), after the new things that I learned. Of course, I might be missing something.

Huge shoutouts to @abeldekat, who helped me through this endeavour (he was the one who pointed out to me the `opts` should be a function, as due to my poor Lua knowledge I thought that using closures was a mean to defer `require`s, so that parsing error from `lazy.nvim` could be avoided, never thought I could also apply it to defer the evaluation of values until plugin loads and he also was the one that found about uncommenting the setting in the extra would allow `tsserver` to format correctly and the piece of code in Neovim where that was happening).

@folke Sorry for the lengthy description, just wanted to properly explain the reasons behind my proposal for this PR.