### PR TITLE
Harpoon2: Use `add` to add the current buffer to the list instead of  `append`

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/harpoon2.lua
+++ b/lua/lazyvim/plugins/extras/editor/harpoon2.lua
@@ -11,7 +11,7 @@ return {
       {
         "<leader>H",
         function()
-          require("harpoon"):list():append()
+          require("harpoon"):list():add()
         end,
         desc = "Harpoon File",
       },


### PR DESCRIPTION
Use `add` to add the current buffer to the list instead of `append.` The plugin warns about the deprecation of the latter in favor of the previous one.