### PR TITLE
fix(extras): `underline = false` for setting diagnostics

### DIFF
--- a/lua/lazyvim/util/extras.lua
+++ b/lua/lazyvim/util/extras.lua
@@ -200,7 +200,7 @@ function X:update()
       diag.lnum = diag.row - 1
       return diag
     end, self.diag),
-    { signs = false, virtual_text = true }
+    { signs = false, virtual_text = true, underline = false }
   )
 end
 


### PR DESCRIPTION
Similar to https://github.com/folke/lazy.nvim/commit/ea7b9c3c3fd9026e1a5ae27950585df9a42ccd5b# 

I only noticed this, because in my main config I have some Extras not managed by `LazyExtras`.