### PR TITLE
feat(java): enable inlay hints

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -193,8 +193,9 @@ return {
           local client = vim.lsp.get_client_by_id(args.data.client_id)
           if client and client.name == "jdtls" then
             -- INFO: without this the inlay hints start toggled off by default.
-            -- Maybe because `nvim-jdtls` attaches on a `FileType` event??
-            -- Still with this the inlay hints are toggled on by default
+            -- Probably because `nvim-lspconfig` is not used to set up `nvim-jdtls`
+            -- and `LazyVim.toggle.inlay_hints` doesn't execute, so we have
+            -- to execute it again ourselves in this autocmd in `LspAttach`
             LazyVim.toggle.inlay_hints(args.buf, true)
             local wk = require("which-key")
             wk.register({

--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -162,6 +162,21 @@ return {
           capabilities = LazyVim.has("cmp-nvim-lsp") and require("cmp_nvim_lsp").default_capabilities() or nil,
         }, opts.jdtls)
 
+        if opts.enableInlayHints then
+          local inlayHintsConfig = function()
+            local extendedClientCapabilities = require("jdtls").extendedClientCapabilities
+
+            return {
+              extendedClientCapabilities = extendedClientCapabilities,
+              parameterNames = {
+                enabled = "all",
+              },
+            }
+          end
+
+          extend_or_override(config, inlayHintsConfig())
+        end
+
         -- Existing server will be reused if the root_dir matches.
         require("jdtls").start_or_attach(config)
         -- not need to require("jdtls.setup").add_commands(), start automatically adds commands

--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -118,6 +118,15 @@ return {
         dap = { hotcodereplace = "auto", config_overrides = {} },
         dap_main = {},
         test = true,
+        settings = {
+          java = {
+            inlayHints = {
+              parameterNames = {
+                enabled = "all",
+              },
+            },
+          },
+        },
       }
     end,
     config = function()
@@ -158,22 +167,10 @@ return {
           init_options = {
             bundles = bundles,
           },
+          settings = opts.settings,
           -- enable CMP capabilities
           capabilities = LazyVim.has("cmp-nvim-lsp") and require("cmp_nvim_lsp").default_capabilities() or nil,
         }, opts.jdtls)
-
-        if opts.enableInlayHints == true then
-          local extendedClientCapabilities = require("jdtls").extendedClientCapabilities
-
-          extend_or_override(config, {
-            extendedClientCapabilities = extendedClientCapabilities,
-            inlayHints = {
-              parameterNames = {
-                enabled = "all",
-              },
-            },
-          })
-        end
 
         -- Existing server will be reused if the root_dir matches.
         require("jdtls").start_or_attach(config)
@@ -195,6 +192,10 @@ return {
         callback = function(args)
           local client = vim.lsp.get_client_by_id(args.data.client_id)
           if client and client.name == "jdtls" then
+            -- INFO: without this the inlay hints start toggled off by default.
+            -- Maybe because `nvim-jdtls` attaches on a `FileType` event??
+            -- Still with this the inlay hints are toggled on by default
+            LazyVim.toggle.inlay_hints(args.buf, true)
             local wk = require("which-key")
             wk.register({
               ["<leader>cx"] = { name = "+extract" },

--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -162,7 +162,7 @@ return {
           capabilities = LazyVim.has("cmp-nvim-lsp") and require("cmp_nvim_lsp").default_capabilities() or nil,
         }, opts.jdtls)
 
-        if opts.enableInlayHints then
+        if opts.enableInlayHints == true then
           local inlayHintsConfig = function()
             local extendedClientCapabilities = require("jdtls").extendedClientCapabilities
 

--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -167,8 +167,10 @@ return {
 
           extend_or_override(config, {
             extendedClientCapabilities = extendedClientCapabilities,
-            parameterNames = {
-              enabled = "all",
+            inlayHints = {
+              parameterNames = {
+                enabled = "all",
+              },
             },
           })
         end

--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -163,18 +163,14 @@ return {
         }, opts.jdtls)
 
         if opts.enableInlayHints == true then
-          local inlayHintsConfig = function()
-            local extendedClientCapabilities = require("jdtls").extendedClientCapabilities
+          local extendedClientCapabilities = require("jdtls").extendedClientCapabilities
 
-            return {
-              extendedClientCapabilities = extendedClientCapabilities,
-              parameterNames = {
-                enabled = "all",
-              },
-            }
-          end
-
-          extend_or_override(config, inlayHintsConfig())
+          extend_or_override(config, {
+            extendedClientCapabilities = extendedClientCapabilities,
+            parameterNames = {
+              enabled = "all",
+            },
+          })
         end
 
         -- Existing server will be reused if the root_dir matches.


### PR DESCRIPTION
I apologize if my Lua code is "bad", but I haven't really coded in Lua before, but this will make sure that the consumer can toggle inlay hints for java development by providing the opts:

```lua
opts.enableInlayHints = true
```

**EDIT**
enabled by default.
