### PR TITLE
fix(extras): env highlighting with dot extra

### DIFF
--- a/lua/lazyvim/plugins/extras/util/dot.lua
+++ b/lua/lazyvim/plugins/extras/util/dot.lua
@@ -47,6 +47,14 @@ return {
         },
       })
 
+      -- add syntax highlighting for new filetype
+      vim.api.nvim_create_autocmd("FileType", {
+        pattern = "dotenv",
+        callback = function()
+          vim.bo.syntax = "sh"
+        end,
+      })
+
       add("git_config")
 
       if have("hypr") then


### PR DESCRIPTION
There was a small issue that highlighting wasn't working with .env files because they were assigned to a new nvim filetype. This PR fixes that.