### PR TITLE
feat(lualine): add more hl options to pretty_path

### DIFF
--- a/lua/lazyvim/util/lualine.lua
+++ b/lua/lazyvim/util/lualine.lua
@@ -56,17 +56,36 @@ function M.format(component, text, hl_group)
   local lualine_hl_group = component.hl_cache[hl_group]
   if not lualine_hl_group then
     local utils = require("lualine.utils.utils")
-    lualine_hl_group = component:create_hl({ fg = utils.extract_highlight_colors(hl_group, "fg") }, "LV_" .. hl_group)
+    local mygui = function()
+      local mybold = utils.extract_highlight_colors(hl_group, "bold") and "bold"
+      local myitalic = utils.extract_highlight_colors(hl_group, "italic") and "italic"
+      if mybold and myitalic then
+        return mybold .. "," .. myitalic
+      elseif mybold then
+        return mybold
+      elseif myitalic then
+        return myitalic
+      else
+        return ""
+      end
+    end
+
+    lualine_hl_group = component:create_hl({
+      fg = utils.extract_highlight_colors(hl_group, "fg"),
+      gui = mygui(),
+    }, "LV_" .. hl_group)
     component.hl_cache[hl_group] = lualine_hl_group
   end
   return component:format_hl(lualine_hl_group) .. text .. component:get_default_hl()
 end
 
----@param opts? {relative: "cwd"|"root", modified_hl: string?}
+---@param opts? {relative: "cwd"|"root", modified_hl: string?, dirpath_hl: string?, filename_hl: string?}
 function M.pretty_path(opts)
   opts = vim.tbl_extend("force", {
     relative = "cwd",
     modified_hl = "Constant",
+    dirpath_hl = "",
+    filename_hl = "",
   }, opts or {})
 
   return function(self)
@@ -75,6 +94,7 @@ function M.pretty_path(opts)
     if path == "" then
       return ""
     end
+
     local root = Util.root.get({ normalize = true })
     local cwd = Util.root.cwd()
 
@@ -86,15 +106,23 @@ function M.pretty_path(opts)
 
     local sep = package.config:sub(1, 1)
     local parts = vim.split(path, "[\\/]")
+
     if #parts > 3 then
       parts = { parts[1], "…", parts[#parts - 1], parts[#parts] }
     end
 
     if opts.modified_hl and vim.bo.modified then
       parts[#parts] = M.format(self, parts[#parts], opts.modified_hl)
+    else
+      parts[#parts] = M.format(self, parts[#parts], opts.filename_hl)
     end
 
-    return table.concat(parts, sep)
+    local dirpath = ""
+    if #parts > 1 then
+      dirpath = table.concat({ unpack(parts, 1, #parts - 1) }, sep)
+      dirpath = M.format(self, dirpath .. sep, opts.dirpath_hl)
+    end
+    return dirpath .. parts[#parts]
   end
 end
 

--- a/lua/lazyvim/util/lualine.lua
+++ b/lua/lazyvim/util/lualine.lua
@@ -48,7 +48,7 @@ end
 ---@param hl_group? string
 ---@return string
 function M.format(component, text, hl_group)
-  if not hl_group then
+  if not hl_group or hl_group == "" then
     return text
   end
   ---@type table<string, string>
@@ -56,36 +56,30 @@ function M.format(component, text, hl_group)
   local lualine_hl_group = component.hl_cache[hl_group]
   if not lualine_hl_group then
     local utils = require("lualine.utils.utils")
-    local mygui = function()
-      local mybold = utils.extract_highlight_colors(hl_group, "bold") and "bold"
-      local myitalic = utils.extract_highlight_colors(hl_group, "italic") and "italic"
-      if mybold and myitalic then
-        return mybold .. "," .. myitalic
-      elseif mybold then
-        return mybold
-      elseif myitalic then
-        return myitalic
-      else
-        return ""
-      end
-    end
+    ---@type string[]
+    local gui = vim.tbl_filter(function(x)
+      return x
+    end, {
+      utils.extract_highlight_colors(hl_group, "bold") and "bold",
+      utils.extract_highlight_colors(hl_group, "italic") and "italic",
+    })
 
     lualine_hl_group = component:create_hl({
       fg = utils.extract_highlight_colors(hl_group, "fg"),
-      gui = mygui(),
-    }, "LV_" .. hl_group)
+      gui = #gui > 0 and table.concat(gui, ",") or nil,
+    }, "LV_" .. hl_group) --[[@as string]]
     component.hl_cache[hl_group] = lualine_hl_group
   end
   return component:format_hl(lualine_hl_group) .. text .. component:get_default_hl()
 end
 
----@param opts? {relative: "cwd"|"root", modified_hl: string?, dirpath_hl: string?, filename_hl: string?}
+---@param opts? {relative: "cwd"|"root", modified_hl: string?, directory_hl: string?, filename_hl: string?}
 function M.pretty_path(opts)
   opts = vim.tbl_extend("force", {
     relative = "cwd",
-    modified_hl = "Constant",
-    dirpath_hl = "",
-    filename_hl = "",
+    modified_hl = "MatchParen",
+    directory_hl = "",
+    filename_hl = "Bold",
   }, opts or {})
 
   return function(self)
@@ -117,12 +111,12 @@ function M.pretty_path(opts)
       parts[#parts] = M.format(self, parts[#parts], opts.filename_hl)
     end
 
-    local dirpath = ""
+    local dir = ""
     if #parts > 1 then
-      dirpath = table.concat({ unpack(parts, 1, #parts - 1) }, sep)
-      dirpath = M.format(self, dirpath .. sep, opts.dirpath_hl)
+      dir = table.concat({ unpack(parts, 1, #parts - 1) }, sep)
+      dir = M.format(self, dir .. sep, opts.directory_hl)
     end
-    return dirpath .. parts[#parts]
+    return dir .. parts[#parts]
   end
 end
 


### PR DESCRIPTION
Adds two additional options to pretty_path: `filename_hl` and `dirpath_hl`.

This allows users to customize the highlight group of both the directory component of the path name and the filename independently. modified_hl is still used when the buffer has been modified. 

This commit does not change LazyVim's default formatting of the lualine path name segment. 

Lazy's default:
<img width="929" alt="image" src="https://github.com/LazyVim/LazyVim/assets/747855/c225240e-4746-443c-b0d0-b9ffc4af8366">

With the new options:
<img width="930" alt="image" src="https://github.com/LazyVim/LazyVim/assets/747855/1a2377d2-85c0-451e-b5e8-dc4aba3f212b">

When the buffer has been modified:
<img width="929" alt="image" src="https://github.com/LazyVim/LazyVim/assets/747855/acde35b6-f3b9-42c2-b542-c5094f04c923">

But, now users can achieve the above by passing the options to `pretty_path`:
```lua
local util = require("lazyvim.util")
return {
  {
    "nvim-lualine/lualine.nvim",
    opts = function(_, opts)
      opts.sections.lualine_c[4] =
        { util.lualine.pretty_path({ filename_hl = "Bold", modified_hl = "MatchParen", dirpath_hl = "Conceal" }) }
      return opts
    end,
  },
}
```

Thanks to @dpetka2001 for this `format` function when I inquired about how to achieve this in discussion  #2605.
