### PR TITLE
fix(options): don't lower timeoutlen when in VS Code

### DIFF
--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -49,7 +49,9 @@ opt.splitkeep = "screen"
 opt.splitright = true -- Put new windows right of current
 opt.tabstop = 2 -- Number of spaces tabs count for
 opt.termguicolors = true -- True color support
-opt.timeoutlen = 300
+if not vim.g.vscode then
+  opt.timeoutlen = 300 -- Lower than default (1000) to quickly trigger which-key
+end
 opt.undofile = true
 opt.undolevels = 10000
 opt.updatetime = 200 -- Save swap file and trigger CursorHold


### PR DESCRIPTION
Avoid lowering timeoutlen when running in VS Code, to avoid unwanted timeouts from key mappings.

The lower value of 300ms (down from Neovim's default of 1000ms) works great outside of VS Code, where it helps trigger the which-key UI quickly, and where which-key prevents timeouts from occuring.

But in VS Code (where which-key isn't applicable), the lower value makes it difficult to perform some key mappings in time, such as `]p`, which requires shifting hand position.