### PR TITLE
feat(git): add <leader>gf for lazygit commit history on current file

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -129,10 +129,9 @@ map("n", "<leader>ub", function() Util.toggle("background", false, {"light", "da
 map("n", "<leader>gg", function() Util.terminal({ "lazygit" }, { cwd = Util.root(), esc_esc = false, ctrl_hjkl = false }) end, { desc = "Lazygit (root dir)" })
 map("n", "<leader>gG", function() Util.terminal({ "lazygit" }, {esc_esc = false, ctrl_hjkl = false}) end, { desc = "Lazygit (cwd)" })
 
--- Function to get the current file path from the root directory
-local current_file_path_from_root_dir = function()
+local current_file_path_from_git_root = function()
   local path = vim.fn.expand("%:p")
-  local root = Util.root()
+  local root = vim.fn.system("git -C " .. path .. " rev-parse --show-toplevel"):gsub("\n$", "")
   if not path:find(root, 1, true) then
     return path
   end
@@ -140,7 +139,7 @@ local current_file_path_from_root_dir = function()
 end
 
 map("n", "<leader>gf", function()
-  Util.terminal({ "lazygit", "-f", current_file_path_from_root_dir() }, { esc_esc = false, ctrl_hjkl = false })
+  Util.terminal({ "lazygit", "-f", current_file_path_from_git_root() }, { esc_esc = false, ctrl_hjkl = false })
 end, { desc = "Lazygit current file history" })
 
 -- quit

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -129,6 +129,20 @@ map("n", "<leader>ub", function() Util.toggle("background", false, {"light", "da
 map("n", "<leader>gg", function() Util.terminal({ "lazygit" }, { cwd = Util.root(), esc_esc = false, ctrl_hjkl = false }) end, { desc = "Lazygit (root dir)" })
 map("n", "<leader>gG", function() Util.terminal({ "lazygit" }, {esc_esc = false, ctrl_hjkl = false}) end, { desc = "Lazygit (cwd)" })
 
+-- Function to get the current file path from the root directory
+local current_file_path_from_root_dir = function()
+  local path = vim.fn.expand("%:p")
+  local root = Util.root()
+  if not path:find(root, 1, true) then
+    return path
+  end
+  return path:sub(#root + 2)
+end
+
+map("n", "<leader>gf", function()
+  Util.terminal({ "lazygit", "-f", current_file_path_from_root_dir() }, { esc_esc = false, ctrl_hjkl = false })
+end, { desc = "Lazygit current file history" })
+
 -- quit
 map("n", "<leader>qq", "<cmd>qa<cr>", { desc = "Quit all" })
 

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -129,17 +129,9 @@ map("n", "<leader>ub", function() Util.toggle("background", false, {"light", "da
 map("n", "<leader>gg", function() Util.terminal({ "lazygit" }, { cwd = Util.root(), esc_esc = false, ctrl_hjkl = false }) end, { desc = "Lazygit (root dir)" })
 map("n", "<leader>gG", function() Util.terminal({ "lazygit" }, {esc_esc = false, ctrl_hjkl = false}) end, { desc = "Lazygit (cwd)" })
 
-local current_file_path_from_git_root = function()
-  local path = vim.fn.expand("%:p")
-  local root = vim.fn.system("git -C " .. path .. " rev-parse --show-toplevel"):gsub("\n$", "")
-  if not path:find(root, 1, true) then
-    return path
-  end
-  return path:sub(#root + 2)
-end
-
 map("n", "<leader>gf", function()
-  Util.terminal({ "lazygit", "-f", current_file_path_from_git_root() }, { esc_esc = false, ctrl_hjkl = false })
+  local git_path = vim.fn.system("git ls-files --full-name " .. vim.api.nvim_buf_get_name(0))
+  Util.terminal({ "lazygit", "-f", vim.trim(git_path) }, { esc_esc = false, ctrl_hjkl = false })
 end, { desc = "Lazygit current file history" })
 
 -- quit


### PR DESCRIPTION
This adds the `<leader>gf` (for Git File) keymap that lets you view commit history for the current file.

Lazygit supports this through their CLI (see [doc](https://github.com/jesseduffield/lazygit/blob/fd18db6ba285eb280aee1cb8c381295df6556cad/docs/Searching.md?plain=1#L20)) with a `-f <filepath>` flag which must be a path to the file from the git dir.

Looks like this:
<img width="1982" alt="image" src="https://github.com/LazyVim/LazyVim/assets/83053931/3cdd931e-de9c-41d5-8d63-ee4776b15c5c">

Open to suggestions on different keymap or implementation