### PR TITLE
fix(util.toggle): In accordance with #3202

### DIFF
--- a/lua/lazyvim/util/toggle.lua
+++ b/lua/lazyvim/util/toggle.lua
@@ -69,7 +69,7 @@ function M.inlay_hints(buf, value)
     if value == nil then
       value = not ih.is_enabled({ bufnr = buf or 0 })
     end
-    ih.enable(value, { bufnr = buf })
+    ih.enable(value, { bufnr = buf or 0 })
   end
 end
 


### PR DESCRIPTION
With this change we can disable inlay hints only in a single buffer without disabling them globally (as the current state is).

Some things to consider:
  - Do we want to consider both `bufstate` and `globalstate`? In this case, maybe we should not merge this and  just add 2 keymaps, one where we pass `buffer` (`bufstate`) and one where we don't pass anything (`globalstate`)? But in `nvim-lspconfig` spec we pass `buffer` to toggle them on (`bufstate`), but I guess that only has effect on the `is_enabled` when checking for the value.
  - Or just don't merge this and keep enabling/disabling globally only.