### PR TITLE
fix(harpoon): replace deprecated append call with add

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/harpoon2.lua
+++ b/lua/lazyvim/plugins/extras/editor/harpoon2.lua
@@ -11,7 +11,7 @@ return {
       {
         "<leader>H",
         function()
-          require("harpoon"):list():append()
+          require("harpoon"):list():add()
         end,
         desc = "Harpoon File",
       },
@@ -22,7 +22,7 @@ return {
           harpoon.ui:toggle_quick_menu(harpoon:list())
         end,
         desc = "Harpoon Quick Menu",
-      }
+      },
     }
 
     for i = 1, 5 do
@@ -35,5 +35,5 @@ return {
       })
     end
     return keys
-  end
+  end,
 }


### PR DESCRIPTION
`list():append()` function was deprecated in favour of `list():add()`, they have the same signature otherwise.

See https://github.com/ThePrimeagen/harpoon/blob/0378a6c428a0bed6a2781d459d7943843f374bce/lua/harpoon/list.lua#L102-L107