### PR TITLE
Make Haskell-snippets lazy load for performance

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/haskell.lua
+++ b/lua/lazyvim/plugins/extras/lang/haskell.lua
@@ -13,14 +13,14 @@ return {
   {
     "mrcjkb/haskell-tools.nvim",
     version = "^3",
-    ft = { 'haskell', 'lhaskell', 'cabal', 'cabalproject' },
+    ft = { "haskell", "lhaskell", "cabal", "cabalproject" },
     dependencies = {
       { "nvim-telescope/telescope.nvim", optional = true },
     },
     config = function()
-      local ok, telescope = pcall(require, 'telescope')
+      local ok, telescope = pcall(require, "telescope")
       if ok then
-        telescope.load_extension('ht')
+        telescope.load_extension("ht")
       end
     end,
   },
@@ -33,8 +33,8 @@ return {
     end,
   },
 
-  { 
-    "mfussenegger/nvim-dap", 
+  {
+    "mfussenegger/nvim-dap",
     optional = true,
     dependencies = {
       {
@@ -51,7 +51,7 @@ return {
     "nvim-neotest/neotest",
     optional = true,
     dependencies = {
-      { "mrcjkb/neotest-haskell", }
+      { "mrcjkb/neotest-haskell" },
     },
     opts = {
       adapters = {
@@ -62,24 +62,24 @@ return {
 
   {
     "mrcjkb/haskell-snippets.nvim",
-    dependencies = { "L3MON4D3/LuaSnip", },
-    ft = { 'haskell', 'lhaskell', 'cabal', 'cabalproject' },
+    dependencies = { "L3MON4D3/LuaSnip" },
+    ft = { "haskell", "lhaskell", "cabal", "cabalproject" },
     config = function()
-      local haskell_snippets = require('haskell-snippets').all
-      require('luasnip').add_snippets('haskell', haskell_snippets, { key = 'haskell' })
+      local haskell_snippets = require("haskell-snippets").all
+      require("luasnip").add_snippets("haskell", haskell_snippets, { key = "haskell" })
     end,
   },
 
   {
     "luc-tielen/telescope_hoogle",
-    ft = { 'haskell', 'lhaskell', 'cabal', 'cabalproject' },
+    ft = { "haskell", "lhaskell", "cabal", "cabalproject" },
     dependencies = {
       { "nvim-telescope/telescope.nvim" },
     },
     config = function()
-      local ok, telescope = pcall(require, 'telescope')
+      local ok, telescope = pcall(require, "telescope")
       if ok then
-        telescope.load_extension('hoogle')
+        telescope.load_extension("hoogle")
       end
     end,
   },
@@ -91,7 +91,7 @@ return {
     opts = {
       setup = {
         hls = function()
-          return true 
+          return true
         end,
       },
     },

--- a/lua/lazyvim/plugins/extras/lang/haskell.lua
+++ b/lua/lazyvim/plugins/extras/lang/haskell.lua
@@ -63,6 +63,7 @@ return {
   {
     "mrcjkb/haskell-snippets.nvim",
     dependencies = { "L3MON4D3/LuaSnip", },
+    ft = { 'haskell', 'lhaskell', 'cabal', 'cabalproject' },
     config = function()
       local haskell_snippets = require('haskell-snippets').all
       require('luasnip').add_snippets('haskell', haskell_snippets, { key = 'haskell' })


### PR DESCRIPTION
The `haskell-snippets.nvim` plugin wasn't being lazy loaded and was increasing my neovim startup time by 100ms.

- Added `ft = { <haskell_files> }` so it lazy loads only when entering a Haskell file.
- Also formatted the file