### PR TITLE
Fix native_snippets for vim.snippet api changes

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/native_snippets.lua
+++ b/lua/lazyvim/plugins/extras/coding/native_snippets.lua
@@ -22,7 +22,7 @@ return {
       {
         "<Tab>",
         function()
-          if vim.snippet.jumpable(1) then
+          if vim.snippet.active({direction = 1}) then
             vim.schedule(function()
               vim.snippet.jump(1)
             end)
@@ -47,7 +47,7 @@ return {
       {
         "<S-Tab>",
         function()
-          if vim.snippet.jumpable(-1) then
+          if vim.snippet.active({ direction = -1 }) then
             vim.schedule(function()
               vim.snippet.jump(-1)
             end)


### PR DESCRIPTION
According to this commit [#2856](https://github.com/neovim/neovim/pull/28560) of neovim , fix native_snippets.