### PR TITLE
fix(toggle-diagnostics): correctly set initial state

### DIFF
--- a/lua/lazyvim/util/toggle.lua
+++ b/lua/lazyvim/util/toggle.lua
@@ -41,13 +41,15 @@ function M.number()
   end
 end
 
-local enabled = true
+local enabled
+-- if this Neovim version supports checking if diagnostics are enabled
+-- then use that for the current state
+if vim.diagnostic.is_disabled then
+  enabled = not vim.diagnostic.is_disabled()
+else
+  enabled = true
+end
 function M.diagnostics()
-  -- if this Neovim version supports checking if diagnostics are enabled
-  -- then use that for the current state
-  if vim.diagnostic.is_disabled then
-    enabled = not vim.diagnostic.is_disabled()
-  end
   enabled = not enabled
 
   if enabled then


### PR DESCRIPTION
With the previous implementation of `toggle-diagnostics` in 3cbfeab, if the user had disabled diagnostics, the first toggle call (using the keymap) would again disable diagnostics and the next one would enable them. This fixes it.