### PR TITLE
fix(trouble): don't enable symbols keymap when `outline.nvim` enabled

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/outline.lua
+++ b/lua/lazyvim/plugins/extras/editor/outline.lua
@@ -1,4 +1,12 @@
 return {
+  -- Disable `<leader>cs` keymap so it doesn't conflict with `outline.nvim`
+  {
+    "folke/trouble.nvim",
+    optional = true,
+    keys = {
+      { "<leader>cs", false },
+    },
+  },
   {
     "hedyhli/outline.nvim",
     keys = { { "<leader>cs", "<cmd>Outline<cr>", desc = "Toggle Outline" } },


### PR DESCRIPTION
Fixes #3406 