### PR TITLE
nvim already binds q to close for man-files

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -57,7 +57,6 @@ vim.api.nvim_create_autocmd("FileType", {
     "PlenaryTestPopup",
     "help",
     "lspinfo",
-    "man",
     "notify",
     "qf",
     "query",
@@ -72,6 +71,15 @@ vim.api.nvim_create_autocmd("FileType", {
   callback = function(event)
     vim.bo[event.buf].buflisted = false
     vim.keymap.set("n", "q", "<cmd>close<cr>", { buffer = event.buf, silent = true })
+  end,
+})
+
+-- make it easier to close man-files when opened inline
+vim.api.nvim_create_autocmd("FileType", {
+  group = augroup("man_unlisted"),
+  pattern = { "man" },
+  callback = function(event)
+    vim.bo[event.buf].buflisted = false
   end,
 })
 


### PR DESCRIPTION
Proposed fix for #2593

Also, close-with-q is default for man-files in Neovim [1]. No need to fix this with a custom binding.

1: <https://github.com/neovim/neovim/blob/master/runtime/ftplugin/man.vim#L28>