### PR TITLE
Fix(extra: typescript): vtsls server experimental settings

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -36,14 +36,14 @@ return {
             complete_function_calls = true,
             vtsls = {
               enableMoveToFileCodeAction = true,
-            },
-            typescript = {
-              updateImportsOnFileMove = { enabled = "always" },
               experimental = {
                 completion = {
                   enableServerSideFuzzyMatch = true,
                 },
               },
+            },
+            typescript = {
+              updateImportsOnFileMove = { enabled = "always" },
               suggest = {
                 completeFunctionCalls = true,
               },


### PR DESCRIPTION
Based on [vtsls schema](https://github.com/yioneko/vtsls/blob/bd2df5a2d45cbc087e4fe285ec7c7396fd96e9cf/packages/service/configuration.schema.json#L1092), experimental setting should be vtsls property not typescript.

```json
"vtsls.experimental.completion.enableServerSideFuzzyMatch": {
      "default": false,
      "type": "boolean",
      "description": "Execute fuzzy match of completion items on server side. Enable this will help filter out useless completion items from tsserver."
    },
```

```lua
vtsls = {
    enableMoveToFileCodeAction = true,
    experimental = {
      completion = {
        enableServerSideFuzzyMatch = true,
      },
    },
  },
```