### PR TITLE
fix(harpoon2): Using add() since append() is deprecated

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/harpoon2.lua
+++ b/lua/lazyvim/plugins/extras/editor/harpoon2.lua
@@ -11,7 +11,7 @@ return {
       {
         "<leader>H",
         function()
-          require("harpoon"):list():append()
+          require("harpoon"):list():add()
         end,
         desc = "Harpoon File",
       },
@@ -22,7 +22,7 @@ return {
           harpoon.ui:toggle_quick_menu(harpoon:list())
         end,
         desc = "Harpoon Quick Menu",
-      }
+      },
     }
 
     for i = 1, 5 do
@@ -35,5 +35,5 @@ return {
       })
     end
     return keys
-  end
+  end,
 }


### PR DESCRIPTION
New updates of harpoon now uses add instead of append 
![image](https://github.com/LazyVim/LazyVim/assets/51878195/27297ede-1d2a-4071-aa82-a63fc3964759)
