### PR TITLE
feat(extra): add repl and code cell

### DIFF
--- a/lua/lazyvim/plugins/extras/repl/slime.lua
+++ b/lua/lazyvim/plugins/extras/repl/slime.lua
@@ -1,0 +1,127 @@
+return {
+  -- General vim repl code send
+  {
+    "jpalardy/vim-slime",
+    init = function()
+      vim.g.slime_no_mappings = 1
+      vim.g.slime_bracketed_paste = 1
+      vim.g.slime_target = "neovim"
+      vim.g.slime_menu_config = true
+      vim.api.nvim_create_user_command("SlimeTarget", function(opts)
+        if opts.args ~= nil then
+          vim.b.slime_target = opts.args
+          vim.b.slime_config = nil
+        else
+          vim.b.slime_config = vim.g.slime_config
+          vim.b.slime_target = vim.g.slime_target
+        end
+        vim.notify("Slime send target is: " .. vim.b.slime_target)
+      end, { desc = "Change Slime target", nargs = 1 })
+    end,
+    cmd = { "SlimeConfig", "SlimeTarget" },
+    keys = {
+      { "<S-CR>", "<Plug>SlimeRegionSend", mode = "x", desc = "Send Selection" },
+      { "<S-CR>", "<Plug>SlimeMotionSend", mode = "n", desc = "Send Textobject" },
+      { "<leader>rr", "<Plug>SlimeMotionSend", mode = "n", desc = "Send Textobject (<S-CR>)" },
+      { "<S-CR><S-CR>", "<S-CR>ir]rj", mode = "n", remap = true, desc = "Send Cell and Jump Next" },
+      { "<leader>rC", "<Cmd>SlimeConfig<CR>", desc = "Slime Run Config" },
+      { "<leader>rT", "<Cmd>SlimeTarget<CR>", desc = "Slime Run Target" },
+    },
+  },
+  -- Separator overlay on cell marker & metadata
+  {
+    "echasnovski/mini.hipatterns",
+    optional = true,
+    opts = function(_, opts)
+      local censor_extmark_opts = function(buf_id, match, data)
+        local mask = string.rep("⎯", vim.api.nvim_win_get_width(0))
+        return {
+          virt_text = { { mask, "SignColumn" } },
+          virt_text_pos = "overlay",
+          virt_text_hide = true,
+          priority = 200,
+          right_gravity = false,
+        }
+      end
+      opts.highlighters["cell_marker"] = {
+        pattern = function(bufid)
+          local cmt_str = vim.api.nvim_get_option_value("commentstring", { buf = bufid })
+          return "^" .. string.gsub(cmt_str, [[%s]], "") .. [[*%%.*]]
+        end,
+        group = "",
+        extmark_opts = censor_extmark_opts,
+      }
+    end,
+  },
+  -- Define code cell object `ir`, `ar`
+  {
+    "echasnovski/mini.ai",
+    opts = {
+      custom_textobjects = {
+        r = function(ai_mode, _, _)
+          local buf_nlines = vim.api.nvim_buf_line_count(0)
+          local cell_markers = {}
+          for line_no = 1, buf_nlines do
+            local line = vim.fn.getline(line_no)
+            if line:match("^# *%%%%") then
+              table.insert(cell_markers, line_no)
+            end
+          end
+          table.insert(cell_markers, 1, 0) -- Beginning
+          table.insert(cell_markers, #cell_markers + 1, buf_nlines + 1)
+
+          local regions = {}
+          for i = 1, #cell_markers - 1 do
+            local from_line, to_line
+            if ai_mode == "i" then
+              from_line = cell_markers[i] + 1
+              to_line = cell_markers[i + 1] - 1
+            else
+              from_line = math.max(cell_markers[i], 1)
+              to_line = cell_markers[i + 1] - 1
+            end
+            -- for `around cell` on empty line select previous cell
+            local to_line_len = vim.fn.getline(to_line):len() + 1
+            table.insert(regions, {
+              from = { line = from_line, col = 1 },
+              to = { line = to_line, col = to_line_len },
+            })
+          end
+          return regions
+        end,
+      },
+    },
+  },
+  -- Mapping for moving between cell `]r`, `[r`
+  -- defined in query/python/textobjects.scm
+  {
+    "nvim-treesitter",
+    opts = {
+      textobjects = {
+        move = {
+          goto_next_start = { ["]r"] = "@cell.marker" },
+          goto_previous_start = { ["[r"] = "@cell.marker" },
+        },
+      },
+    },
+  },
+  {
+    "lualine.nvim",
+    opts = function(_, opts)
+      table.insert(opts.sections.lualine_y, {
+        function()
+          -- show terminal jobid if in a Slime connected buffer
+          if vim.b.slime_config and vim.b.slime_config.jobid then
+            return " " .. vim.b.slime_config.jobid
+          -- or if cursor focus on a terminal buffer
+          elseif vim.o.buftype == "terminal" then
+            return " " .. vim.o.channel
+          else
+            return ""
+          end
+        end,
+        color = LazyVim.ui.fg("Constant"),
+      })
+    end,
+  },
+}

--- a/lua/lazyvim/plugins/xtras.lua
+++ b/lua/lazyvim/plugins/xtras.lua
@@ -4,6 +4,7 @@ local Config = require("lazyvim.config")
 local prios = {
   ["lazyvim.plugins.extras.editor.aerial"] = 100,
   ["lazyvim.plugins.extras.editor.outline"] = 100,
+  ["lazyvim.plugins.extras.repl.slime"] = 100,
   ["lazyvim.plugins.extras.test.core"] = 1,
   ["lazyvim.plugins.extras.dap.core"] = 1,
 }

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -1,0 +1,10 @@
+;; extends
+
+; Set highlight to @variable so it appears similar to plaintext in .md
+; otherwise will be highlighted as @string
+; # %% [markdown] cell
+((
+  (comment) @_cell.marker.md
+  . (expression_statement
+      (string (string_content) @variable)))
+  (#lua-match? @_cell.marker.md "^# %%%% %[markdown%]"))

--- a/queries/python/injections.scm
+++ b/queries/python/injections.scm
@@ -1,0 +1,16 @@
+;extends
+
+; # %% [markdown]
+; """
+; This is markdown cell, with triple-quote multiline string
+; """
+((comment) @cell.marker
+  . (expression_statement
+    (string
+      (string_start) @_comment_mark
+      (string_content) @injection.content)
+    )
+  (#lua-match? @cell.marker "^# *%%%% *%[markdown%]")
+  (#eq? @_comment_mark "\"\"\"")
+  (#set! injection.language "markdown")
+  )

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -1,0 +1,6 @@
+; extends
+
+; Code cells in percent format: # %%, #%% with any metadata
+((comment) @cell.marker
+  (#lua-match? @cell.marker "^# *%%%%.*"))
+


### PR DESCRIPTION
LazyVim extra for REPL functionality, emulate [VSCode's code cell](https://code.visualstudio.com/docs/python/jupyter-support-py#_jupyter-code-cells) features, using [slime](https://github.com/jpalardy/vim-slime?tab=readme-ov-file), treesitter and other plugins already in used by LazyVim.

## Edit script
1. Open a normal python file and write code as usual.
1. Defining code cell with the [percent](https://github.com/mwouts/jupytext/blob/main/docs/formats-scripts.md#the-percent-format) format 
1. Write markdown cell with proper highlight injection  (particularly relevant for conversion from  <img width="711" alt="Screenshot 2024-03-27 at 22 49 33" src="https://github.com/LazyVim/LazyVim/assets/12573521/1c9b9631-4a66-4b53-9c4f-b3aadfef678c">
1. Optionally conceal cell marker with `mini.hipatterns`, revealed on selection <img width="596" alt="Screenshot 2024-03-27 at 22 47 36" src="https://github.com/LazyVim/LazyVim/assets/12573521/e46e7ccd-211e-469e-8621-357c2c237551">
1. Navigate to previous and next cell with `]r`, `[r`

## Run
1. Start a neovim terminal for repl
    - Run `:SlimeTarget wezterm` for example if you don't want to use neovim's terminal
1. Attach code buffer to target with `<leader>rC`, `:SlimeConfig` or just start send code
1. Select the correct target terminal if there are many based on terminal jobid <img width="716" alt="Screenshot 2024-03-27 at 22 37 48" src="https://github.com/LazyVim/LazyVim/assets/12573521/6d9828ab-2096-4f04-acc8-81a0aa67d94d">
    - lualine component to show terminal's jobid for terminal buffer and connected code buffer via slime  <img width="371" alt="Screenshot 2024-03-27 at 23 47 49" src="https://github.com/LazyVim/LazyVim/assets/12573521/3c6ce780-6cee-4351-a022-3213a7ea12f6">
1. Send code to repl
    -  `<S-CR>` + motion in normal mode, `<S-CR>ip, <S-CR>af, <S-CR>ac` etc
    - Visually select + `<S-CR>` `<S-v><S-CR>` to send current line etc...
    - `<S-CR><S-CR>` to send and jump to next cell, similar to jupyter notebook's <S-CR>


## Remarks
- Use `leader<r>, ir, ar, ]r, [r` for "repl", as there is not many letter left for new text objects. 
- The functionality from treesitter is only for python for now, but can be extend to other languages
- The custom treesitter queries are bundled directly to LazyVim, outside of the extra. I don't know if there's a better way.
- This extra is just a collection of simple configuration for REPL-behaviour and code cell manipulation. Advanced functionality for jupyter like notebook like conversion, display output, kernel execution with completion, hover etc are out of scope. These can comes later as another LazyVim extra.
