### PR TITLE
fix(format): Don't leak bufnr into opts tables

### DIFF
--- a/lua/lazyvim/plugins/formatting.lua
+++ b/lua/lazyvim/plugins/formatting.lua
@@ -56,7 +56,7 @@ return {
             local plugin = require("lazy.core.config").plugins["conform.nvim"]
             local Plugin = require("lazy.core.plugin")
             local opts = Plugin.values(plugin, "opts", false)
-            require("conform").format(Util.merge(opts.format, { bufnr = buf }))
+            require("conform").format(Util.merge({}, opts.format, { bufnr = buf }))
           end,
           sources = function(buf)
             local ret = require("conform").list_formatters(buf)

--- a/lua/lazyvim/util/lsp.lua
+++ b/lua/lazyvim/util/lsp.lua
@@ -87,10 +87,10 @@ function M.formatter(opts)
     primary = true,
     priority = 1,
     format = function(buf)
-      M.format(Util.merge(filter, { bufnr = buf }))
+      M.format(Util.merge({}, filter, { bufnr = buf }))
     end,
     sources = function(buf)
-      local clients = M.get_clients(Util.merge(filter, { bufnr = buf }))
+      local clients = M.get_clients(Util.merge({}, filter, { bufnr = buf }))
       ---@param client lsp.Client
       local ret = vim.tbl_filter(function(client)
         return client.supports_method("textDocument/formatting")


### PR DESCRIPTION
Since `Util.merge` performs an **in-place** merge, `bufnr` is being leaked into the opts tables before being sent to the formatter.
This causes, in rare cases, the `bufnr` to be **replaced** by the wrong `bufnr` (i.e, not the current buffer), causing the formatting to apply to the wrong file.

This bug caused random text to be copied and inserted into unrelated files on save, which eventually snuck into our QA environment. Luckily, it got caught and I started investigating the issue. I found that the issue happened after ([afca0b7](https://github.com/LazyVim/LazyVim/commit/afca0b7876abf9022ee0754270f603e981ea42a5)), and found the root cause.

To demonstrate why this is a problem, do as follows:
- Open an arbitrary file and save it, triggering conform
- Note which `bufnr` this has via `:echo bufnr('%')`
- Open a different file (do not save)
- Check that `bufnr` is now a different `bufnr` as expected via `:echo bufnr('%')`
- Run the following `:lua vim.print(require("lazyvim.util").opts("conform.nvim").format or {})`
- Observe that `bufnr` is present in the `conform.nvim` options table, and that it points to the old buffer

Because of a recent change ([afca0b7](https://github.com/LazyVim/LazyVim/commit/afca0b7876abf9022ee0754270f603e981ea42a5)), the `conform.nvim` `opts.format` table is applied into the `opts` table before formatting, *overwriting* the proper `bufnr` value in the `opts` sent to the formatter, because `conform.nvim` would now contain it's own, stale `bufnr`.

This made me look at other uses of `Util.merge` and see that this indeed happens in several places.

The fix is to make sure we make a clone of the `opts` table before we trigger `format`, avoiding leaking the `bufnr` value into the plugin `opts`.

After this fix, observe that `:lua vim.print(require("lazyvim.util").opts("conform.nvim").format or {})` does not contain `bufnr` in the `conform.nvim` table.