### PR TITLE
fix(fzf): correctly pass `opts.cwd` when `root=false`

### DIFF
--- a/lua/lazyvim/util/pick.lua
+++ b/lua/lazyvim/util/pick.lua
@@ -34,13 +34,13 @@ function M.open(command, opts)
     opts.cwd = LazyVim.root({ buf = opts.buf })
   end
 
-  local cwd = opts.cwd or vim.uv.cwd()
+  opts.cwd = opts.cwd or vim.uv.cwd()
   if command == "auto" then
     command = "files"
     if
-      vim.uv.fs_stat(cwd .. "/.git")
-      and not vim.uv.fs_stat(cwd .. "/.ignore")
-      and not vim.uv.fs_stat(cwd .. "/.rgignore")
+      vim.uv.fs_stat(opts.cwd .. "/.git")
+      and not vim.uv.fs_stat(opts.cwd .. "/.ignore")
+      and not vim.uv.fs_stat(opts.cwd .. "/.rgignore")
     then
       command = "git_files"
       opts.show_untracked = opts.show_untracked ~= false


### PR DESCRIPTION
## What is this PR for?

Currently, `util.pick` does not pass correctly `opts.cwd` to `M._open` when `root = false`. The value of `vim.uv.getcwd` gets assigned to `local cwd` and then used to evaluate if `git_files` should be used. 

I noticed this when using `<leader>fR` (Recent cwd) which returned the same results as `<leader>fr`. The other pickers just start
the search in the directory of the current buffer if no `cwd` is passed, so not passing `opts.cwd` when `root = false` didn't affect their behavior.

If this is intended behavior to rely on the fact that most pickers start the search in the directory of the current buffer, then probably we should discard this PR, but remove `<leader>fR` (Recent cwd) from the commands since it doesn't provide different results than `<leader>fr`.

## Does this PR fix an existing issue?

No

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
