### PR TITLE
fix(cmp): don't enable `snippets` source without `nvim-snippets`

### DIFF
--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -111,7 +111,9 @@ return {
           return LazyVim.cmp.expand(item.body)
         end,
       }
-      table.insert(opts.sources, { name = "snippets" })
+      if LazyVim.has("nvim-snippets") then
+        table.insert(opts.sources, { name = "snippets" })
+      end
     end,
     keys = {
       {


### PR DESCRIPTION
Make it easier, so if users decide to disable `nvim-snippets`, they don't have to remove the `snippets` source manually in their config.