### PR TITLE
fix(ui): don't lazy-load dashboard-nvim

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -346,9 +346,10 @@ return {
       return false
     end,
   },
+
   {
     "nvimdev/dashboard-nvim",
-    event = "VimEnter",
+    lazy = false, -- As https://github.com/nvimdev/dashboard-nvim/pull/450, dashboard-nvim shouldn't be lazy-loaded to properly handle stdin.
     opts = function()
       local logo = [[
            ██╗      █████╗ ███████╗██╗   ██╗██╗   ██╗██╗███╗   ███╗          Z


### PR DESCRIPTION
As https://github.com/nvimdev/dashboard-nvim/pull/450, dashboard-nvim shouldn't be lazy-loaded to properly handle stdin.

Not really sure if this is enough to make dashboard-nvim not lazy-loaded.