### PR TITLE
fix(treesitter-rewrite): add missed local Config

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/treesitter-rewrite.lua
+++ b/lua/lazyvim/plugins/extras/ui/treesitter-rewrite.lua
@@ -1,3 +1,5 @@
+local Config = require("lazyvim.config")
+
 -- backwards compatibility with the old treesitter config for adding custom parsers
 local function patch()
   local parsers = require("nvim-treesitter.parsers")


### PR DESCRIPTION
fix error `...Vim/lua/lazyvim/plugins/extras/ui/treesitter-rewrite.lua:11: attempt to index global 'Config' (a nil value)`