### PR TITLE
fix(rust): let rustaceans.nvim setup rust_analyzer

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -103,6 +103,11 @@ return {
   {
     "neovim/nvim-lspconfig",
     opts = {
+      setup = {
+        rust_analyzer = function()
+          return true
+        end,
+      },
       servers = {
         taplo = {
           keys = {


### PR DESCRIPTION
fix this warning
```
   Warn  11:52:45 PM notify.warn nvim-lspconfig.rust_analyzer has been setup.
This will likely lead to conflicts with the rustaceanvim LSP client.
See ':h rustaceanvim.mason'
```
fix taken from https://github.com/mrcjkb/rustaceanvim/blob/master/doc/mason.txt