### PR TITLE
fix(neo-tree): correctly set up `cwd`

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -46,15 +46,14 @@ return {
       vim.api.nvim_create_autocmd("BufEnter", {
         group = vim.api.nvim_create_augroup("Neotree_start_directory", { clear = true }),
         desc = "Start Neo-tree with directory",
+        once = true,
         callback = function()
           if package.loaded["neo-tree"] then
-            vim.api.nvim_del_augroup_by_name("Neotree_start_directory")
             return
           else
             local stats = vim.uv.fs_stat(vim.fn.argv(0))
             if stats and stats.type == "directory" then
               require("neo-tree")
-              vim.api.nvim_del_augroup_by_name("Neotree_start_directory")
             end
           end
         end,

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -41,12 +41,24 @@ return {
       vim.cmd([[Neotree close]])
     end,
     init = function()
-      if vim.fn.argc(-1) == 1 then
-        local stat = vim.uv.fs_stat(vim.fn.argv(0))
-        if stat and stat.type == "directory" then
-          require("neo-tree")
-        end
-      end
+      -- FIX: use `autocmd` for lazy-loading neo-tree instead of directly requiring it,
+      -- because `cwd` is not set up properly.
+      vim.api.nvim_create_autocmd("BufEnter", {
+        group = vim.api.nvim_create_augroup("Neotree_start_directory", { clear = true }),
+        desc = "Start Neo-tree with directory",
+        callback = function()
+          if package.loaded["neo-tree"] then
+            vim.api.nvim_del_augroup_by_name("Neotree_start_directory")
+            return
+          else
+            local stats = vim.uv.fs_stat(vim.fn.argv(0))
+            if stats and stats.type == "directory" then
+              require("neo-tree")
+              vim.api.nvim_del_augroup_by_name("Neotree_start_directory")
+            end
+          end
+        end,
+      })
     end,
     opts = {
       sources = { "filesystem", "buffers", "git_status", "document_symbols" },

--- a/lua/lazyvim/util/root.lua
+++ b/lua/lazyvim/util/root.lua
@@ -142,7 +142,10 @@ function M.setup()
     LazyVim.root.info()
   end, { desc = "LazyVim roots for the current buffer" })
 
-  vim.api.nvim_create_autocmd({ "LspAttach", "BufWritePost", "DirChanged" }, {
+  -- FIX: doesn't properly clear cache in neo-tree `set_root` (which should happen presumably on `DirChanged`),
+  -- probably because the event is triggered in the neo-tree buffer, therefore add `BufEnter`
+  -- Maybe this is too frequent on `BufEnter` and something else should be done instead??
+  vim.api.nvim_create_autocmd({ "LspAttach", "BufWritePost", "DirChanged", "BufEnter" }, {
     group = vim.api.nvim_create_augroup("lazyvim_root_cache", { clear = true }),
     callback = function(event)
       M.cache[event.buf] = nil


### PR DESCRIPTION
After taking another look at #3088 and #3090, I remembered another issue about Neo-tree, which used an autocommand to lazy-load it instead of directly requiring it at startup (see [this comment](https://github.com/LazyVim/LazyVim/discussions/2366#discussioncomment-8156257)). 

I then tested again with the initial LazyVim implementation in `init` function and saw that when you do `nvim some_directory/`, then it opens 2 buffers (neo-tree on the left and an empty unnamed buffer on the right). I did `verbose pwd` on both buffers and I saw different results. neo-tree buffer had `[tabpage] some_directory` (the same as the file argument passed when invoking nvim with a directory), but the empty unnamed buffer had `window current_working_directory` (the directory where Neovim was invoked from). Consequentially, if you close neo-tree and open it again it will open in the current working directory where Neovim was invoked from as opposed to where it was initially opened (the directory name of the file argument passed to Neovim). 

After that I tried to lazy-load neo-tree in LazyVim with an autocommand as suggested in the comment that I linked to and another issue at neo-tree repo for correctly hijacking netrw behavior without disabling netrw and saw that the results were different. With lazy-loading neo-tree both neo-tree buffer and the unnamed empty buffer show the same result when doing `verbose pwd`, namely `[tabpage] some_directory` (which is the name of the directory that was passed as file argument while invoking nvim). 

I also saw in Astronvim repo, which was mentioned as working correctly in one of the issues, and saw that instead of deleting the augroup of the autocommand it just uses `return true` as seen [here](https://github.com/AstroNvim/AstroNvim/commit/75458e693aecde45ab8d33cd55649c759e9873f3#diff-588c4f224d969c909997c8b380551855a56900cc105de17971aad31a7c1cc155), but I left the initial deletion of augroup the traditional way, because I honestly don't understand how `return true` accomplishes self-deletion of the augroup.

I also added `BufEnter` to clear the `root.cache`, because for some reason it was not being cleared when doing `set_root` from neo-tree (which i presumed that it should based on `DirChanged` event) and now when doing `set_root` you get the correct directory after closing and opening neo-tree again. Maybe `BufEnter` is triggered too often for this and this could be done differently? Unfortunately, I can't think of a better approach for this with my limited programming knowledge.

I'd appreciate further input from @folke, as I don't understand why directly requiring neo-tree in the `init` function shows 2 different `cwd` in the 2 buffers as opposed to lazy-loading it in an autocommand. 

Edit: the above tests were made with `vim.g.root_spec = { "cwd" }` and `filesystem.bind_to_cwd = true`, as that was what the OPs of the aforementioned issues wanted, I presume.

Edit 2: feel free to remove the comments. I just left them for clarity.