### PR TITLE
fix(refactoring): add label to refactoring key group

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/refactoring.lua
+++ b/lua/lazyvim/plugins/extras/editor/refactoring.lua
@@ -122,4 +122,15 @@ return {
       end
     end,
   },
+
+  -- which key integration
+  {
+    "folke/which-key.nvim",
+    optional = true,
+    opts = {
+      defaults = {
+        ["<leader>r"] = { name = "+refactor" },
+      },
+    },
+  },
 }


### PR DESCRIPTION
This adds a missing label for the key group in the refactoring extra.
