### PR TITLE
feat(lsp): additional reference keymaps

### DIFF
--- a/lua/lazyvim/plugins/lsp/keymaps.lua
+++ b/lua/lazyvim/plugins/lsp/keymaps.lua
@@ -42,6 +42,8 @@ function M.get()
       },
       { "]]", function() LazyVim.lsp.words.jump(vim.v.count1) end, has = "documentHighlight", desc = "Next Reference" },
       { "[[", function() LazyVim.lsp.words.jump(-vim.v.count1) end, has = "documentHighlight", desc = "Prev Reference" },
+      { "<a-n>", function() LazyVim.lsp.words.jump(vim.v.count1) end, has = "documentHighlight", desc = "Next Reference" },
+      { "<a-p>", function() LazyVim.lsp.words.jump(-vim.v.count1) end, has = "documentHighlight", desc = "Prev Reference" },
     }
   if LazyVim.has("inc-rename.nvim") then
     M._keys[#M._keys + 1] = {


### PR DESCRIPTION
After getting rid of `vim-illluminate`, we lost the keymaps `<a-n>` and `<a-p>` for reference jumping. This might be a personal preference but I miss these mappings as they are easier to spam/repeat compared to `[[` and `]]`.

EDIT: Future note: With illuminate, pressing `<a-n>` while on the last reference, it would jump to the first one. This was a nice feature that is not supported by the `lsp.words.jump` method. Would be nice to have it.