### PR TITLE
feat(neo-tree): add h/l navigation and open file support

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -87,6 +87,26 @@ return {
             end,
             desc = "Open with System Application",
           },
+          ["h"] = function(state)
+            local node = state.tree:get_node()
+            if node:has_children() and node:is_expanded() then
+              state.commands.toggle_node(state)
+            else
+              require("neo-tree.ui.renderer").focus_node(state, node:get_parent_id())
+            end
+          end,
+          ["l"] = function(state)
+            local node = state.tree:get_node()
+            if node:has_children() then
+              if not node:is_expanded() then
+                state.commands.toggle_node(state)
+              else
+                require("neo-tree.ui.renderer").focus_node(state, node:get_child_ids()[1])
+              end
+            else
+              state.commands.open(state)
+            end
+          end,
         },
       },
       default_component_configs = {


### PR DESCRIPTION
Taken from https://github.com/nvim-neo-tree/neo-tree.nvim/wiki/Tips#navigation-with-hjkl and adjusted slightly to allow opening files.

`h`:
- if directory is opened -> close it
- if directory is closed or focused item is file -> focus parent directory

`l`:
- if focused item is file -> open it
- if focused item is directory and is closed -> open it
- if focused item is directory and is opened -> move focus to the first child


Unrelated but I think the `{}` are unnecessary for the `Y` and `O` keymaps but I didn't touch them.

EDIT: Force pushed an update to enable this for all source selectors (i.e. buffer/git), not filesystem only. (see https://github.com/nvim-neo-tree/neo-tree.nvim/discussions/163#discussioncomment-4747082)