### PR TITLE
Revert "feat(python): use new `ruff` instead of `ruff_lsp`"

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -28,7 +28,7 @@ return {
         [lsp] = {
           enabled = true,
         },
-        ruff = {
+        ruff_lsp = {
           keys = {
             {
               "<leader>co",
@@ -47,9 +47,9 @@ return {
         },
       },
       setup = {
-        ruff = function()
+        ruff_lsp = function()
           LazyVim.lsp.on_attach(function(client, _)
-            if client.name == "ruff" then
+            if client.name == "ruff_lsp" then
               -- Disable hover in favor of Pyright
               client.server_capabilities.hoverProvider = false
             end


### PR DESCRIPTION
Reverts LazyVim/LazyVim#3016
As described in ruff web page, ruff server is alpha.

I believe this change is too early. And its not only too early but there are real problems.  

For example, after updating this, command line ruff complains about non formatted import block "I001".  