### PR TITLE
fix(python): make both `ruff` and `ruff_lsp` available to user

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -2,9 +2,11 @@ if lazyvim_docs then
   -- LSP Server to use for Python.
   -- Set to "basedpyright" to use basedpyright instead of pyright.
   vim.g.lazyvim_python_lsp = "pyright"
+  vim.g.lazyvim_ruff = "ruff_lsp"
 end
 
 local lsp = vim.g.lazyvim_python_lsp or "pyright"
+local ruff = vim.g.lazyvim_ruff or "ruff_lsp"
 
 return {
   {
@@ -28,7 +30,26 @@ return {
         [lsp] = {
           enabled = true,
         },
+        ruff_lsp = {
+          enabled = ruff == "ruff_lsp",
+          keys = {
+            {
+              "<leader>co",
+              function()
+                vim.lsp.buf.code_action({
+                  apply = true,
+                  context = {
+                    only = { "source.organizeImports" },
+                    diagnostics = {},
+                  },
+                })
+              end,
+              desc = "Organize Imports",
+            },
+          },
+        },
         ruff = {
+          enabled = ruff == "ruff",
           keys = {
             {
               "<leader>co",
@@ -47,6 +68,14 @@ return {
         },
       },
       setup = {
+        ruff_lsp = function()
+          LazyVim.lsp.on_attach(function(client, _)
+            if client.name == "ruff_lsp" then
+              -- Disable hover in favor of Pyright
+              client.server_capabilities.hoverProvider = false
+            end
+          end)
+        end,
         ruff = function()
           LazyVim.lsp.on_attach(function(client, _)
             if client.name == "ruff" then

--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -2,11 +2,11 @@ if lazyvim_docs then
   -- LSP Server to use for Python.
   -- Set to "basedpyright" to use basedpyright instead of pyright.
   vim.g.lazyvim_python_lsp = "pyright"
-  vim.g.lazyvim_ruff = "ruff_lsp"
+  vim.g.lazyvim_python_ruff = "ruff_lsp"
 end
 
 local lsp = vim.g.lazyvim_python_lsp or "pyright"
-local ruff = vim.g.lazyvim_ruff or "ruff_lsp"
+local ruff = vim.g.lazyvim_python_ruff or "ruff_lsp"
 
 return {
   {
@@ -32,24 +32,11 @@ return {
         },
         ruff_lsp = {
           enabled = ruff == "ruff_lsp",
-          keys = {
-            {
-              "<leader>co",
-              function()
-                vim.lsp.buf.code_action({
-                  apply = true,
-                  context = {
-                    only = { "source.organizeImports" },
-                    diagnostics = {},
-                  },
-                })
-              end,
-              desc = "Organize Imports",
-            },
-          },
         },
         ruff = {
           enabled = ruff == "ruff",
+        },
+        [ruff] = {
           keys = {
             {
               "<leader>co",
@@ -68,17 +55,9 @@ return {
         },
       },
       setup = {
-        ruff_lsp = function()
+        [ruff] = function()
           LazyVim.lsp.on_attach(function(client, _)
-            if client.name == "ruff_lsp" then
-              -- Disable hover in favor of Pyright
-              client.server_capabilities.hoverProvider = false
-            end
-          end)
-        end,
-        ruff = function()
-          LazyVim.lsp.on_attach(function(client, _)
-            if client.name == "ruff" then
+            if client.name == ruff then
               -- Disable hover in favor of Pyright
               client.server_capabilities.hoverProvider = false
             end


### PR DESCRIPTION
Provide global variable to choose between `ruff` and `ruff_lsp` in accordance to `pyright`/`basedpyright`.

Pinging @arafune for #3057. Are you ok with something like this, so that users can decide which one to use? 
By default, `ruff_lsp` is used unless the user explicitly chooses `ruff` instead. If you would like to incorporate these changes
to your PR yourself, I don't have any problem closing this.