### PR TITLE
fix(lang/rust): Remove `rust-analyzer` from `nvim-lspconfig`

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -90,7 +90,6 @@ return {
     "neovim/nvim-lspconfig",
     opts = {
       servers = {
-        rust_analyzer = {},
         taplo = {
           keys = {
             {
@@ -106,11 +105,6 @@ return {
             },
           },
         },
-      },
-      setup = {
-        rust_analyzer = function()
-          return true
-        end,
       },
     },
   },


### PR DESCRIPTION
According to the maintainer of `rustaceanvim` (see his comment [here](https://github.com/LazyVim/LazyVim/pull/2198#issuecomment-1999475044)) he says
> To pick up on this: There's a good reason rustaceanvim doesn't automatically pick up a mason.nvim installation. It will most likely be built with a different toolchain than the one your project uses, often leading to discrepancies and subtle bugs.
It's easy to configure rustaceanvim to use mason.nvim if you really want it, but I generally adhere to the YAGNI principle.

I tried locally and the removal of `rust-analyzer` from `nvim-lspconfig` doesn't seem to have any effect on how `rustaceanvim` behaves.

I propose to remove all instances of `rust-analyzer` from `nvim-lspconfig` to avoid any possible issues from users that don't have `rust-analyzer` installed in their toolchain (in this case it would pick up Mason's $PATH I believe), since they will think that since `rust-analyzer` is installed by Mason, there shouldn't be a problem and report issues as bugs. See for example #2746.

PS: Would appreciate further input from users, who actually use Rust if the proposed change breaks anything I'm not aware of.