### PR TITLE
Add default formatters for yaml

### DIFF
--- a/lua/lazyvim/plugins/formatting.lua
+++ b/lua/lazyvim/plugins/formatting.lua
@@ -90,6 +90,8 @@ return {
           lua = { "stylua" },
           fish = { "fish_indent" },
           sh = { "shfmt" },
+          -- yamlls doesn't respect your prettier config
+          yaml = { { "prettierd", "prettier", "yamlfix" } },
         },
         -- The options you set here will be merged with the builtin formatters.
         -- You can also define any custom formatters here.


### PR DESCRIPTION
Yaml formatting has been a pain for some time now. I finally figured out that the yaml LSP formatter doesn't respect my prettier config. Since the sub-list searches for installed formatters, I think these are sane (non-invasive) defaults.