### PR TITLE
fix(keymaps): delete lazygit keymap when using gitui

### DIFF
--- a/lua/lazyvim/plugins/extras/util/gitui.lua
+++ b/lua/lazyvim/plugins/extras/util/gitui.lua
@@ -18,6 +18,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = opts.ensure_installed or {}
       vim.list_extend(opts.ensure_installed, { "gitui" })
+      vim.keymap.del("n", "<leader>gf")
     end,
   },
 }


### PR DESCRIPTION
Currently even when using gitui, lazy gits current file history keymap is still there. This deletes the keymap