### PR TITLE
fix(autocmds): apply conceal level change to local buffer options

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -90,7 +90,7 @@ vim.api.nvim_create_autocmd({ "FileType" }, {
   group = augroup("json_conceal"),
   pattern = { "json", "jsonc", "json5" },
   callback = function()
-    vim.wo.conceallevel = 0
+    vim.opt_local.conceallevel = 0
   end,
 })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

A recent commit added an auto command to set `conceallevel` to 0 (show normally) for JSON files. The issue is that this is applying the change at the window level. So other file types (like markdown) are also affected after a JSON file is opened. The proposed change is to apply the change to the local buffer options. This will preserve the default `conceallevel` set in both the LazyVim and user options.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Restrict changes to `conceallevel` to the desired file types.

# How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Applied this change to my local configuration and opened up both json and markdown files to confirm that the desired conceal level is being applied.
