### PR TITLE
feat(mini.ai): add more objects d,e,g,u,U

### DIFF
--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -212,6 +212,26 @@ return {
           f = ai.gen_spec.treesitter({ a = "@function.outer", i = "@function.inner" }, {}),
           c = ai.gen_spec.treesitter({ a = "@class.outer", i = "@class.inner" }, {}),
           t = { "<([%p%w]-)%f[^<%w][^<>]->.-</%1>", "^<.->().*()</[^/]->$" },
+          d = { "%f[%d]%d+" }, -- digits
+          e = { -- Word with case
+            {
+              "%u[%l%d]+%f[^%l%d]",
+              "%f[%S][%l%d]+%f[^%l%d]",
+              "%f[%P][%l%d]+%f[^%l%d]",
+              "^[%l%d]+%f[^%l%d]",
+            },
+            "^().*()$",
+          },
+          g = function() -- Whole buffer, similar to `gg` and 'G' motion
+            local from = { line = 1, col = 1 }
+            local to = {
+              line = vim.fn.line("$"),
+              col = math.max(vim.fn.getline("$"):len(), 1),
+            }
+            return { from = from, to = to }
+          end,
+          u = ai.gen_spec.function_call(), -- u for "Usage"
+          U = ai.gen_spec.function_call({ name_pattern = "[%w_]" }), -- without dot in function name
         },
       }
     end,
@@ -238,10 +258,15 @@ return {
           a = "Argument",
           b = "Balanced ), ], }",
           c = "Class",
+          d = "Digit(s)",
+          e = "Word in CamelCase & snake_case",
           f = "Function",
+          g = "Entire file",
           o = "Block, conditional, loop",
           q = "Quote `, \", '",
           t = "Tag",
+          u = "Use/call function & method",
+          U = "Use/call without dot in name",
         }
         local a = vim.deepcopy(i)
         for k, v in pairs(a) do


### PR DESCRIPTION
Proposing to add some more text objects I've been using quite frequently for a while.
These are all examples from the mini.ai document itself.

- `d` for digits, matches consecutive digits
- `e` because it's near `w`, for subword in camelCase and snake_case
- `g` for entire buffer, similar motion to `gg` and `G`. For example, now `dag` instead of `ggdG` or `ggvGd` will delete entire buffer.
- `u` for "Usage", to selection function and method call since `f` and `c` is already taken for function definition.
- `U` similar to `u`, but match without dot in function name