### PR TITLE
fix(dot): can't match kitty conf file

### DIFF
--- a/lua/lazyvim/plugins/extras/util/dot.lua
+++ b/lua/lazyvim/plugins/extras/util/dot.lua
@@ -43,8 +43,8 @@ return {
         pattern = {
           [".*/waybar/config"] = "jsonc",
           [".*/mako/config"] = "dosini",
-          [".*/kitty/*.conf"] = "bash",
-          [".*/hypr/.*%.conf"] = "hyprlang",
+          [".*/kitty/.+%.conf"] = "bash",
+          [".*/hypr/.+%.conf"] = "hyprlang",
           ["%.env%.[%w_.-]+"] = "dotenv",
         },
       })


### PR DESCRIPTION
previous `.*/kitty/*.conf` can only match two kind of file: `kitty.conf` and `kitty/.conf`