### PR TITLE
feat(mini.files): add cwd and vertical/horizontal keybindings to mini.files

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/mini-files.lua
+++ b/lua/lazyvim/plugins/extras/editor/mini-files.lua
@@ -45,12 +45,59 @@ return {
       require("mini.files").refresh({ content = { filter = new_filter } })
     end
 
+    local map_split = function(buf_id, lhs, direction, close_on_file)
+      local rhs = function()
+        local new_target_window
+        local cur_target_window = require("mini.files").get_target_window()
+        if cur_target_window ~= nil then
+          vim.api.nvim_win_call(cur_target_window, function()
+            vim.cmd("belowright " .. direction .. " split")
+            new_target_window = vim.api.nvim_get_current_win()
+          end)
+
+          require("mini.files").set_target_window(new_target_window)
+          require("mini.files").go_in({ close_on_file = close_on_file })
+        end
+      end
+
+      local desc = "Open in " .. direction .. " split"
+      if close_on_file then
+        desc = desc .. " and close"
+      end
+      vim.keymap.set("n", lhs, rhs, { buffer = buf_id, desc = desc })
+    end
+
+    local files_set_cwd = function()
+      local cur_entry_path = MiniFiles.get_fs_entry().path
+      local cur_directory = vim.fs.dirname(cur_entry_path)
+      if cur_directory ~= nil then
+        vim.fn.chdir(cur_directory)
+      end
+    end
+
     vim.api.nvim_create_autocmd("User", {
       pattern = "MiniFilesBufferCreate",
       callback = function(args)
         local buf_id = args.data.buf_id
-        -- Tweak left-hand side of mapping to your liking
-        vim.keymap.set("n", "g.", toggle_dotfiles, { buffer = buf_id, desc = "Toggle Hidden Files" })
+
+        vim.keymap.set(
+          "n",
+          opts.mappings.toggle_hidden or "g.",
+          toggle_dotfiles,
+          { buffer = buf_id, desc = "Toggle hidden files" }
+        )
+
+        vim.keymap.set(
+          "n",
+          opts.mappings.change_cwd or "gc",
+          files_set_cwd,
+          { buffer = args.data.buf_id, desc = "Set cwd" }
+        )
+
+        map_split(buf_id, opts.mappings.go_in_horizontal or "<C-w>s", "horizontal", false)
+        map_split(buf_id, opts.mappings.go_in_vertical or "<C-w>v", "vertical", false)
+        map_split(buf_id, opts.mappings.go_in_horizontal_plus or "<C-w>S", "horizontal", true)
+        map_split(buf_id, opts.mappings.go_in_vertical_plus or "<C-w>V", "vertical", true)
       end,
     })
 


### PR DESCRIPTION
* Makes the toggle_hidden keybinding configurable via mappings
* Adds new mini.files keybindings for opening files in a vertical split, with both go_in and go_in_plus modes (configurable via mappings)
* Adds new keybinding to change working directory from mini.files (configurable via mappings)

Closes #2692 