### PR TITLE
Add description to "Y" in Neo-Tree

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -61,11 +61,14 @@ return {
       window = {
         mappings = {
           ["<space>"] = "none",
-          ["Y"] = function(state)
-            local node = state.tree:get_node()
-            local path = node:get_id()
-            vim.fn.setreg("+", path, "c")
-          end,
+          ["Y"] = {
+            function(state)
+              local node = state.tree:get_node()
+              local path = node:get_id()
+              vim.fn.setreg("+", path, "c")
+            end,
+            desc = "copy path to clipboard",
+          },
         },
       },
       default_component_configs = {


### PR DESCRIPTION
It copies the path of the file/directory

I was confused by the `"Y" : <function>` tooltip in neo-tree