### PR TITLE
Say "local map =" in the comment under DO NOT USE THIS!

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -1,7 +1,7 @@
 -- This file is automatically loaded by lazyvim.config.init
 
--- DO NOT USE THIS IN YOU OWN CONFIG!!
--- use `local map = vim.keymap.set` instead
+-- DO NOT USE `LazyVim.safe_keymap_set` IN YOU OWN CONFIG!!
+-- use `vim.keymap.set` instead
 local map = LazyVim.safe_keymap_set
 
 -- better up/down

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -1,7 +1,7 @@
 -- This file is automatically loaded by lazyvim.config.init
 
 -- DO NOT USE THIS IN YOU OWN CONFIG!!
--- use `vim.keymap.set` instead
+-- use `local map = vim.keymap.set` instead
 local map = LazyVim.safe_keymap_set
 
 -- better up/down

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -1,6 +1,6 @@
 -- This file is automatically loaded by lazyvim.config.init
 
--- DO NOT USE `LazyVim.safe_keymap_set` IN YOU OWN CONFIG!!
+-- DO NOT USE `LazyVim.safe_keymap_set` IN YOUR OWN CONFIG!!
 -- use `vim.keymap.set` instead
 local map = LazyVim.safe_keymap_set
 


### PR DESCRIPTION
Really minor change.

Make the warning more clear on what "THIS" is -- LazyVim.safe_keymap_set.  Because when I saw this, it wasn't clear to me what I need to do.

I saw `local map = vim.keymap.set` in someone else's config.