### PR TITLE
update the attribute name for process ID

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -144,7 +144,7 @@ return {
             type = "codelldb",
             request = "attach",
             name = "Attach to process",
-            processId = require("dap.utils").pick_process,
+            pid = require("dap.utils").pick_process,
             cwd = "${workspaceFolder}",
           },
         }


### PR DESCRIPTION
The attribute name for picked process id when attaching the debugger is `pid`, not `processId`.
https://github.com/vadimcn/codelldb/blob/master/MANUAL.md