### PR TITLE
feat(treesitter): nvim-treesitter-refactor

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -382,46 +382,6 @@ return {
     },
   },
 
-  -- Automatically highlights other instances of the word under your cursor.
-  -- This works with LSP, Treesitter, and regexp matching to find the other
-  -- instances.
-  {
-    "RRethy/vim-illuminate",
-    event = "LazyFile",
-    opts = {
-      delay = 200,
-      large_file_cutoff = 2000,
-      large_file_overrides = {
-        providers = { "lsp" },
-      },
-    },
-    config = function(_, opts)
-      require("illuminate").configure(opts)
-
-      local function map(key, dir, buffer)
-        vim.keymap.set("n", key, function()
-          require("illuminate")["goto_" .. dir .. "_reference"](false)
-        end, { desc = dir:sub(1, 1):upper() .. dir:sub(2) .. " Reference", buffer = buffer })
-      end
-
-      map("]]", "next")
-      map("[[", "prev")
-
-      -- also set it after loading ftplugins, since a lot overwrite [[ and ]]
-      vim.api.nvim_create_autocmd("FileType", {
-        callback = function()
-          local buffer = vim.api.nvim_get_current_buf()
-          map("]]", "next", buffer)
-          map("[[", "prev", buffer)
-        end,
-      })
-    end,
-    keys = {
-      { "]]", desc = "Next Reference" },
-      { "[[", desc = "Prev Reference" },
-    },
-  },
-
   -- buffer remove
   {
     "echasnovski/mini.bufremove",

--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -114,8 +114,8 @@ return {
             list_definitions = false,
             list_definitions_toc = false,
 
-            goto_next_usage = { ["]]"] = "Next reference" },
-            goto_previous_usage = { ["[["] = "Previous reference" },
+            goto_next_usage = "]]",
+            goto_previous_usage = "[[",
           },
         },
       },

--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -42,6 +42,9 @@ return {
           end
         end,
       },
+      {
+        "nvim-treesitter/nvim-treesitter-refactor",
+      },
     },
     cmd = { "TSUpdateSync", "TSUpdate", "TSInstall" },
     keys = {
@@ -94,6 +97,26 @@ return {
           goto_next_end = { ["]F"] = "@function.outer", ["]C"] = "@class.outer" },
           goto_previous_start = { ["[f"] = "@function.outer", ["[c"] = "@class.outer" },
           goto_previous_end = { ["[F"] = "@function.outer", ["[C"] = "@class.outer" },
+        },
+      },
+      refactor = {
+        highlight_definitions = { enable = true },
+        smart_rename = {
+          enable = true,
+          keymaps = {
+            smart_rename = "grr",
+          },
+        },
+        navigation = {
+          enable = true,
+          keymaps = {
+            goto_definition = false,
+            list_definitions = false,
+            list_definitions_toc = false,
+
+            goto_next_usage = { ["]]"] = "Next reference" },
+            goto_previous_usage = { ["[["] = "Previous reference" },
+          },
         },
       },
     },


### PR DESCRIPTION
This PR adds the treesitter refactor module. The module config adds smart renaming & definition highlights(removes vim-illuminate)

**Smart rename** `<grr>`

![image](https://github.com/LazyVim/LazyVim/assets/43573646/f12e8746-445c-46a3-bb4a-50960d52ba93)


**Definition highlights**

![image](https://github.com/LazyVim/LazyVim/assets/43573646/cdcaa9cf-61c6-4497-a790-5fca2f39a981)


It also removes vim-illuminate. The refactor module is significantly faster, powered by treesitter. (The highlighting happens as soon as the buffer opens, as opposed to vim-illuminate which waits for lsp's to load)

The current (broken?) keymaps for previous & next reference in vim-illuminate also work out of the box!
