### PR TITLE
feat(java): allow opts for setup_dap_main_class_configs()

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -104,6 +104,7 @@ return {
 
         -- These depend on nvim-dap, but can additionally be disabled by setting false here.
         dap = { hotcodereplace = "auto", config_overrides = {} },
+        dap_main = {},
         test = true,
       }
     end,
@@ -198,7 +199,7 @@ return {
             if opts.dap and Util.has("nvim-dap") and mason_registry.is_installed("java-debug-adapter") then
               -- custom init for Java debugger
               require("jdtls").setup_dap(opts.dap)
-              require("jdtls.dap").setup_dap_main_class_configs()
+              require("jdtls.dap").setup_dap_main_class_configs(opts.dap_main)
 
               -- Java Test require Java debugger to work
               if opts.test and mason_registry.is_installed("java-test") then


### PR DESCRIPTION
[1] https://github.com/mfussenegger/nvim-jdtls/blob/382b9f625861f47d95876bcfb4c261f3b96077cb/doc/jdtls.txt#L206-L210

---

Personally I needed this to configure different dap_main environment variables.
