### PR TITLE
Fixed: Neotree isn't properly invoked when a directory is given by argument

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -45,6 +45,7 @@ return {
         local stat = vim.uv.fs_stat(vim.fn.argv(0))
         if stat and stat.type == "directory" then
           require("neo-tree")
+          vim.cmd("Neotree toggle")
         end
       end
     end,


### PR DESCRIPTION
When a directory is given at launch through argument e.g. "nvim .", LazyVim opens Neo-tree side window instead of the dashboard. However, the instance isn't fully initialized: if one opens a file directly from Neotree, the tree buffer will be override by that file. And toggling Neotree will then result in error "failed to rename the buffer". Manually toggling Neotree can solve this issue.

I am still very new to Neovim and LazyVim, maybe there's a better solution :)