### PR TITLE
fix: Updated the move lines of keymaps for mac

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -31,6 +31,14 @@ map("i", "<A-k>", "<esc><cmd>m .-2<cr>==gi", { desc = "Move up" })
 map("v", "<A-j>", ":m '>+1<cr>gv=gv", { desc = "Move down" })
 map("v", "<A-k>", ":m '<-2<cr>gv=gv", { desc = "Move up" })
 
+-- Move lines compatible with Mac
+map("n", "∆", "<cmd>m .+1<cr>==", { desc = "Move down" })
+map("n", "˚", "<cmd>m .-2<cr>==", { desc = "Move up" })
+map("i", "∆", "<esc><cmd>m .+1<cr>==gi", { desc = "Move down" })
+map("i", "˚", "<esc><cmd>m .-2<cr>==gi", { desc = "Move up" })
+map("v", "∆", ":m '>+1<cr>gv=gv", { desc = "Move down" })
+map("v", "˚", ":m '<-2<cr>gv=gv", { desc = "Move up" })
+
 -- buffers
 map("n", "<S-h>", "<cmd>bprevious<cr>", { desc = "Prev buffer" })
 map("n", "<S-l>", "<cmd>bnext<cr>", { desc = "Next buffer" })


### PR DESCRIPTION
## Issue
The `<A-j>` and `<A-h>` couldn't working in mac.

<hr />

## Description
When I  tried to use both of keymap in mac,

`<A-j>`, I got this symbol `∆`
`<A-k>`, I got this symbol `˚`

<hr />

## Snapshot
| Before | After |
| --------- | ---------  
| The move lines keymaps wasn't working: https://github.com/LazyVim/LazyVim/assets/82575487/07c62a83-404f-405a-ab76-3f8a54a76cb1 | The move lines keymaps is working: https://github.com/LazyVim/LazyVim/assets/82575487/6da48575-a94b-452b-b98a-c3ba52dccb2a |

<hr />

## What's changed
Added the compatibility keymaps into default keymaps.lua.
