### PR TITLE
fix(harpoon2): replace deprecated append() with add()

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/harpoon2.lua
+++ b/lua/lazyvim/plugins/extras/editor/harpoon2.lua
@@ -11,7 +11,7 @@ return {
       {
         "<leader>H",
         function()
-          require("harpoon"):list():append()
+          require("harpoon"):list():add()
         end,
         desc = "Harpoon File",
       },


### PR DESCRIPTION
lazyvim is showing a popup mentioning that append is deprecated while harpooning a file.  
This is the new function to use to fix this.