### PR TITLE
fix(extras): Rust-Analyzer cargo option

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -60,7 +60,7 @@ return {
             cargo = {
               allFeatures = true,
               loadOutDirsFromCheck = true,
-              runBuildScripts = true,
+              buildScripts = true,
             },
             -- Add clippy lints for Rust.
             checkOnSave = {

--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -60,7 +60,9 @@ return {
             cargo = {
               allFeatures = true,
               loadOutDirsFromCheck = true,
-              buildScripts = true,
+              buildScripts = {
+                enable = true,
+              },
             },
             -- Add clippy lints for Rust.
             checkOnSave = {


### PR DESCRIPTION
I saw the official manual said this. I thought our configuration was wrong. I fixed it.    
rust-analyzer manual:  
https://rust-analyzer.github.io/manual.html#nvim-lsp