### PR TITLE
fix(mini.move): <A-j> & <A-k> overridden by default global keybindings

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/mini-move.lua
+++ b/lua/lazyvim/plugins/extras/editor/mini-move.lua
@@ -1,7 +1,7 @@
 return {
   {
     "echasnovski/mini.move",
-    event = "VeryLazy",
+    event = "LazyFile",
     opts = {},
   },
 }


### PR DESCRIPTION
The global keybindings <A-j> and <A-k> is still taking precedence over mini.move. This means that when one uses <A-j> or <A-k> with this setting they cannot use a single `u` to undo consecutive moves.

This fixes that.