### PR TITLE
fix(lsp): Enable using `deno.enablePaths` in denols settings

### DIFF
--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -244,8 +244,11 @@ return {
       if LazyVim.lsp.is_enabled("denols") and LazyVim.lsp.is_enabled("vtsls") then
         local is_deno = require("lspconfig.util").root_pattern("deno.json", "deno.jsonc")
         LazyVim.lsp.disable("vtsls", is_deno)
-        LazyVim.lsp.disable("denols", function(root_dir)
-          return not is_deno(root_dir)
+        LazyVim.lsp.disable("denols", function(root_dir, config)
+          if not is_deno(root_dir) then
+            config.settings.deno.enable = false
+          end
+          return false
         end)
       end
     end,


### PR DESCRIPTION
denols LSP client has support for enabling using Deno in _parts_ of a codebase using the `deno.enablePaths` setting. For example, the following setting would enable denols in all files matching the `./deno-files` path:

```lua
settings = {
  deno = {
    enablePaths = { "./deno-files" }
  }
}
```

If we return `true` in the callback to `LazyVim.lsp.disable("denols")` denols will be completely disabled and can never pick up the `deno.enablePaths` setting.

In this PR I've changed it so that we – when a Deno root can't be found, instead disable Deno using its LSP client setting `deno.enable`. This allows denols to still pick up `deno.enablePaths`, and that setting will then take precedence over `deno.enable` for the files matched.

I'm not sure this is the best way way to please let me know if there's a better way.