### PR TITLE
fix(editor): telescope init error when trouble.nvim is disabled

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -240,7 +240,9 @@ return {
     opts = function()
       local actions = require("telescope.actions")
 
-      local open_with_trouble = require("trouble.sources.telescope").open
+      local open_with_trouble = function(...)
+        return require("trouble.sources.telescope").open(...)
+      end
       local find_files_no_ignore = function()
         local action_state = require("telescope.actions.state")
         local line = action_state.get_current_line()


### PR DESCRIPTION
I got this error message when opening telescope.

```
Failed to run `config` for telescope.nvim

...l/share/nvim/lazy/LazyVim/lua/lazyvim/plugins/editor.lua:241: module 'trouble.sources.telescope' not found:
^Ino field package.preload['trouble.sources.telescope']
...
```

After investigating it, the reason was I have `trouble.nvim` disabled but the default base `opts` function is loading it.
I tried wrapping it with a function to lazy load the `trouble.nvim` module and it worked in my local setup.