### PR TITLE
Use the more sane snippet session logic

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -105,3 +105,17 @@ vim.api.nvim_create_autocmd({ "BufWritePre" }, {
     vim.fn.mkdir(vim.fn.fnamemodify(file, ":p:h"), "p")
   end,
 })
+
+-- Use the more sane snippet session leave logic. Copied from:
+-- https://github.com/L3MON4D3/LuaSnip/issues/258#issuecomment-1429989436
+vim.api.nvim_create_autocmd('ModeChanged', {
+  pattern = '*',
+  callback = function()
+    if ((vim.v.event.old_mode == 's' and vim.v.event.new_mode == 'n') or vim.v.event.old_mode == 'i')
+        and require('luasnip').session.current_nodes[vim.api.nvim_get_current_buf()]
+        and not require('luasnip').session.jump_active
+    then
+      require('luasnip').unlink_current()
+    end
+  end
+})


### PR DESCRIPTION
When hitting tab, nvim very often jumps to random places in the code. This has been observed not only with LazyVim, but also AstroNvim and others: https://www.reddit.com/r/neovim/comments/12kurkl/why_does_tab_sometimes_send_me_to_a_random/

Apparently the problem is this: https://github.com/L3MON4D3/LuaSnip/issues/258

Conveniently, the issue provides configuration that prevents this from happening. I have tested it locally and it seems to work well for me. I am not sure if I should have guarded the autocmd with a check whether luasnip is available, but I didn't know how that would work.