### PR TITLE
feat(statuscol): fold open indicator

### DIFF
--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -19,6 +19,12 @@ vim.g.root_spec = { "lsp", { ".git", "lua" }, "cwd" }
 -- Set to false to disable.
 vim.g.lazygit_config = true
 
+-- Options for the LazyVim statuscolumn
+vim.g.lazyvim_statuscolumn = {
+  folds_open = false, -- show fold sign when fold is open
+  folds_githl = false, -- highlight fold sign with git sign color
+}
+
 -- Optionally setup the terminal to use
 -- This sets `vim.o.shell` and does some additional configuration for:
 -- * pwsh

--- a/lua/lazyvim/util/ui.lua
+++ b/lua/lazyvim/util/ui.lua
@@ -101,10 +101,11 @@ function M.statuscolumn()
 
   if show_signs then
     ---@type Sign?,Sign?,Sign?
-    local left, right, fold
+    local left, right, fold, githl
     for _, s in ipairs(M.get_signs(buf, vim.v.lnum)) do
       if s.name and (s.name:find("GitSign") or s.name:find("MiniDiffSign")) then
         right = s
+        githl = s["texthl"]
       else
         left = s
       end
@@ -114,7 +115,9 @@ function M.statuscolumn()
     end
     vim.api.nvim_win_call(win, function()
       if vim.fn.foldclosed(vim.v.lnum) >= 0 then
-        fold = { text = vim.opt.fillchars:get().foldclose or "", texthl = "Folded" }
+        fold = { text = vim.opt.fillchars:get().foldclose or "", texthl = githl or "Folded" }
+      elseif not LazyVim.ui.skip_foldexpr[buf] and vim.treesitter.foldexpr(vim.v.lnum):sub(1, 1) == ">" then -- fold start
+        fold = { text = vim.opt.fillchars:get().foldopen or "", texthl = githl }
       end
     end)
     -- Left: mark or non-git sign

--- a/lua/lazyvim/util/ui.lua
+++ b/lua/lazyvim/util/ui.lua
@@ -99,13 +99,18 @@ function M.statuscolumn()
 
   local components = { "", "", "" } -- left, middle, right
 
+  local show_open_folds = vim.g.lazyvim_statuscolumn and vim.g.lazyvim_statuscolumn.folds_open
+  local use_githl = vim.g.lazyvim_statuscolumn and vim.g.lazyvim_statuscolumn.folds_githl
+
   if show_signs then
     ---@type Sign?,Sign?,Sign?
     local left, right, fold, githl
     for _, s in ipairs(M.get_signs(buf, vim.v.lnum)) do
       if s.name and (s.name:find("GitSign") or s.name:find("MiniDiffSign")) then
         right = s
-        githl = s["texthl"]
+        if use_githl then
+          githl = s["texthl"]
+        end
       else
         left = s
       end
@@ -113,10 +118,15 @@ function M.statuscolumn()
     if vim.v.virtnum ~= 0 then
       left = nil
     end
+
     vim.api.nvim_win_call(win, function()
       if vim.fn.foldclosed(vim.v.lnum) >= 0 then
         fold = { text = vim.opt.fillchars:get().foldclose or "", texthl = githl or "Folded" }
-      elseif not LazyVim.ui.skip_foldexpr[buf] and vim.treesitter.foldexpr(vim.v.lnum):sub(1, 1) == ">" then -- fold start
+      elseif
+        show_open_folds
+        and not LazyVim.ui.skip_foldexpr[buf]
+        and vim.treesitter.foldexpr(vim.v.lnum):sub(1, 1) == ">"
+      then -- fold start
         fold = { text = vim.opt.fillchars:get().foldopen or "", texthl = githl }
       end
     end)


### PR DESCRIPTION
- Add to the status column the sign to indicate open fold, i.e where a fold will be triggered.
- Open and close fold sign will use the git sign color if it git info is present on the line (rel. line 5,4,2) and gitsigns' `signcolumn` is enabled (by default)
- otherwise close fold icon use "Folded" group, as before (line 7)
- open fold icon has no special highlight, the same as the number column (line 8, 3) 
<img width="603" alt="Screenshot 2024-04-05 at 22 43 59" src="https://github.com/LazyVim/LazyVim/assets/12573521/1c44a289-f1d3-480b-8207-1df3d58f3c65">

This is similar to VSCode on mouse hover
<img width="172" alt="Screenshot 2024-04-04 at 17 28 00" src="https://github.com/LazyVim/LazyVim/assets/12573521/f0bfa82b-312c-4696-977c-61aa90f896ba">