### PR TITLE
feat(omnisharp): add more handlers

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/omnisharp.lua
+++ b/lua/lazyvim/plugins/extras/lang/omnisharp.lua
@@ -62,9 +62,30 @@ return {
             {
               "gd",
               function()
-                require("omnisharp_extended").telescope_lsp_definitions()
+                require("omnisharp_extended").telescope_lsp_definitions({ reuse_win = true })
               end,
               desc = "Goto Definition",
+            },
+            {
+              "gr",
+              function()
+                require("omnisharp_extended").telescope_lsp_references()
+              end,
+              desc = "References",
+            },
+            {
+              "gI",
+              function()
+                require("omnisharp_extended").telescope_lsp_implementation({ reuse_win = true })
+              end,
+              desc = "Goto Implementation",
+            },
+            {
+              "gy",
+              function()
+                require("omnisharp_extended").telescope_lsp_type_definition({ reuse_win = true })
+              end,
+              desc = "Goto T[y]pe Definition",
             },
           },
           enable_roslyn_analyzers = true,

--- a/lua/lazyvim/plugins/extras/lang/omnisharp.lua
+++ b/lua/lazyvim/plugins/extras/lang/omnisharp.lua
@@ -46,7 +46,16 @@ return {
         omnisharp = {
           handlers = {
             ["textDocument/definition"] = function(...)
-              return require("omnisharp_extended").handler(...)
+              return require("omnisharp_extended").definition_handler(...)
+            end,
+            ["textDocument/typeDefinition"] = function(...)
+              return require("omnisharp_extended").type_definition_handler(...)
+            end,
+            ["textDocument/references"] = function(...)
+              return require("omnisharp_extended").references_handler(...)
+            end,
+            ["textDocument/implementation"] = function(...)
+              return require("omnisharp_extended").implementation_handler(...)
             end,
           },
           keys = {


### PR DESCRIPTION
## What is this PR for?

adds handlers for `textDocument/definition`, `textDocument/typeDefinition`, `textDocument/references`, `textDocument/implementation` from [`omnisharp_extended`](https://github.com/Hoffs/omnisharp-extended-lsp.nvim), 
this allows for `vim.lsp.buf.{definition,implementation,type_definition,references}()`

this however does not override / add to `telescope.builtins` (e.g. `require("telescope.builtin").lsp_implementations
`) (*haven't figured that one out yet*) 
> test `gd` with `Console.WriteLine`

as such i'v just overridden the keymaps `gd` `gr` `gI` `gy` with the telescope keymaps from [`omnisharp_extended`](https://github.com/Hoffs/omnisharp-extended-lsp.nvim)

## Does this PR fix an existing issue?

<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
