### PR TITLE
fix(util.ui.fg): Add `link=false` to show effective definition

### DIFF
--- a/lua/lazyvim/util/ui.lua
+++ b/lua/lazyvim/util/ui.lua
@@ -142,7 +142,8 @@ end
 function M.fg(name)
   ---@type {foreground?:number}?
   ---@diagnostic disable-next-line: deprecated
-  local hl = vim.api.nvim_get_hl and vim.api.nvim_get_hl(0, { name = name }) or vim.api.nvim_get_hl_by_name(name, true)
+  local hl = vim.api.nvim_get_hl and vim.api.nvim_get_hl(0, { name = name, link = false })
+    or vim.api.nvim_get_hl_by_name(name, true)
   ---@diagnostic disable-next-line: undefined-field
   local fg = hl and (hl.fg or hl.foreground)
   return fg and { fg = string.format("#%06x", fg) } or nil


### PR DESCRIPTION
Fixes #2540 by showing the effective definition instead of the linked group name.