### PR TITLE
fix(extra-lang-angular): add BufNew event to attach angular treesitter

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/angular.lua
+++ b/lua/lazyvim/plugins/extras/lang/angular.lua
@@ -14,7 +14,7 @@ return {
       if type(opts.ensure_installed) == "table" then
         vim.list_extend(opts.ensure_installed, { "angular", "scss" })
       end
-      vim.api.nvim_create_autocmd("BufEnter", {
+      vim.api.nvim_create_autocmd({ "BufReadPost", "BufNewFile" }, {
         pattern = { "*.component.html", "*.container.html" },
         callback = function()
           vim.treesitter.start(nil, "angular")

--- a/lua/lazyvim/plugins/extras/lang/angular.lua
+++ b/lua/lazyvim/plugins/extras/lang/angular.lua
@@ -14,7 +14,7 @@ return {
       if type(opts.ensure_installed) == "table" then
         vim.list_extend(opts.ensure_installed, { "angular", "scss" })
       end
-      vim.api.nvim_create_autocmd("BufRead", {
+      vim.api.nvim_create_autocmd("BufEnter", {
         pattern = { "*.component.html", "*.container.html" },
         callback = function()
           vim.treesitter.start(nil, "angular")


### PR DESCRIPTION
## Problem

Sometimes angular treesitter didn't get started, e.g. when creating a new file.

## Solution

- Add `BufNew` event to attach angular treesitter.
- Change `BufRead` to `BufReadPost` for better readability.

### Related Neovim docs
- [BufRead / BufReadPost docs](https://neovim.io/doc/user/autocmd.html#BufRead)
- [BufNew](https://neovim.io/doc/user/autocmd.html#BufNew)

