### PR TITLE
fix(prettier): correctly recognize patterns in condition

### DIFF
--- a/lua/lazyvim/plugins/extras/formatting/prettier.lua
+++ b/lua/lazyvim/plugins/extras/formatting/prettier.lua
@@ -58,7 +58,7 @@ return {
             end
             if enabled[ctx.filename] == nil then
               enabled[ctx.filename] = vim.fs.find(function(name, path)
-                return name:match("^%.prettierrc%.") or name:match("^prettier%.config%.")
+                return name:match("^%.prettierrc%.*.*") or name:match("^prettier%.config%.*.*")
               end, { path = ctx.filename, upward = true })[1] ~= nil
             end
             return enabled[ctx.filename]


### PR DESCRIPTION
Without it, it shows in `ConformInfo` that the formatter is available but the condition failed. I experimented with the pattern in `vim.fs.find` to see if it could find the `.prettierrc` at the root of my projects directory.