### PR TITLE
fix(git): compatible function

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -130,7 +130,7 @@ map("n", "<leader>gg", function() Util.terminal({ "lazygit" }, { cwd = Util.root
 map("n", "<leader>gG", function() Util.terminal({ "lazygit" }, {esc_esc = false, ctrl_hjkl = false}) end, { desc = "Lazygit (cwd)" })
 
 map("n", "<leader>gf", function()
-  local git_path = vim.fn.system("git ls-files --full-name " .. vim.api.nvim_buf_get_name(0))
+  local git_path = vim.api.nvim_buf_get_name(0)
   Util.terminal({ "lazygit", "-f", vim.trim(git_path) }, { esc_esc = false, ctrl_hjkl = false })
 end, { desc = "Lazygit current file history" })
 


### PR DESCRIPTION
use compatible function for windows and linux for keybinding `<leader>gf`.

Fixes #2735