### PR TITLE
fix(autocmds): remove query from q-to-quit autocmd

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -59,7 +59,6 @@ vim.api.nvim_create_autocmd("FileType", {
     "lspinfo",
     "notify",
     "qf",
-    "query",
     "spectre_panel",
     "startuptime",
     "tsplayground",


### PR DESCRIPTION
I fixed this before in #473 but maybe it was accidentally reintroduced. I can understand the benefits of being able to just use q to close the query editor, but query *files* (those in nvim-treesitter or any tree sitter repository) are actual files and become very annoying to edit with this shortcut if i accidentally hit q