### PR TITLE
fix(toggle): use `vim.diagnostic.is_disabled()`

### DIFF
--- a/lua/lazyvim/util/toggle.lua
+++ b/lua/lazyvim/util/toggle.lua
@@ -41,10 +41,8 @@ function M.number()
   end
 end
 
-local enabled = true
 function M.diagnostics()
-  enabled = not enabled
-  if enabled then
+  if vim.diagnostic.is_disabled() then
     vim.diagnostic.enable()
     Util.info("Enabled diagnostics", { title = "Diagnostics" })
   else


### PR DESCRIPTION
Use `vim.diagnostic.is_disabled()` instead of local variable `enable` to tracking diagnostic status.

If keeping using local var `enable`, toggle will **filp** at first time when the user disable diagnostic by default.