### PR TITLE
ci: update action versions to remove node warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Neovim
         shell: bash
         run: |
@@ -31,7 +31,7 @@ jobs:
     needs: tests
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: panvimdoc
         uses: kdheepak/panvimdoc@main
         with:
@@ -40,7 +40,7 @@ jobs:
           demojify: true
           treesitter: true
       - name: Push changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore(build): auto-generate vimdoc"
           commit_user_name: "github-actions[bot]"
@@ -54,14 +54,14 @@ jobs:
       - tests
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         id: release
         with:
           release-type: simple
           package-name: LazyVim
           extra-files: |
             lua/lazyvim/config/init.lua
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: tag stable versions
         if: ${{ steps.release.outputs.release_created }}
         run: |


### PR DESCRIPTION
Since Node.js 16 actions are deprecated, updating the actions to use Node.js 20 is recommended. All actions in `ci.yml` have a newer version; this change bumps the actions to subsequent versions. A sample warning is provided below:

<img width="907" alt="Screenshot 2024-04-21 at 12 57 25" src="https://github.com/LazyVim/LazyVim/assets/34691280/87a86666-92dc-49f1-bc1f-9bba15252647">