### PR TITLE
feat(terraform): ensure tflint is installed

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/terraform.lua
+++ b/lua/lazyvim/plugins/extras/lang/terraform.lua
@@ -24,6 +24,14 @@ return {
       },
     },
   },
+  -- ensure terraform tools are installed
+  {
+    "williamboman/mason.nvim",
+    opts = function(_, opts)
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "tflint" })
+    end,
+  },
   {
     "nvimtools/none-ls.nvim",
     optional = true,


### PR DESCRIPTION
Ensures `tflint` (terraform linter) is installed when `lazyvim.plugins.extras.lang.terraform` is enabled