### PR TITLE
Python Venv Selector: Switch to newer regexp branch

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -113,20 +113,17 @@ return {
   },
   {
     "linux-cultist/venv-selector.nvim",
+    branch = "regexp", -- Use this branch for the new version
     cmd = "VenvSelect",
-    opts = function(_, opts)
-      if LazyVim.has("nvim-dap-python") then
-        opts.dap_enabled = true
-      end
-      return vim.tbl_deep_extend("force", opts, {
-        name = {
-          "venv",
-          ".venv",
-          "env",
-          ".env",
+    opts = {
+      settings = {
+        options = {
+          notify_user_on_venv_activation = true,
         },
-      })
-    end,
+      },
+    },
+    --  Call config for python files and load the cached venv automatically
+    ft = "python", 
     keys = { { "<leader>cv", "<cmd>:VenvSelect<cr>", desc = "Select VirtualEnv", ft = "python" } },
   },
   {


### PR DESCRIPTION
The regex branch belongs to the rewrite of the plugin. The changes brought in the new branch are quoted below.

<blockquote>
Why did you rewrite the plugin?

Because the current code has grown from supporting only simple venvs to lots of different venv managers. Each one works in a slightly different way, and the current code has lots of conditional logic to try and figure out what to do in certain situations. It made it difficult to change something without breaking something else. And it made it difficult to add features in a clean way.

This rewrite is about giving you as a user the power to add your own searches, and have anything you want show up in the telescope viewer. If its the path to a python executable, the plugin will attempt to activate it. Note that your LSP server must be running for this to happen, so you need to have a python file opened in the editor.
</blockquote>

The changes in the config reflecting the rewrite are listed below.
1. The plugin automatically checks if dap is enabled, so we can remove the block that checks it.
2. Since the plugin checks for all the folders in the current directory, no need to extend it manually to custom venv names.
3. Change the opts from a function to a Lua table to simplify it.
4. Load the plugin for Python filetype to load the cached venv environment automatically.