### PR TITLE
fix(toggle): Restore width/height values when closing while maximized is toggled on

### DIFF
--- a/lua/lazyvim/util/toggle.lua
+++ b/lua/lazyvim/util/toggle.lua
@@ -88,6 +88,17 @@ function M.maximize()
     vim.o.winwidth = 999
     vim.o.winheight = 999
   end
+  -- `QuitPre` seems to be executed even if we quit a normal window, so we don't want that
+  -- `VimLeavePre` might be another consideration? Not sure about differences between the 2
+  vim.api.nvim_create_autocmd("ExitPre", {
+    once = true,
+    group = vim.api.nvim_create_augroup("lazyvim_restore_max_exit_pre", { clear = true }),
+    desc = "Restore width/height when close Neovim while maximized",
+    callback = function()
+      vim.o.winwidth = M._maximized.width
+      vim.o.winheight = M._maximized.height
+    end,
+  })
 end
 
 setmetatable(M, {


### PR DESCRIPTION
When closing Neovim with a window maximized toggled on, the session manager saves the value `999` for both `height/width`. So, next time Neovim starts it starts with a really weird layout because of that. I believe, since `toggle.maximize()` is intended as a toggle rather a permanent state, we should restore the `height/width` values to the ones before `maximize` was toggled on when quiting Neovim with a maximised window. 

Also, I'm most certain we don't want to use `QuitPre` event, but am unsure if we should choose `VimLeavePre` instead of `ExitPre`. Please make necessary changes according to what you think might be the best approach.