### PR TITLE
fix(extra): fix lost ensured_installed issue after release

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/angular.lua
+++ b/lua/lazyvim/plugins/extras/lang/angular.lua
@@ -11,9 +11,8 @@ return {
   {
     "nvim-treesitter",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "angular", "scss" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "angular", "scss" })
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/lang/astro.lua
+++ b/lua/lazyvim/plugins/extras/lang/astro.lua
@@ -16,9 +16,8 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "astro" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "astro" })
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -17,9 +17,8 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "cpp" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "cpp" })
     end,
   },
 
@@ -121,9 +120,8 @@ return {
       "williamboman/mason.nvim",
       optional = true,
       opts = function(_, opts)
-        if type(opts.ensure_installed) == "table" then
-          vim.list_extend(opts.ensure_installed, { "codelldb" })
-        end
+        opts.ensure_installed = opts.ensure_installed or {}
+        vim.list_extend(opts.ensure_installed, { "codelldb" })
       end,
     },
     opts = function()

--- a/lua/lazyvim/plugins/extras/lang/cmake.lua
+++ b/lua/lazyvim/plugins/extras/lang/cmake.lua
@@ -8,9 +8,8 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "cmake" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "cmake" })
     end,
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/docker.lua
+++ b/lua/lazyvim/plugins/extras/lang/docker.lua
@@ -8,9 +8,8 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "dockerfile" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "dockerfile" })
     end,
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/haskell.lua
+++ b/lua/lazyvim/plugins/extras/lang/haskell.lua
@@ -10,9 +10,8 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "haskell" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "haskell" })
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/lang/json.lua
+++ b/lua/lazyvim/plugins/extras/lang/json.lua
@@ -10,9 +10,8 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "json5" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "json5" })
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/lang/omnisharp.lua
+++ b/lua/lazyvim/plugins/extras/lang/omnisharp.lua
@@ -10,9 +10,8 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "c_sharp" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "c_sharp" })
     end,
   },
   {
@@ -42,9 +41,8 @@ return {
   {
     "williamboman/mason.nvim",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "netcoredbg", "csharpier" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "netcoredbg", "csharpier" })
     end,
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -25,9 +25,8 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "ninja", "rst" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "ninja", "rst" })
     end,
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/r.lua
+++ b/lua/lazyvim/plugins/extras/lang/r.lua
@@ -60,9 +60,8 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "r", "rnoweb" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "r", "rnoweb" })
     end,
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/scala.lua
+++ b/lua/lazyvim/plugins/extras/lang/scala.lua
@@ -8,9 +8,8 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "scala" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "scala" })
     end,
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/svelte.lua
+++ b/lua/lazyvim/plugins/extras/lang/svelte.lua
@@ -16,9 +16,8 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "svelte" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "svelte" })
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/lang/terraform.lua
+++ b/lua/lazyvim/plugins/extras/lang/terraform.lua
@@ -9,12 +9,11 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, {
-          "terraform",
-          "hcl",
-        })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, {
+        "terraform",
+        "hcl",
+      })
     end,
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -20,9 +20,8 @@ return {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
       opts.highlight = opts.highlight or {}
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "bibtex" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "bibtex" })
       if type(opts.highlight.disable) == "table" then
         vim.list_extend(opts.highlight.disable, { "latex" })
       else

--- a/lua/lazyvim/plugins/extras/lang/vue.lua
+++ b/lua/lazyvim/plugins/extras/lang/vue.lua
@@ -12,9 +12,8 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "vue" })
-      end
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "vue" })
     end,
   },
 


### PR DESCRIPTION
I found an issue after the 12.5.0 release where lists were not being merged in the type(opts.ensure_installed) == “table” condition.