### PR TITLE
fix: extras.lang.python to enable venv select keys on ft

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -127,7 +127,7 @@ return {
         },
       })
     end,
-    keys = { { "<leader>cv", "<cmd>:VenvSelect<cr>", desc = "Select VirtualEnv" } },
+    keys = { { "<leader>cv", "<cmd>:VenvSelect<cr>", desc = "Select VirtualEnv", ft = "python" } },
   },
   {
     "hrsh7th/nvim-cmp",


### PR DESCRIPTION
Update the Python extra for the `linux-cultist/venv-selector.nvim` plugin so that the key map to select a virtual environment is only present (in which-key) when the filetype of the buffer is `python`.

This is mostly a nice UI thing for when I'm not working in a Python project, so that which-key doesn't show me an option that is not currently relevant.