### PR TITLE
fix(markdown): missing markdown-toc in mason

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/markdown.lua
+++ b/lua/lazyvim/plugins/extras/lang/markdown.lua
@@ -19,7 +19,7 @@ return {
     "williamboman/mason.nvim",
     opts = function(_, opts)
       opts.ensure_installed = opts.ensure_installed or {}
-      vim.list_extend(opts.ensure_installed, { "markdownlint" })
+      vim.list_extend(opts.ensure_installed, { "markdownlint", "markdown-toc" })
     end,
   },
   {


### PR DESCRIPTION
missing `markdown-toc` in ensure installed for `extra/markdown`