### PR TITLE
fix(neo-tree): use last window for preview

### DIFF
--- a/doc/LazyVim.txt
+++ b/doc/LazyVim.txt
@@ -1,4 +1,4 @@
-*LazyVim.txt*           For Neovim >= 0.9.0          Last change: 2024 June 09
+*LazyVim.txt*           For Neovim >= 0.9.0          Last change: 2024 June 10
 
 ==============================================================================
 Table of Contents                                  *LazyVim-table-of-contents*

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -89,6 +89,7 @@ return {
             end,
             desc = "Open with System Application",
           },
+          ["P"] = { "toggle_preview", config = { use_float = false } },
         },
       },
       default_component_configs = {


### PR DESCRIPTION
Similar to "trouble.nvim" I want the preview to open in the last active window. Currently the neo-tree preview opens in a floating window, which (to me) doesn’t look very good.

What do you think about doing preview window the same everywhere (trouble & neo-tree)?

## Before:

https://github.com/LazyVim/LazyVim/assets/3313023/7d7c21c9-158d-40ef-82f2-62e0dc795555

## After:

https://github.com/LazyVim/LazyVim/assets/3313023/bafc5bae-20cb-4dd1-8e40-1358ada573d9

