### PR TITLE
Description for `g.` keybinding in mini.files

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/mini-files.lua
+++ b/lua/lazyvim/plugins/extras/editor/mini-files.lua
@@ -50,7 +50,7 @@ return {
       callback = function(args)
         local buf_id = args.data.buf_id
         -- Tweak left-hand side of mapping to your liking
-        vim.keymap.set("n", "g.", toggle_dotfiles, { buffer = buf_id })
+        vim.keymap.set("n", "g.", toggle_dotfiles, { buffer = buf_id, desc = "Toggle hidden files" })
       end,
     })
 


### PR DESCRIPTION
If you press `g` in a mini.files menu, the `.` key shows up but doesn't have a description. This adds a desc attribute to the binding so the menu shows a correct description.