### PR TITLE
feat(ui): add codewindow (minimap)

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/codewindow-nvim.lua
+++ b/lua/lazyvim/plugins/extras/ui/codewindow-nvim.lua
@@ -1,0 +1,37 @@
+return {
+  {
+    "gorbit99/codewindow.nvim",
+    keys = {
+      {
+        "<leader>um",
+        function()
+          require("codewindow").toggle_minimap()
+        end,
+        desc = "Toggle minimap",
+      },
+    },
+    lazy = false,
+    opts = {
+      auto_enable = true,
+      minimap_width = 20,
+      width_multiplier = 2,
+      screen_bounds = "background",
+      window_border = "none",
+      relative = "win",
+      exclude_filetypes = {
+        "dashboard",
+        "neo-tree",
+        "lazy",
+        "lazyterm",
+        "mason",
+        "help",
+        "checkhealth",
+        "lspinfo",
+        "noice",
+        "Trouble",
+        "fish",
+        "zsh",
+      },
+    },
+  },
+}


### PR DESCRIPTION
[codewindow](https://github.com/gorbit99/codewindow.nvim) is a very light and unobtrusive minimap.

Of the many I tried this does the best job at both being a great minimap and not getting in a coders way.

I have also added keymappings `<leader>um` to toggle it.