### PR TITLE
fix(dap): debugger config via launch.json for c/c++

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -149,6 +149,7 @@ return {
           },
         }
       end
+      require("dap.ext.vscode").load_launchjs(nil, { codelldb = {'c', 'cpp'} })
     end,
   },
 }


### PR DESCRIPTION
# debugger config via launch.json for c/c++

nvim-dap allows to configure a debugger on the project level (see `:help dap-launch.json`). Currently this feature is not working because of a missing mapping between debug adapter and debug configuration name.

## the issue

Within `.vscode/launch.json` by default `configurations[].type` describes both, the name of the debug adapter and the debug configuration. Currently LazyVim configures a debug adapter `codellvm` for two configurations called `c` and `cpp`. The adapter name and the configuration are not the same.

## the fix

The adapter's name has to be mapped to the configuration names by calling the function `require("dap.ext.vscode").load_launchjs` with a table as the second argument that assigns the configuration names properly to the adapter name.

## how to test this

- create file named `main.c` and put in this contents
```c
#include <stdio.h>
int main() {
  printf("hello world!\n");
  return 0;
}
```
- compile with: `cc -g -O0 main.c`
- create a file `.vscode/launch.json` next to `main.c` and put in this contents:
```json
{
  "configurations": [
    {
      "type": "codelldb",
      "request": "launch",
      "name": "LaunchLLDB",
      "program": "${workspaceFolder}/${input:myInput}"
    }
  ],
  "inputs": [
    {
      "id": "myInput",
      "type": "pickString",
      "description": "Your input",
      "options": [
        "./a.out"
      ],
      "default": "./a.out"
    }
  ]
}
```
- open `main.c` in LazyVim, set a break point at line three (:DapToggleBreakpoint) and launch the debugger (:DapContinue)

With the added line from the PR there should be a debug configuration available called `LaunchLLDB`. Try without the added line and it won't show up.

## temporary workaround

Add this to your custom configuration as a temporary workaround:

```lua
  {
    "mfussenegger/nvim-dap",
    opts = function ()
      require("dap.ext.vscode").load_launchjs(nil, { codelldb = {'c', 'cpp'} })
    end
  },

```