### PR TITLE
feat(lang/thrift): add thrift lang support

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/thrift.lua
+++ b/lua/lazyvim/plugins/extras/lang/thrift.lua
@@ -1,0 +1,19 @@
+return {
+  {
+    "nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "thrift" })
+    end,
+  },
+  {
+    "nvim-lspconfig",
+    optional = true,
+    opts = {
+      servers = {
+        thriftls = {},
+      },
+    },
+  },
+}

--- a/lua/lazyvim/plugins/extras/lang/thrift.lua
+++ b/lua/lazyvim/plugins/extras/lang/thrift.lua
@@ -1,4 +1,8 @@
 return {
+  recommended = {
+    ft = "thrift",
+    root = ".thrift",
+  },
   {
     "nvim-treesitter",
     optional = true,


### PR DESCRIPTION
This PR adds support for thriftls, the first line is because thrift is not among the neovim built-in file types.