### PR TITLE
feat(hipatterns): add shorthand hex color support

### DIFF
--- a/lua/lazyvim/plugins/extras/util/mini-hipatterns.lua
+++ b/lua/lazyvim/plugins/extras/util/mini-hipatterns.lua
@@ -19,6 +19,18 @@ M.plugin = {
       },
       highlighters = {
         hex_color = hi.gen_highlighter.hex_color({ priority = 2000 }),
+        shorthand = {
+          pattern = "#%x%x%x%f[%X]",
+          group = function(_, _, data)
+            ---@type string
+            local match = data.full_match
+            local r, g, b = match:sub(2, 2), match:sub(3, 3), match:sub(4, 4)
+            local hex_color = "#" .. r .. r .. g .. g .. b .. b
+
+            return MiniHipatterns.compute_hex_color_group(hex_color, "bg")
+          end,
+          extmark_opts = { priority = 2000 },
+        },
       },
     }
   end,


### PR DESCRIPTION
Shorthand hex colors will have a matching background color. For example, `#f00` will have a red background.

I'm not very experienced with hipatterns' API. If anything at all can be done in a better way, please let me know.