### PR TITLE
fix(extras.lang.rust): creates.nvim src option was renamed to completion

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -8,7 +8,7 @@ return {
         "Saecki/crates.nvim",
         event = { "BufRead Cargo.toml" },
         opts = {
-          src = {
+          completion = {
             cmp = { enabled = true },
           },
         },


### PR DESCRIPTION
Recent changes to create.nvim displayed warning.
https://github.com/Saecki/crates.nvim/pull/120

![2024-05-12_17-44](https://github.com/LazyVim/LazyVim/assets/26534710/889def53-fbd3-43f3-9ef2-7e6e9adfdb11)

Renamed `src` to `completion`