### PR TITLE
fix: format injected langs does not wait 300ms

### DIFF
--- a/lua/lazyvim/plugins/formatting.lua
+++ b/lua/lazyvim/plugins/formatting.lua
@@ -39,7 +39,7 @@ return {
       {
         "<leader>cF",
         function()
-          require("conform").format({ formatters = { "injected" } })
+          require("conform").format({ formatters = { "injected" }, timeout_ms = 3000 })
         end,
         mode = { "n", "v" },
         desc = "Format Injected Langs",


### PR DESCRIPTION
Some formatters like styler take a while to format (2s). They fail to format when run on injected code. This should help fix that :).