### PR TITLE
fix(yanky): load yanky earlier to avoid losing deleted lines

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/yanky.lua
+++ b/lua/lazyvim/plugins/extras/coding/yanky.lua
@@ -3,6 +3,7 @@ return {
   "gbprod/yanky.nvim",
   recommended = true,
   desc = "Better Yank/Paste",
+  event = "LazyFile",
   opts = {
     highlight = { timer = 150 },
   },


### PR DESCRIPTION
Currently, yanky is only loaded on yank and put operations. This is problematic because if you open a file and start deleting lines (`d<motion>`), you lose them because yanky is not loaded to save them.