### PR TITLE
feat(editor-extra): Add inc-rename

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/inc-rename.lua
+++ b/lua/lazyvim/plugins/extras/editor/inc-rename.lua
@@ -1,14 +1,19 @@
 return {
+
+  -- Rename with cmdpreview
+  recommended = true,
+  desc = "Incremental LSP renaming based on Neovim's command-preview feature",
   {
     "smjonas/inc-rename.nvim",
     cmd = "IncRename",
-    config = true,
+    opts = {},
   },
+
+  -- LSP Keymaps
   {
     "neovim/nvim-lspconfig",
-    init = function()
+    opts = function()
       local keys = require("lazyvim.plugins.lsp.keymaps").get()
-
       keys[#keys + 1] = {
         "<leader>cr",
         function()
@@ -16,9 +21,18 @@ return {
           return ":" .. inc_rename.config.cmd_name .. " " .. vim.fn.expand("<cword>")
         end,
         expr = true,
-        desc = "Rename",
+        desc = "Rename (inc-rename.nvim)",
         has = "rename",
       }
     end,
+  },
+
+  --- Noice integration
+  {
+    "folke/noice.nvim",
+    optional = true,
+    opts = {
+      presets = { inc_rename = true },
+    },
   },
 }

--- a/lua/lazyvim/plugins/extras/editor/inc-rename.lua
+++ b/lua/lazyvim/plugins/extras/editor/inc-rename.lua
@@ -1,0 +1,24 @@
+return {
+  {
+    "smjonas/inc-rename.nvim",
+    cmd = "IncRename",
+    config = true,
+  },
+  {
+    "neovim/nvim-lspconfig",
+    init = function()
+      local keys = require("lazyvim.plugins.lsp.keymaps").get()
+
+      keys[#keys + 1] = {
+        "<leader>cr",
+        function()
+          local inc_rename = require("inc_rename")
+          return ":" .. inc_rename.config.cmd_name .. " " .. vim.fn.expand("<cword>")
+        end,
+        expr = true,
+        desc = "Rename",
+        has = "rename",
+      }
+    end,
+  },
+}

--- a/lua/lazyvim/plugins/lsp/keymaps.lua
+++ b/lua/lazyvim/plugins/lsp/keymaps.lua
@@ -26,6 +26,7 @@ function M.get()
       { "<leader>cc", vim.lsp.codelens.run, desc = "Run Codelens", mode = { "n", "v" }, has = "codeLens" },
       { "<leader>cC", vim.lsp.codelens.refresh, desc = "Refresh & Display Codelens", mode = { "n" }, has = "codeLens" },
       { "<leader>cR", LazyVim.lsp.rename_file, desc = "Rename File", mode ={"n"}, has = { "workspace/didRenameFiles", "workspace/willRenameFiles" } },
+      { "<leader>cr", vim.lsp.buf.rename, desc = "Rename", has = "rename" },
       {
         "<leader>cA",
         function()
@@ -50,20 +51,7 @@ function M.get()
       { "<a-p>", function() LazyVim.lsp.words.jump(-vim.v.count1, true) end, has = "documentHighlight",
         desc = "Prev Reference", cond = function() return LazyVim.lsp.words.enabled end },
     }
-  if LazyVim.has("inc-rename.nvim") then
-    M._keys[#M._keys + 1] = {
-      "<leader>cr",
-      function()
-        local inc_rename = require("inc_rename")
-        return ":" .. inc_rename.config.cmd_name .. " " .. vim.fn.expand("<cword>")
-      end,
-      expr = true,
-      desc = "Rename",
-      has = "rename",
-    }
-  else
-    M._keys[#M._keys + 1] = { "<leader>cr", vim.lsp.buf.rename, desc = "Rename", has = "rename" }
-  end
+
   return M._keys
 end
 

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -299,7 +299,6 @@ return {
         bottom_search = true,
         command_palette = true,
         long_message_to_split = true,
-        inc_rename = true,
       },
     },
     -- stylua: ignore


### PR DESCRIPTION
Not sure how to safely move the LSP keymap into this file `<leader>cr`...

Using

`LazyVim.lsp.on_attach(function(client, buffer)`?

but how do I ensure that the function in the config for this extra gets called after the default lsp keymap one?