### PR TITLE
fix(dot): remove hyprlang plugin

### DIFF
--- a/lua/lazyvim/plugins/extras/util/dot.lua
+++ b/lua/lazyvim/plugins/extras/util/dot.lua
@@ -7,32 +7,6 @@ local function have(path)
 end
 
 return {
-
-  -- Add Hyprland Parser
-  {
-    "luckasRanarison/tree-sitter-hyprlang",
-    dependencies = {
-      "nvim-treesitter/nvim-treesitter",
-      opts = function(_, opts)
-        require("nvim-treesitter.parsers").get_parser_configs().hyprlang = {
-          install_info = {
-            url = "https://github.com/luckasRanarison/tree-sitter-hyprlang",
-            files = { "src/parser.c" },
-            branch = "master",
-          },
-          filetype = "hyprlang",
-        }
-
-        opts.ensure_installed = opts.ensure_installed or {}
-        vim.list_extend(opts.ensure_installed, { "hyprlang" })
-      end,
-    },
-    enabled = function()
-      return have("hypr")
-    end,
-    event = "BufRead */hypr/*.conf",
-  },
-
   -- add some stuff to treesitter
   {
     "nvim-treesitter/nvim-treesitter",
@@ -49,10 +23,15 @@ return {
           [".*/waybar/config"] = "jsonc",
           [".*/mako/config"] = "dosini",
           [".*/kitty/*.conf"] = "bash",
+          [".*/hypr/.*%.conf"] = "hyprlang",
         },
       })
 
       add("git_config")
+
+      if have("hypr") then
+        add("hyprlang")
+      end
 
       if have("fish") then
         add("fish")


### PR DESCRIPTION
hyprlang grammar is now included in nvim-treesitter and the plugin itself has been removed from the tree-sitter-hyprlang repo, so I've updated the file accordingly.