### PR TITLE
fix(hyprlang): use lazyvim way to install

### DIFF
--- a/lua/lazyvim/plugins/extras/util/dot.lua
+++ b/lua/lazyvim/plugins/extras/util/dot.lua
@@ -11,25 +11,26 @@ return {
   -- Add Hyprland Parser
   {
     "luckasRanarison/tree-sitter-hyprlang",
+    dependencies = {
+      "nvim-treesitter/nvim-treesitter",
+      opts = function(_, opts)
+        require("nvim-treesitter.parsers").get_parser_configs().hyprlang = {
+          install_info = {
+            url = "https://github.com/luckasRanarison/tree-sitter-hyprlang",
+            files = { "src/parser.c" },
+            branch = "master",
+          },
+          filetype = "hyprlang",
+        }
+
+        opts.ensure_installed = opts.ensure_installed or {}
+        vim.list_extend(opts.ensure_installed, { "hyprlang" })
+      end,
+    },
     enabled = function()
       return have("hypr")
     end,
     event = "BufRead */hypr/*.conf",
-    build = ":TSUpdate hypr",
-    config = function()
-      -- Fix ft detection for hyprland
-      vim.filetype.add({
-        pattern = { [".*/hypr/.*%.conf"] = "hyprlang" },
-      })
-      require("nvim-treesitter.parsers").get_parser_configs().hyprlang = {
-        install_info = {
-          url = "https://github.com/luckasRanarison/tree-sitter-hyprlang",
-          files = { "src/parser.c" },
-          branch = "master",
-        },
-        filetype = "hypr",
-      }
-    end,
   },
 
   -- add some stuff to treesitter


### PR DESCRIPTION
Hey @folke,

Apologies for the noise in #2330. I've double-checked the `tree-sitter-hyprlang` setup for Neovim users. It appears that the parser declaration is happening after Tree-sitter's initialization [init.lua](https://github.com/luckasRanarison/tree-sitter-hyprlang/blob/master/plugin/init.lua), preventing the Hyprlang parser from being installed during the install step. To address this, I've created this PR to leverage LazyVim's approach for Tree-sitter installation.

Please let me know if you have any questions or concerns.

Thanks!
