### PR TITLE
fix(leap): add label to renamed surround mappings key group

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/leap.lua
+++ b/lua/lazyvim/plugins/extras/editor/leap.lua
@@ -51,6 +51,15 @@ return {
       },
     },
   },
+  {
+    "folke/which-key.nvim",
+    optional = true,
+    opts = {
+      defaults = {
+        ["gz"] = { name = "+surround" },
+      },
+    },
+  },
 
   -- makes some plugins dot-repeatable like leap
   { "tpope/vim-repeat", event = "VeryLazy" },


### PR DESCRIPTION
This adds a missing label for the remapped surround key group in the leap extra.

I was considering adding `["gs"] = { }` to the mappings, but I wasn't certain if this would be necessary or correct for removing the original `gs` key group (which doesn't appear in which-key anyway).