### PR TITLE
feat(lang): add elm

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/elm.lua
+++ b/lua/lazyvim/plugins/extras/lang/elm.lua
@@ -1,4 +1,9 @@
 return {
+  recommended = {
+    ft = { "elm" },
+    root = { "elm.json" },
+  },
+
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
@@ -7,41 +12,30 @@ return {
       end
     end,
   },
+
   {
     "williamboman/mason.nvim",
     opts = function(_, opts)
       opts.ensure_installed = opts.ensure_installed or {}
-      vim.list_extend(opts.ensure_installed, { "elm-language-server", "elm-format" })
+      vim.list_extend(opts.ensure_installed, { "elm-format" })
     end,
   },
+
   {
     "stevearc/conform.nvim",
+    optional = true,
     opts = {
       formatters_by_ft = {
         elm = { "elm_format" },
       },
     },
   },
+
   {
     "neovim/nvim-lspconfig",
     opts = {
       servers = {
         elmls = {},
-      },
-    },
-  },
-  { -- neotest config needs improvement from someone more expert than me
-    "nvim-neotest/neotest",
-    dependencies = {
-      "nvim-neotest/neotest-vim-test",
-      "vim-test/vim-test",
-    },
-    opts = {
-      adapters = {
-        ["neotest-vim-test"] = {
-          allow_file_types = { "elm" },
-          runner = "elmtest",
-        },
       },
     },
   },

--- a/lua/lazyvim/plugins/extras/lang/elm.lua
+++ b/lua/lazyvim/plugins/extras/lang/elm.lua
@@ -1,0 +1,48 @@
+return {
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = function(_, opts)
+      if type(opts.ensure_installed) == "table" then
+        vim.list_extend(opts.ensure_installed, { "elm" })
+      end
+    end,
+  },
+  {
+    "williamboman/mason.nvim",
+    opts = function(_, opts)
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "elm-language-server", "elm-format" })
+    end,
+  },
+  {
+    "stevearc/conform.nvim",
+    opts = {
+      formatters_by_ft = {
+        elm = { "elm_format" },
+      },
+    },
+  },
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        elmls = {},
+      },
+    },
+  },
+  { -- neotest config needs improvement from someone more expert than me
+    "nvim-neotest/neotest",
+    dependencies = {
+      "nvim-neotest/neotest-vim-test",
+      "vim-test/vim-test",
+    },
+    opts = {
+      adapters = {
+        ["neotest-vim-test"] = {
+          allow_file_types = { "elm" },
+          runner = "elmtest",
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
Adding https://elm-lang.org support.

- Adds `elm` Treesitter parsers
- Adds `elm-language-server` language server
- Adds `elm-format` formatter

## LSP Configuration

The default [elm-language-server](https://github.com/elm-tooling/elm-language-server) configuration matches all [currently supported features for Neovim LSP](https://github.com/elm-tooling/elm-language-server#editor-support).

## A note on elm-test and elm-review

`elm-test` is not directly supported by [neo-test](../test/neotest) but it's available via [neotest-vim-test](https://github.com/nvim-neotest/neotest-vim-test).

However, it is common practice to peruse both [elm-test](https://github.com/elm-explorations/test/) and [elm-review](https://github.com/jfmengels/elm-review) directly via the command line.