### PR TITLE
fix(fzf): disable mini.indentscope in fzf-lua buffer

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/mini-indentscope.lua
+++ b/lua/lazyvim/plugins/extras/ui/mini-indentscope.lua
@@ -14,17 +14,18 @@ return {
     init = function()
       vim.api.nvim_create_autocmd("FileType", {
         pattern = {
-          "help",
           "alpha",
           "dashboard",
-          "neo-tree",
-          "Trouble",
-          "trouble",
+          "fzf",
+          "help",
           "lazy",
+          "lazyterm",
           "mason",
+          "neo-tree",
           "notify",
           "toggleterm",
-          "lazyterm",
+          "Trouble",
+          "trouble",
         },
         callback = function()
           vim.b.miniindentscope_disable = true


### PR DESCRIPTION
## What is this PR for?

If `fzf-lua` and `mini.indentscope` are enabled together, the indent line created by `indentscope` makes the fzf window hard and confusing to work with

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

PS: also sorted the file list.

## Does this PR fix an existing issue?

I don't think there's an existing issue for this.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
