### PR TITLE
fix(extra-lang-angular): re-fix angular html treesitter

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/angular.lua
+++ b/lua/lazyvim/plugins/extras/lang/angular.lua
@@ -14,13 +14,12 @@ return {
       if type(opts.ensure_installed) == "table" then
         vim.list_extend(opts.ensure_installed, { "angular", "scss" })
       end
-      vim.filetype.add({
-        pattern = {
-          [".*%.component%.html"] = "angular.html",
-          [".*%.container%.html"] = "angular.html",
-        },
+      vim.api.nvim_create_autocmd("BufRead", {
+        pattern = { "*.component.html", "*.container.html" },
+        callback = function()
+          vim.treesitter.start(nil, "angular")
+        end,
       })
-      vim.treesitter.language.register("angular", "angular.html")
     end,
   },
 


### PR DESCRIPTION
This was previously attemped to be fixed by https://github.com/LazyVim/LazyVim/pull/3469, which caused an issue with angular LSP.
The PR was reverted as mentioned in https://github.com/LazyVim/LazyVim/pull/3485.

This PR implements suggestion by @folke, which fixes treesitter without breaking LSP.