### PR TITLE
fix(lang/rust): don't overwrite `vim.g.rustaceanvim` if it is defined

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -81,7 +81,7 @@ return {
       },
     },
     config = function(_, opts)
-      vim.g.rustaceanvim = vim.tbl_deep_extend("force", {}, opts or {})
+      vim.g.rustaceanvim = vim.tbl_deep_extend("keep", vim.g.rustaceanvim or {}, opts or {})
     end,
   },
 


### PR DESCRIPTION
Hey :wave: 

A way to override rustaceanvim's settings per project is by using `:h exrc`.
This doesn't appear to work with LazyVim (see https://github.com/mrcjkb/rustaceanvim/issues/283), likely because it overwrites `vim.g.rustaceanvim` the settings in the `config` function.

This should fix that.