### PR TITLE
fix(extra.lang.angular): treesitter not enabled for angular templates

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/angular.lua
+++ b/lua/lazyvim/plugins/extras/lang/angular.lua
@@ -20,12 +20,7 @@ return {
           [".*%.container%.html"] = "angular.html",
         },
       })
-      vim.api.nvim_create_autocmd("FileType", {
-        pattern = "angular.html",
-        callback = function()
-          vim.treesitter.language.register("angular", "angular.html")
-        end,
-      })
+      vim.treesitter.language.register("angular", "angular.html")
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/lang/angular.lua
+++ b/lua/lazyvim/plugins/extras/lang/angular.lua
@@ -14,6 +14,18 @@ return {
       if type(opts.ensure_installed) == "table" then
         vim.list_extend(opts.ensure_installed, { "angular", "scss" })
       end
+      vim.filetype.add({
+        pattern = {
+          [".*%.component%.html"] = "angular.html",
+          [".*%.container%.html"] = "angular.html",
+        },
+      })
+      vim.api.nvim_create_autocmd("FileType", {
+        pattern = "angular.html",
+        callback = function()
+          vim.treesitter.language.register("angular", "angular.html")
+        end,
+      })
     end,
   },
 


### PR DESCRIPTION
## Problem
Treesitter was not working in angular html templates after enabling `lang.angular` extra.

## Solution
Added a change recommeded by angular treesitter developer to enable treesitter for components and containers.

### Reference to recommendation in treesitter docs
[Reference to the recommendation for this hack](https://github.com/dlvandenberg/tree-sitter-angular?tab=readme-ov-file#filetype).