### PR TITLE
fix(lazyfile): exclude `filetypedetect` from skips

### DIFF
--- a/lua/lazyvim/util/plugin.lua
+++ b/lua/lazyvim/util/plugin.lua
@@ -86,7 +86,11 @@ function M.lazy_file()
     ---@type table<string,string[]>
     local skips = {}
     for _, event in ipairs(events) do
-      skips[event.event] = skips[event.event] or Event.get_augroups(event.event)
+      local augroups = Event.get_augroups(event.event)
+      local groups = vim.tbl_filter(function(t)
+        return not vim.tbl_contains({ t }, "filetypedetect")
+      end, augroups)
+      skips[event.event] = skips[event.event] or groups
     end
 
     vim.api.nvim_exec_autocmds("User", { pattern = "LazyFile", modeline = false })


### PR DESCRIPTION
Fixes #2891 (potentially)

After I saw that issue after a long a time, I decided to take a deeper dive to how `lazyfile` works. 

Unfortunately, with my lack of programming experience, I could only understand some things on the surface, so I ended up doing some `vim.print` to have some visual hints. I then noticed that `filetypedetect` was given back from `Event.get_augroups(event.event)` and included in the `skips` table, which is later excluded in `Event.trigger`. 

My assumption was that due to `filetypedetect` being skipped, the filetypes added in `extras.util.dot` could not be detected in `LazyFile` event when Neovim was invoked with file arguments, as also stated in the aforementioned issue.

So, I just tried to exclude `filetypedetect` from being added to `skips` table and when I tested it locally it worked when invoking Neovim with file arguments.

I would love some input from the maintainer, as the steps I followed were mostly based on logical deductions, rather having in-depth knowledge of what's actually going on in the `lazyfile` function and the maintainer is obviously the one most intrinsically acquainted with LazyVim codebase and obviously there might be a more correct way to do it.