### PR TITLE
fix(vimtex): suppress treesitter warning

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -36,6 +36,7 @@ return {
     config = function()
       vim.g.vimtex_mappings_disable = { ["n"] = { "K" } } -- disable `K` as it conflicts with LSP hover
       vim.g.vimtex_quickfix_method = vim.fn.executable("pplatex") == 1 and "pplatex" or "latexlog"
+      vim.g.vimtex_syntax_enabled = false -- suppress treesitter warning
     end,
   },
 


### PR DESCRIPTION
Currently, vimtex warns:

    syntax highlighting is controlled by Treesitter

Explicitly disabling syntax higlighting disables the warning.