### PR TITLE
fix(edgy): neo-tree doesn't open when leader isn't space

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/edgy.lua
+++ b/lua/lazyvim/plugins/extras/ui/edgy.lua
@@ -61,7 +61,8 @@ return {
             end,
             pinned = true,
             open = function()
-              vim.api.nvim_input("<esc><space>e")
+              local leader = vim.g.mapleader
+              vim.api.nvim_input('<esc>' .. leader .. 'e')
             end,
             size = { height = 0.5 },
           },


### PR DESCRIPTION
The default mapping for this is to use `<leader>` which edgy should
respect. This ensures that neo-tree still opens even when leader has
been remapped. Otherwise, the top neo-tree window just stays in a
loading state.

Unfortunately, it seems the `<leader>` isn't a supported keycode for
`nvim_input` (or at least it isn't listed in `:help keycodes` and it
doesn't seem to work). Getting the leader first, then passing it to
`nvim_input` seems to clear this up.