### PR TITLE
Adding required nvim-nio to test and dap extra (neotest and nvim-dap-ui respectively)

### DIFF
--- a/lua/lazyvim/plugins/extras/dap/core.lua
+++ b/lua/lazyvim/plugins/extras/dap/core.lua
@@ -18,6 +18,7 @@ return {
     -- fancy UI for the debugger
     {
       "rcarriga/nvim-dap-ui",
+      dependencies = { "nvim-neotest/nvim-nio" },
       -- stylua: ignore
       keys = {
         { "<leader>du", function() require("dapui").toggle({ }) end, desc = "Dap UI" },

--- a/lua/lazyvim/plugins/extras/test/core.lua
+++ b/lua/lazyvim/plugins/extras/test/core.lua
@@ -10,6 +10,7 @@ return {
   },
   {
     "nvim-neotest/neotest",
+    dependencies = { "nvim-neotest/nvim-nio" },
     opts = {
       -- Can be a list of adapters like what neotest expects,
       -- or a list of adapter names,


### PR DESCRIPTION
neotest now requires nvim-neotest/nvim-nio to be
installed as per BREAKING CHANGE: https://github.com/nvim-neotest/neotest/pull/337