### PR TITLE
fix: remove lazygit log gl keymap when on gitui

### DIFF
--- a/lua/lazyvim/plugins/extras/util/gitui.lua
+++ b/lua/lazyvim/plugins/extras/util/gitui.lua
@@ -26,6 +26,7 @@ return {
         once = true,
         callback = function()
           pcall(vim.keymap.del, "n", "<leader>gf")
+          pcall(vim.keymap.del, "n", "<leader>gl")
         end,
       })
     end,


### PR DESCRIPTION
![image](https://github.com/LazyVim/LazyVim/assets/8222059/d0692efd-d0d6-4369-afa4-07808edf520e)

When using gitui, remove the gl keymap which is not remapped