### PR TITLE
fix(typescript): clean up configuration of the vscode dap extension

### DIFF
--- a/lua/lazyvim/plugins/extras/dap/core.lua
+++ b/lua/lazyvim/plugins/extras/dap/core.lua
@@ -87,16 +87,11 @@ return {
 
       -- setup dap config by VsCode launch.json file
       local vscode = require("dap.ext.vscode")
-      local _filetypes = require("mason-nvim-dap.mappings.filetypes")
-      local filetypes = vim.tbl_deep_extend("force", _filetypes, {
-        ["node"] = { "javascriptreact", "typescriptreact", "typescript", "javascript" },
-        ["pwa-node"] = { "javascriptreact", "typescriptreact", "typescript", "javascript" },
-      })
       local json = require("plenary.json")
       vscode.json_decode = function(str)
         return vim.json.decode(json.json_strip_comments(str))
       end
-      vscode.load_launchjs(nil, filetypes)
+      vscode.load_launchjs()
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/dap/core.lua
+++ b/lua/lazyvim/plugins/extras/dap/core.lua
@@ -91,7 +91,6 @@ return {
       vscode.json_decode = function(str)
         return vim.json.decode(json.json_strip_comments(str))
       end
-      vscode.load_launchjs()
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -220,7 +220,13 @@ return {
         end
       end
 
-      for _, language in ipairs({ "typescript", "javascript", "typescriptreact", "javascriptreact" }) do
+      local js_filetypes = { "typescript", "javascript", "typescriptreact", "javascriptreact" }
+
+      local vscode = require("dap.ext.vscode")
+      vscode.type_to_filetypes["node"] = js_filetypes
+      vscode.type_to_filetypes["pwa-node"] = js_filetypes
+
+      for _, language in ipairs(js_filetypes) do
         if not dap.configurations[language] then
           dap.configurations[language] = {
             {


### PR DESCRIPTION
`mason-nvim-dap.nvim` adds it's own adapter filetype mappings to the vscode extension in `nvim-dap` (as of https://github.com/jay-babu/mason-nvim-dap.nvim/pull/129)

This also moves the type mappings for the `pwa-node` and `node` adapters to where they are defined in the typescript pack.

Now that the default internal type mappings are configured we can rely on the automatic loading of the `.vscode/launch.json` that `nvim-dap` does