### PR TITLE
fix(extra-lang-angular): fix angular lsp not working for angular.html filetype

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/angular.lua
+++ b/lua/lazyvim/plugins/extras/lang/angular.lua
@@ -32,7 +32,13 @@ return {
     "neovim/nvim-lspconfig",
     opts = {
       servers = {
-        angularls = {},
+        angularls = {
+          filetypes = {
+            -- default filetypes
+            "typescript", "html", "typescriptreact", "typescript.tsx",
+            -- file type added in order to enable treesitter
+            "angular.html" },
+        },
       },
       setup = {
         angularls = function()

--- a/lua/lazyvim/plugins/extras/lang/angular.lua
+++ b/lua/lazyvim/plugins/extras/lang/angular.lua
@@ -35,9 +35,13 @@ return {
         angularls = {
           filetypes = {
             -- default filetypes
-            "typescript", "html", "typescriptreact", "typescript.tsx",
+            "typescript",
+            "html",
+            "typescriptreact",
+            "typescript.tsx",
             -- file type added in order to enable treesitter
-            "angular.html" },
+            "angular.html",
+          },
         },
       },
       setup = {


### PR DESCRIPTION
## Problem

After adding a new `angular.html` filetype in #3469 , angular LSP stopped working for the files marked with this filetype.

## Solution

Add `angular.html` to filetypes the LSP is enabled for.


Thank you @BBboy01 for catching this issue :heart: