### PR TITLE
feat(extras): propose to add mini.move as an extra instead of native move command

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/mini-move.lua
+++ b/lua/lazyvim/plugins/extras/editor/mini-move.lua
@@ -1,0 +1,32 @@
+return {
+  {
+    "echasnovski/mini.move",
+    event = "VeryLazy",
+    opts = {},
+    keys = function()
+      local ret = {}
+      local directions = { "left", "down", "up", "right" }
+      local keys = { "h", "j", "k", "l" }
+      local move = require("mini.move")
+      for i, dir in ipairs(directions) do
+        ret[#ret + 1] = {
+          "<A-" .. keys[i] .. ">",
+          mode = { "i", "n" },
+          function()
+            move.move_line(dir)
+          end,
+        }
+      end
+      for i, dir in ipairs(directions) do
+        ret[#ret + 1] = {
+          "<A-" .. keys[i] .. ">",
+          mode = { "v" },
+          function()
+            move.move_selection(dir)
+          end,
+        }
+      end
+      return ret
+    end,
+  },
+}


### PR DESCRIPTION
The main motivation for using mini.move instead of the native move command is to avoid polluting the undo history as mini.move allows undoing consecutive moves with one single `u`. And horizontal moves are nice too!

I set up the keybindings manually to overwrite the default keymaps, as well as to set up moving in InsertMode.

