### PR TITLE
fix(extras.lang.vue) missing typescript autocomplete in .vue files

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/vue.lua
+++ b/lua/lazyvim/plugins/extras/lang/vue.lua
@@ -39,12 +39,10 @@ return {
         },
       })
       LazyVim.extend(opts.servers.vtsls.settings.vtsls.tsserver.globalPlugins, {
-        {
-          name = "@vue/typescript-plugin",
-          location = vue_typescript_plugin,
-          languages = { "vue" },
-          configNamespace = "typescript",
-        },
+        name = "@vue/typescript-plugin",
+        location = vue_typescript_plugin,
+        languages = { "vue" },
+        configNamespace = "typescript",
       })
     end,
 

--- a/lua/lazyvim/plugins/extras/lang/vue.lua
+++ b/lua/lazyvim/plugins/extras/lang/vue.lua
@@ -36,13 +36,21 @@ return {
             "typescript.tsx",
             "vue",
           },
+          settings = {
+            vtsls = {
+              tsserver = {
+                globalPlugins = {
+                  {
+                    name = "@vue/typescript-plugin",
+                    location = vue_typescript_plugin,
+                    languages = { "vue" },
+                    configNamespace = "typescript",
+                  },
+                },
+              },
+            },
+          },
         },
-      })
-
-      LazyVim.extend(opts.servers.vtsls, "settings.vtsls.tsserver.globalPlugins", {
-        name = "@vue/typescript-plugin",
-        location = vue_typescript_plugin,
-        languages = { "vue" },
       })
     end,
   },

--- a/lua/lazyvim/plugins/extras/lang/vue.lua
+++ b/lua/lazyvim/plugins/extras/lang/vue.lua
@@ -18,9 +18,9 @@ return {
   {
     "neovim/nvim-lspconfig",
     opts = function(_, opts)
-      local vue_typescript_plugin = require("mason-registry").get_package("vue-language-server"):get_install_path()
-        .. "/node_modules/@vue/language-server"
-        .. "/node_modules/@vue/typescript-plugin"
+      local vue_typescript_plugin = require("mason-registry")
+        .get_package("vue-language-server")
+        :get_install_path() .. "/node_modules/@vue/language-server" .. "/node_modules/@vue/typescript-plugin"
 
       opts.servers = vim.tbl_deep_extend("force", opts.servers, {
         volar = {},
@@ -36,22 +36,18 @@ return {
             "typescript.tsx",
             "vue",
           },
-          settings = {
-            vtsls = {
-              tsserver = {
-                globalPlugins = {
-                  {
-                    name = "@vue/typescript-plugin",
-                    location = vue_typescript_plugin,
-                    languages = { "vue" },
-                    configNamespace = "typescript",
-                  },
-                },
-              },
-            },
-          },
+        },
+      })
+      LazyVim.extend(opts.servers.vtsls.settings.vtsls.tsserver.globalPlugins, {
+        {
+          name = "@vue/typescript-plugin",
+          location = vue_typescript_plugin,
+          languages = { "vue" },
+          configNamespace = "typescript",
         },
       })
     end,
+
+
   },
 }


### PR DESCRIPTION
The existing Vue extra was not properly configuring vtsls to use the globalPlugin: `@vue/typescript-plugin`

This meant that even though the language server could load and provide hover info, it wouldn't provide any sort of autocomplete.

This commit fixes that by moving the `@vue/typescript-plugin` config to the vtsls settings and adding the line `configNamespace = "typescript"`. The fix does not work without the mentioned line.

I dont understand the intention behind LazyVim.extend() in the original code, given that the function takes two arguments and not three as provided. It also doesn't seem necessary to use any extend function to begin with either.