### PR TITLE
fix(bufferline): prevent tabline pop-(in/out)

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -56,7 +56,7 @@ return {
   -- tabs, which include filetype icons and close buttons.
   {
     "akinsho/bufferline.nvim",
-    event = "VeryLazy",
+    event = "UIEnter",
     keys = {
       { "<leader>bp", "<Cmd>BufferLineTogglePin<CR>", desc = "Toggle Pin" },
       { "<leader>bP", "<Cmd>BufferLineGroupClose ungrouped<CR>", desc = "Delete Non-Pinned Buffers" },

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -108,7 +108,7 @@ return {
   -- statusline
   {
     "nvim-lualine/lualine.nvim",
-    event = "VeryLazy",
+    event = "UIEnter",
     init = function()
       vim.g.lualine_laststatus = vim.o.laststatus
       if vim.fn.argc(-1) > 0 then


### PR DESCRIPTION
bufferline.nvim updates the showtabline option in its `setup()`, so if showtabline is set to a conflicting value prior to loading bufferline, the user will see it flash in/out as the UI loads. Change the event that loads the plugin from `VeryLazy` to `UIEnter` to avoid this

e.g. set `vim.opt.showtabline = 2` in `lua/config/options.lua` and then open a single file. The tabline will display but only for less than a second