### PR TITLE
feat(mason-lspconfig): allow `opts.ensure_installed` to be taken into account

### DIFF
--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -212,7 +212,14 @@ return {
       end
 
       if have_mason then
-        mlsp.setup({ ensure_installed = ensure_installed, handlers = { setup } })
+        mlsp.setup({
+          ensure_installed = vim.tbl_deep_extend(
+            "force",
+            ensure_installed,
+            LazyVim.opts("mason-lspconfig.nvim").ensure_installed or {}
+          ),
+          handlers = { setup },
+        })
       end
 
       if LazyVim.lsp.get_config("denols") and LazyVim.lsp.get_config("tsserver") then


### PR DESCRIPTION
In `mason-lspconfig` you can specify versions of packages to be installed (i.e eslint@4.8.0). The current `ensure_installed` in `lsp/init.lua` doesn't take that into account, rather only populates `local ensure_installed` with the server names declared in `nvim-lspconfig`. 

This change makes it possible to also take into account the `opts.ensure_installed` of `mason-lspconfig.nvim` in case users want to declare specific versions of packages to be installed.