### PR TITLE
fix(conform): make `lsp_fallback` option user configurable

### DIFF
--- a/lua/lazyvim/plugins/formatting.lua
+++ b/lua/lazyvim/plugins/formatting.lua
@@ -84,6 +84,7 @@ return {
           timeout_ms = 3000,
           async = false, -- not recommended to change
           quiet = false, -- not recommended to change
+          lsp_fallback = true, -- not recommended to change
         },
         ---@type table<string, conform.FormatterUnit[]>
         formatters_by_ft = {

--- a/lua/lazyvim/util/lsp.lua
+++ b/lua/lazyvim/util/lsp.lua
@@ -109,13 +109,18 @@ end
 
 ---@param opts? lsp.Client.format
 function M.format(opts)
-  opts = vim.tbl_deep_extend("force", {}, opts or {}, require("lazyvim.util").opts("nvim-lspconfig").format or {})
+  opts = vim.tbl_deep_extend(
+    "force",
+    {},
+    opts or {},
+    require("lazyvim.util").opts("nvim-lspconfig").format or {},
+    require("lazyvim.util").opts("conform.nvim").format or {}
+  )
   local ok, conform = pcall(require, "conform")
   -- use conform for formatting with LSP when available,
   -- since it has better format diffing
   if ok then
     opts.formatters = {}
-    opts.lsp_fallback = true
     conform.format(opts)
   else
     vim.lsp.buf.format(opts)


### PR DESCRIPTION
Inspired by #2615, I thought this might be a good change hopefully.

Not 100% sure if this breaks anything else (though I tested it locally and seemed to work correctly), since I'm not that familiar with LazyVim formatting in depth, thus starting as a draft.