### PR TITLE
fix(autocmds): avoid checktime when buftype=nofile

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -7,7 +7,11 @@ end
 -- Check if we need to reload the file when it changed
 vim.api.nvim_create_autocmd({ "FocusGained", "TermClose", "TermLeave" }, {
   group = augroup("checktime"),
-  command = "checktime",
+  callback = function()
+    if vim.o.buftype ~= 'nofile' then
+      vim.cmd('checktime')
+    end
+  end
 })
 
 -- Highlight on yank


### PR DESCRIPTION
It triggered an 'E11: Invalid in command-line window; <CR> executes,
CTRL-C quits' error when Neovim was in Command Line window and
FocusGained.
