### PR TITLE
fix(extras): Drop unnecessary commentstring config for terraform

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/terraform.lua
+++ b/lua/lazyvim/plugins/extras/lang/terraform.lua
@@ -1,9 +1,3 @@
-vim.api.nvim_create_autocmd("FileType", {
-  pattern = { "hcl", "terraform" },
-  desc = "terraform/hcl commentstring configuration",
-  command = "setlocal commentstring=#\\ %s",
-})
-
 return {
   {
     "nvim-treesitter/nvim-treesitter",


### PR DESCRIPTION
The commentstring for terraform and hcl files is now handled by
nvim-ts-context-commentstring:
https://github.com/JoosepAlviste/nvim-ts-context-commentstring/pull/94
