### PR TITLE
fix: keep user provided values of mapleader and maplocalleader

### DIFF
--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -1,6 +1,6 @@
 -- This file is automatically loaded by plugins.core
-vim.g.mapleader = " "
-vim.g.maplocalleader = "\\"
+vim.g.mapleader = vim.g.mapleader or " "
+vim.g.maplocalleader = vim.g.maplocalleader or "\\"
 
 -- Enable LazyVim auto format
 vim.g.autoformat = true


### PR DESCRIPTION
If the user provides a value, keep it, otherwise set to <space> and \ repectively.

Fixes: #2668