### PR TITLE
feat(git): unnested hunk keymaps, add toggle &find

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -129,7 +129,7 @@ map("n", "<leader>ub", function() Util.toggle("background", false, {"light", "da
 map("n", "<leader>gg", function() Util.terminal({ "lazygit" }, { cwd = Util.root.git(), esc_esc = false, ctrl_hjkl = false }) end, { desc = "Lazygit (root dir)" })
 map("n", "<leader>gG", function() Util.terminal({ "lazygit" }, {esc_esc = false, ctrl_hjkl = false}) end, { desc = "Lazygit (cwd)" })
 
-map("n", "<leader>gf", function()
+map("n", "<leader>gh", function()
   local git_path = vim.api.nvim_buf_get_name(0)
   Util.terminal({ "lazygit", "-f", vim.trim(git_path) }, { esc_esc = false, ctrl_hjkl = false })
 end, { desc = "Lazygit current file history" })

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -153,8 +153,10 @@ return {
       { "<leader>fr", "<cmd>Telescope oldfiles<cr>", desc = "Recent" },
       { "<leader>fR", Util.telescope("oldfiles", { cwd = vim.loop.cwd() }), desc = "Recent (cwd)" },
       -- git
-      { "<leader>gc", "<cmd>Telescope git_commits<CR>", desc = "commits" },
-      { "<leader>gs", "<cmd>Telescope git_status<CR>", desc = "status" },
+      { "<leader>gfc", "<cmd>Telescope git_commits<CR>", desc = "commits" },
+      { "<leader>gfs", "<cmd>Telescope git_status<CR>", desc = "status" },
+      { "<leader>gfb", "<cmd>Telescope git_branches<CR>", desc = "branch" },
+      { "<leader>gfh", "<cmd>Telescope git_stash<CR>", desc = "stashs" },
       -- search
       { '<leader>s"', "<cmd>Telescope registers<cr>", desc = "Registers" },
       { "<leader>sa", "<cmd>Telescope autocommands<cr>", desc = "Auto Commands" },
@@ -323,7 +325,8 @@ return {
         ["<leader>c"] = { name = "+code" },
         ["<leader>f"] = { name = "+file/find" },
         ["<leader>g"] = { name = "+git" },
-        ["<leader>gh"] = { name = "+hunks" },
+        ["<leader>gt"] = { name = "+toggle" },
+        ["<leader>gf"] = { name = "+find" },
         ["<leader>q"] = { name = "+quit/session" },
         ["<leader>s"] = { name = "+search" },
         ["<leader>u"] = { name = "+ui" },
@@ -363,16 +366,24 @@ return {
         -- stylua: ignore start
         map("n", "]h", gs.next_hunk, "Next Hunk")
         map("n", "[h", gs.prev_hunk, "Prev Hunk")
-        map({ "n", "v" }, "<leader>ghs", ":Gitsigns stage_hunk<CR>", "Stage Hunk")
-        map({ "n", "v" }, "<leader>ghr", ":Gitsigns reset_hunk<CR>", "Reset Hunk")
-        map("n", "<leader>ghS", gs.stage_buffer, "Stage Buffer")
-        map("n", "<leader>ghu", gs.undo_stage_hunk, "Undo Stage Hunk")
-        map("n", "<leader>ghR", gs.reset_buffer, "Reset Buffer")
-        map("n", "<leader>ghp", gs.preview_hunk_inline, "Preview Hunk Inline")
-        map("n", "<leader>ghb", function() gs.blame_line({ full = true }) end, "Blame Line")
-        map("n", "<leader>ghd", gs.diffthis, "Diff This")
-        map("n", "<leader>ghD", function() gs.diffthis("~") end, "Diff This ~")
+        map({ "n", "v" }, "<leader>gs", ":Gitsigns stage_hunk<CR>", "Stage Hunk")
+        map({ "n", "v" }, "<leader>gr", ":Gitsigns reset_hunk<CR>", "Reset Hunk")
+        map("n", "<leader>gS", gs.stage_buffer, "Stage Buffer")
+        map("n", "<leader>gu", gs.undo_stage_hunk, "Undo Stage Hunk")
+        map("n", "<leader>gU", gs.reset_buffer_index, "Undo all Stage Hunk")
+        map("n", "<leader>gR", gs.reset_buffer, "Reset Buffer")
+        map("n", "<leader>gp", gs.preview_hunk_inline, "Preview Hunk Inline")
+        map("n", "<leader>gb", function() gs.blame_line({ full = true }) end, "Blame Line")
+        map("n", "<leader>gd", gs.diffthis, "Diff This")
+        map("n", "<leader>gD", function() gs.diffthis("~") end, "Diff This ~")
         map({ "o", "x" }, "ih", ":<C-U>Gitsigns select_hunk<CR>", "GitSigns Select Hunk")
+
+        map("n", "<leader>gtb", gs.toggle_current_line_blame, "blame virtual text")
+        map("n", "<leader>gtd", gs.toggle_deleted, "deleted virtual text")
+        map("n", "<leader>gtl", gs.toggle_linehl, "line highlight")
+        map("n", "<leader>gtn", gs.toggle_numhl, "line number highlight")
+        map("n", "<leader>gts", gs.toggle_signs, "signs column")
+        map("n", "<leader>gtw", gs.toggle_word_diff, "word diff")
       end,
     },
   },


### PR DESCRIPTION
This PR is a long shot since it introduces breaking changes to gitsigns keymaps.
- Unpack the hunk-related keymap from `<leader>ghx` to just `<leader>gx`. These are most commonly used keymaps for gitsigns and I find it to be unnecessarily long, especially when there is (almost) no conflicting shorter keymap.
- New keymaps for "undo all staged hunks".
- Move the Telescope's git functionality inside `<leader>gf` for "git finds ..."
- Add new gitsigns' UI-related toggle inside `<leader>gt` for "git toggle  ..."
- Current file git history with lazygit from `<leader>gf` to `<leader>gh`