### PR TITLE
feat(copilot-chat): use fzf-lua if enabled in extras

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/copilot-chat.lua
+++ b/lua/lazyvim/plugins/extras/coding/copilot-chat.lua
@@ -100,6 +100,35 @@ return {
     },
   },
 
+  {
+    "ibhagwan/fzf-lua",
+    optional = true,
+    keys = {
+      -- Show help actions with fzf-lua (if installed in extras)
+      {
+        "<leader>ad",
+        function()
+          local actions = require("CopilotChat.actions")
+          local help = actions.help_actions()
+          if not help then
+            LazyVim.warn("No diagnostics found on the current line")
+            return
+          end
+          require("CopilotChat.integrations.fzflua").pick(help)
+        end,
+        desc = "Diagnostic Help (CopilotChat)",
+      },
+      -- Show prompts actions with fzf-lua (if installed in extras)
+      {
+        "<leader>ap",
+        function()
+          local actions = require("CopilotChat.actions")
+          require("CopilotChat.integrations.fzflua").pick(actions.prompt_actions())
+        end,
+        desc = "Prompt Actions (CopilotChat)",
+      },
+    },
+  },
   -- Edgy integration
   {
     "folke/edgy.nvim",


### PR DESCRIPTION
Adds the abiltiy for fzf-lua to be used as a picker for these copilot chat actions if it was enabled in LazyExtras

## What is this PR for?

This adds keybinds that exist currently for copilot-chat and Telescope but with the addition of fzf-lua as an extra, I noticed we needed the ability for the user to take advantage of them with FzfLua.

## Does this PR fix an existing issue?

No

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
