### PR TITLE
fix(dial): Fix dial.nvim commands in visual line/block

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/dial.lua
+++ b/lua/lazyvim/plugins/extras/editor/dial.lua
@@ -5,7 +5,9 @@ M.dials_by_ft = {}
 ---@param increment boolean
 ---@param g? boolean
 function M.dial(increment, g)
-  local is_visual = vim.fn.mode(true):sub(1, 1) == "v"
+  local mode = vim.fn.mode(true)
+  -- Use visual commands for VISUAL 'v', VISUAL LINE 'V' and VISUAL BLOCK '\22'
+  local is_visual = mode == "v" or mode == "V" or mode == "\22"
   local func = (increment and "inc" or "dec") .. (g and "_g" or "_") .. (is_visual and "visual" or "normal")
   local group = M.dials_by_ft[vim.bo.filetype] or "default"
   return require("dial.map")[func](group)


### PR DESCRIPTION
In the dial.nvim extra config, keymaps use the dial normal mode commands in visual line and visual block mode. 

This limits the cases where the dial.nvim keymaps can be used. Eg visual-block selecting and incrementing all object keys to fix this example:

```javascript
const digitToStr = {
  //   < v-block  ctrl-a >
  one: "0",
  two: "1",
  three: "2",
  // ...
};
```

This PR fixes the mode argument passed to the `dial.manipulate` function when using `<C-a>`, `<C-x>`, `g<C-a>` and `g<C-x>` when in VISUAL-LINE and VISUAL-BLOCK modes.
