### PR TITLE
fix(ansible): ansiblels not loading, neotest keymap conflict

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/ansible.lua
+++ b/lua/lazyvim/plugins/extras/lang/ansible.lua
@@ -25,12 +25,14 @@ return {
   },
   {
     "mfussenegger/nvim-ansible",
+    ft = {},
     keys = {
       {
-        "<leader>tr",
+        "<leader>ta",
         function()
           require("ansible").run()
         end,
+        desc = "Ansible Run Playbook/Role",
         silent = true,
       },
     },


### PR DESCRIPTION
If lazy extras yaml is enabled, yamlls was being loaded not ansiblels.

Add `ft = {}` to nvim-ansible spec allows `ft=yaml.ansible` to be detected.

Re-mapped nvim-ansible plugin key to not conflict with neotest.

Added a description for the keymap.