### PR TITLE
feat(python): use new `ruff` instead of `ruff_lsp`

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -28,7 +28,7 @@ return {
         [lsp] = {
           enabled = true,
         },
-        ruff_lsp = {
+        ruff = {
           keys = {
             {
               "<leader>co",
@@ -47,9 +47,9 @@ return {
         },
       },
       setup = {
-        ruff_lsp = function()
+        ruff = function()
           LazyVim.lsp.on_attach(function(client, _)
-            if client.name == "ruff_lsp" then
+            if client.name == "ruff" then
               -- Disable hover in favor of Pyright
               client.server_capabilities.hoverProvider = false
             end


### PR DESCRIPTION
Use the new builtin rust-based `ruff server` instead of the python-based `ruff_lsp` wrapper.
Ruff_lsp is not deprecated (yet) but the new rust-based server is faster and is (almost?) feature complete.
Though it's still in beta, it has been highlighted in the latest [ruff release](https://github.com/astral-sh/ruff/releases/tag/v0.4.0) and it has worked well for me for a while.