### PR TITLE
fix(yanky): properly disable sqlite.lua on Windows

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/yanky.lua
+++ b/lua/lazyvim/plugins/extras/coding/yanky.lua
@@ -2,7 +2,7 @@ return {
   -- better yank/paste
   {
     "gbprod/yanky.nvim",
-    dependencies = { { "kkharji/sqlite.lua", enabled = not jit.os:find("Windows") } },
+    dependencies = not jit.os:find("Windows") and { "kkharji/sqlite.lua" } or {},
     opts = {
       highlight = { timer = 250 },
       ring = { storage = jit.os:find("Windows") and "shada" or "sqlite" },


### PR DESCRIPTION
When directly modifying its `enabled` property, the plugin will remain disabled even if required by another plugin.