### PR TITLE
fix(bufferline): unpin bufferline with 0.9.x compatibility

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -56,7 +56,6 @@ return {
   -- tabs, which include filetype icons and close buttons.
   {
     "akinsho/bufferline.nvim",
-    commit = vim.fn.has("nvim-0.10") == 0 and "73540cb95f8d95aa1af3ed57713c6720c78af915" or nil,
     event = "VeryLazy",
     keys = {
       { "<leader>bp", "<Cmd>BufferLineTogglePin<CR>", desc = "Toggle Pin" },


### PR DESCRIPTION
Pin is no longer needed as bufferline added 0.9.x compatibility.