### PR TITLE
fix(lsp): properly get buffer for dynamic capabilities

### DIFF
--- a/lua/lazyvim/util/lsp.lua
+++ b/lua/lazyvim/util/lsp.lua
@@ -44,7 +44,7 @@ function M.setup()
     local ret = register_capability(err, res, ctx)
     local client = vim.lsp.get_client_by_id(ctx.client_id)
     if client then
-      for buffer in ipairs(client.attached_buffers) do
+      for buffer in pairs(client.attached_buffers) do
         vim.api.nvim_exec_autocmds("User", {
           pattern = "LspDynamicCapability",
           data = { client_id = client.id, buffer = buffer },


### PR DESCRIPTION
When getting `buffer` from `client.attached_buffers` with `ipairs`, the loop and the `LspDynamicCapability` autocmds may not run at all because buffer numbers may not be sequential numbers starting at 1. In such case, Goto Definition (`gd`), Rename (`<leader> cr`) and inlay hints are missing when jdtls is being loaded for the first time.

Getting `buffer` with `pairs` would fix the issue.