### PR TITLE
fix(util): clear buffer root cache when cwd change

### DIFF
--- a/lua/lazyvim/util/root.lua
+++ b/lua/lazyvim/util/root.lua
@@ -144,7 +144,7 @@ function M.setup()
     Util.root.info()
   end, { desc = "LazyVim roots for the current buffer" })
 
-  vim.api.nvim_create_autocmd({ "LspAttach", "BufWritePost" }, {
+  vim.api.nvim_create_autocmd({ "LspAttach", "BufWritePost", "DirChanged" }, {
     group = vim.api.nvim_create_augroup("lazyvim_root_cache", { clear = true }),
     callback = function(event)
       M.cache[event.buf] = nil


### PR DESCRIPTION
This PR clean up the buffer root dir cache also when CWD changes.

This issue happens when the CWD changes by using a cd command while inside a file or netrw buffer (or oil.nvim buffer). Then the LazyRoot command output does not coincide to the value inside the root dir cache if the root spec was using cwd option.

Not sure if this is the correct way to fix this case. But when using oil.nvim I found out that changing the CWD while inside oil buffer does not change the lazy root hence telescope find files returned files from another dir. 