### PR TITLE
fix(config): harpoon2 deprecated message 

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/harpoon2.lua
+++ b/lua/lazyvim/plugins/extras/editor/harpoon2.lua
@@ -5,13 +5,16 @@ return {
     menu = {
       width = vim.api.nvim_win_get_width(0) - 4,
     },
+    settings = {
+      save_on_toggle = true,
+    },
   },
   keys = function()
     local keys = {
       {
         "<leader>H",
         function()
-          require("harpoon"):list():append()
+          require("harpoon"):list():add()
         end,
         desc = "Harpoon File",
       },
@@ -22,7 +25,7 @@ return {
           harpoon.ui:toggle_quick_menu(harpoon:list())
         end,
         desc = "Harpoon Quick Menu",
-      }
+      },
     }
 
     for i = 1, 5 do
@@ -35,5 +38,5 @@ return {
       })
     end
     return keys
-  end
+  end,
 }

--- a/lua/lazyvim/plugins/extras/editor/harpoon2.lua
+++ b/lua/lazyvim/plugins/extras/editor/harpoon2.lua
@@ -1,7 +1,6 @@
 return {
   "ThePrimeagen/harpoon",
   branch = "harpoon2",
-  dependencies = { "nvim-lua/plenary.nvim" },
   opts = {
     menu = {
       width = vim.api.nvim_win_get_width(0) - 4,


### PR DESCRIPTION
When adding a new file with `<leader>H` a new message pops-up with please use add instead of append. 
Also when removing a file from the harpooned files list without command `:wq` the file list is not updated. That behaviour is corrected with the `save_on_toggle = true` flag.

![image](https://github.com/LazyVim/LazyVim/assets/48456822/f7a46263-4dd5-4be5-b2c3-1c2dfe065814)
![image](https://github.com/LazyVim/LazyVim/assets/48456822/e97a20f7-3988-4885-9a28-e55d35d65724)
