### PR TITLE
feat(treesitter): `v` for incremental node select

### DIFF
--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -81,8 +81,7 @@ return {
       incremental_selection = {
         enable = true,
         keymaps = {
-          init_selection = "<C-space>",
-          node_incremental = "<C-space>",
+          node_incremental = "v",
           scope_incremental = false,
           node_decremental = "<bs>",
         },


### PR DESCRIPTION
In case a breaking change get through #2795 , I propose another one for treesitter's textobject selection borrowed from from reddit.
Using `v` as increment keymap, now you can just spam `vvvvv` from normal mode to select bigger treesitter node, and `<bs>` to decrease node.
Everything behaves absolutely the same as before, `V` uses to change between line selection, etc.