### PR TITLE
fix(util.toggle): correctly toggle `inlay_hints`

### DIFF
--- a/lua/lazyvim/util/toggle.lua
+++ b/lua/lazyvim/util/toggle.lua
@@ -67,7 +67,7 @@ function M.inlay_hints(buf, value)
     ih(buf, value)
   elseif type(ih) == "table" and ih.enable then
     if value == nil then
-      value = not ih.is_enabled(buf)
+      value = not ih.is_enabled({ bufnr = buf or 0 })
     end
     ih.enable(value, { bufnr = buf })
   end


### PR DESCRIPTION
`is_enabled` also accepts a `filter` and when we initially toggle `inlay_hints` on [here](https://github.com/LazyVim/LazyVim/blob/735f5905f85fec0dd5210f2c835597caa5a409fb/lua/lazyvim/plugins/lsp/init.lua#L153), we pass a `bufnr` which sets the `inlay_hints` in the `bufstate` (see [here](https://github.com/neovim/neovim/blob/42aa69b076cb338e20b5b4656771f1873e8930d8/runtime/lua/vim/lsp/inlay_hint.lua#L407-L432)), but when we call `is_enabled` without a filter table the returned result if from the `globalstate` (see [here](https://github.com/neovim/neovim/blob/42aa69b076cb338e20b5b4656771f1873e8930d8/runtime/lua/vim/lsp/inlay_hint.lua#L376-L388)). With `inlay_hints` toggled on by default you have to press `<leader>uh` twice to toggle them off without this change.