### PR TITLE
fix(go): adding opts recursive_run

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -148,6 +148,7 @@ return {
         ["neotest-go"] = {
           -- Here we can set options for neotest-go, e.g.
           -- args = { "-tags=integration" }
+          recursive_run = true,
         },
       },
     },


### PR DESCRIPTION
Adding opts recursive_run to fix the error `no Go files in /path/project`. This issue is caused by a recent change in the `nvim-neotest/neotest-go` project, which now [defaults to non-recursively](https://github.com/nvim-neotest/neotest-go/pull/72)