### PR TITLE
feat(neo-tree): add mapping "O" to open with system default

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -69,17 +69,16 @@ return {
             end,
             desc = "copy path to clipboard",
           },
-          ["O"] = {
-            command = function(state)
-              if vim.ui.open then
-                local filepath = state.tree:get_node().path
-                vim.ui.open(filepath)
-              else
-                require("lazyvim.util").error("vim.ui.open is not available")
+          ["O"] = vim.ui.open and {
+            function(state)
+              local path = state.tree:get_node().path
+              local ret = vim.ui.open(path)
+              if ret and ret.code ~= 0 then
+                require("lazyvim.util").error("Failed to open file: " .. ret.stderr .. "\n .. " .. ret.stdout)
               end
             end,
-            desc = "open_with_system_default",
-          },
+            desc = "open with system default application",
+          } or nil,
         },
       },
       default_component_configs = {

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -72,6 +72,12 @@ return {
           ["O"] = {
             command = function(state)
               local filepath = state.tree:get_node().path
+
+              if vim.ui.open then
+                vim.ui.open(filepath)
+                return
+              end
+
               local uname = vim.loop.os_uname()
               local OS = uname.sysname
               local is_mac = OS == "Darwin"

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -72,8 +72,23 @@ return {
           ["O"] = {
             command = function(state)
               local filepath = state.tree:get_node().path
-
-              os.execute("open " .. string.format("'%s'", filepath))
+              local uname = vim.loop.os_uname()
+              local OS = uname.sysname
+              local is_mac = OS == "Darwin"
+              local is_linux = OS == "Linux"
+              local is_windows = OS:find("Windows") and true or false
+              local is_wsl = is_linux and uname.release:lower():find("microsoft") and true or false
+              if is_mac then
+                os.execute("open " .. string.format("'%s'", filepath))
+              elseif is_wsl then
+                os.execute("wslview " .. string.format("'%s'", filepath))
+              elseif is_linux then
+                os.execute("xdg-open " .. string.format("'%s'", filepath))
+              elseif is_windows then
+                os.execute("start " .. string.format("'%s'", filepath))
+              else
+                vim.notify("neo-tree: OS not detected", "error")
+              end
             end,
             desc = "open_with_system_defaults",
           },

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -71,29 +71,26 @@ return {
           },
           ["O"] = {
             command = function(state)
+              local function open_file(filepath)
+                if vim.fn.has("mac") == 1 then
+                  os.execute("open " .. string.format("'%s'", filepath))
+                elseif vim.fn.has("win32") == 1 then
+                  if vim.fn.executable("rundll32") == 1 then
+                    os.execute("rundll32 " .. string.format("'%s'", filepath))
+                  end
+                elseif vim.fn.executable("wslview") == 1 then
+                  os.execute("wslview " .. string.format("'%s'", filepath))
+                elseif vim.fn.executable("xdg-open") == 1 then
+                  os.execute("xdg-open " .. string.format("'%s'", filepath))
+                else
+                  vim.notify("neo-tree: OS not detected", "error")
+                end
+              end
               local filepath = state.tree:get_node().path
-
               if vim.ui.open then
                 vim.ui.open(filepath)
-                return
-              end
-
-              local uname = vim.loop.os_uname()
-              local OS = uname.sysname
-              local is_mac = OS == "Darwin"
-              local is_linux = OS == "Linux"
-              local is_windows = OS:find("Windows") and true or false
-              local is_wsl = is_linux and uname.release:lower():find("microsoft") and true or false
-              if is_mac then
-                os.execute("open " .. string.format("'%s'", filepath))
-              elseif is_wsl then
-                os.execute("wslview " .. string.format("'%s'", filepath))
-              elseif is_linux then
-                os.execute("xdg-open " .. string.format("'%s'", filepath))
-              elseif is_windows then
-                os.execute("start " .. string.format("'%s'", filepath))
               else
-                vim.notify("neo-tree: OS not detected", "error")
+                open_file(filepath)
               end
             end,
             desc = "open_with_system_defaults",

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -71,29 +71,14 @@ return {
           },
           ["O"] = {
             command = function(state)
-              local function open_file(filepath)
-                if vim.fn.has("mac") == 1 then
-                  os.execute("open " .. string.format("'%s'", filepath))
-                elseif vim.fn.has("win32") == 1 then
-                  if vim.fn.executable("rundll32") == 1 then
-                    os.execute("rundll32 " .. string.format("'%s'", filepath))
-                  end
-                elseif vim.fn.executable("wslview") == 1 then
-                  os.execute("wslview " .. string.format("'%s'", filepath))
-                elseif vim.fn.executable("xdg-open") == 1 then
-                  os.execute("xdg-open " .. string.format("'%s'", filepath))
-                else
-                  vim.notify("neo-tree: OS not detected", "error")
-                end
-              end
-              local filepath = state.tree:get_node().path
               if vim.ui.open then
+                local filepath = state.tree:get_node().path
                 vim.ui.open(filepath)
               else
-                open_file(filepath)
+                require("lazyvim.util").error("vim.ui.open is not available")
               end
             end,
-            desc = "open_with_system_defaults",
+            desc = "open_with_system_default",
           },
         },
       },

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -69,6 +69,14 @@ return {
             end,
             desc = "copy path to clipboard",
           },
+          ["O"] = {
+            command = function(state)
+              local filepath = state.tree:get_node().path
+
+              os.execute("open " .. string.format("'%s'", filepath))
+            end,
+            desc = "open_with_system_defaults",
+          },
         },
       },
       default_component_configs = {

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -69,16 +69,12 @@ return {
             end,
             desc = "copy path to clipboard",
           },
-          ["O"] = vim.ui.open and {
+          ["O"] = {
             function(state)
-              local path = state.tree:get_node().path
-              local ret = vim.ui.open(path)
-              if ret and ret.code ~= 0 then
-                require("lazyvim.util").error("Failed to open file: " .. ret.stderr .. "\n .. " .. ret.stdout)
-              end
+              require("lazy.util").open(state.tree:get_node().path, { system = true })
             end,
-            desc = "open with system default application",
-          } or nil,
+            desc = "open with system application",
+          },
         },
       },
       default_component_configs = {


### PR DESCRIPTION
This adds the "O" mapping to Neo-tree to open the file in the system default app. I found this really useful for opening things like directories in the default file explorer, or images/pdfs since the terminal can't render those. There is an open [issue](https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1224) in neo-tree but it's been labelled as wontfix so I think adding this to something like LazyVim is a good idea.

Let me know if you need me to add anything.