### PR TITLE
fix(inlay-hint): update `inlay_hint.enable()` args

### DIFF
--- a/lua/lazyvim/util/toggle.lua
+++ b/lua/lazyvim/util/toggle.lua
@@ -67,7 +67,7 @@ function M.inlay_hints(buf, value)
     if value == nil then
       value = not ih.is_enabled(buf)
     end
-    ih.enable(buf, value)
+    ih.enable(value, { buffrn = buf })
   end
 end
 


### PR DESCRIPTION
With the merge of neovim/neovim#28374, the `vim.lsp.inlay_hint.enable()` signature has been updated. In the new version, it takes the boolean flag first and accepts a filter in the form of a table. The previous version's buffer input can be passed with the provided implementation.

Fixes: #3011
