### PR TITLE
fix(rust): avoid resetting cmp group_index to 1

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -16,10 +16,8 @@ return {
     },
     ---@param opts cmp.ConfigSchema
     opts = function(_, opts)
-      local cmp = require("cmp")
-      opts.sources = cmp.config.sources(vim.list_extend(opts.sources, {
-        { name = "crates" },
-      }))
+      opts.sources = opts.sources or {}
+      table.insert(opts.sources, { name = "crates" })
     end,
   },
 


### PR DESCRIPTION
<!-- === GH HISTORY FENCE === -->
For example, 'buffer' source by default has group_index = 2 [1], however
if we take all the sources plus crates and run them through
cmp.config.sources() again, since it's a one-dimensional list, all
group_indexes will be reset to 1.

[1] https://github.com/LazyVim/LazyVim/blob/879e29504d43e9f178d967ecc34d482f902e5a91/lua/lazyvim/plugins/coding.lua#L74-L80
<!-- === GH HISTORY FENCE === -->
