### PR TITLE
feat(vscode): enable more compatible plugins

### DIFF
--- a/lua/lazyvim/plugins/extras/vscode.lua
+++ b/lua/lazyvim/plugins/extras/vscode.lua
@@ -3,17 +3,20 @@ if not vim.g.vscode then
 end
 
 local enabled = {
+  "dial.nvim",
   "flit.nvim",
   "lazy.nvim",
   "leap.nvim",
   "mini.ai",
   "mini.comment",
+  "mini.move",
   "mini.pairs",
   "mini.surround",
   "nvim-treesitter",
   "nvim-treesitter-textobjects",
   "nvim-ts-context-commentstring",
   "vim-repeat",
+  "yanky.nvim",
   "LazyVim",
 }
 


### PR DESCRIPTION
Enable dial.nvim, yanky.nvim, and mini.move, all extras which are compatible with vscode.