### PR TITLE
fix(dot): install when list is empty

### DIFF
--- a/lua/lazyvim/plugins/extras/util/dot.lua
+++ b/lua/lazyvim/plugins/extras/util/dot.lua
@@ -18,10 +18,8 @@ return {
   {
     "williamboman/mason.nvim",
     opts = function(_, opts)
-      vim.list_extend(opts.ensure_installed or {}, {
-        "shfmt",
-        "shellcheck",
-      })
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "shellcheck" })
     end,
   },
   -- add some stuff to treesitter


### PR DESCRIPTION
Assign `opts.ensure_installed` first because if it were to be nil, I believe that it would not be assigned nor extended with shellcheck.

Remove shfmt since LazyVim sets it up by default.