### PR TITLE
fix(tailwind): use default init_options if none are provided

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/tailwind.lua
+++ b/lua/lazyvim/plugins/extras/lang/tailwind.lua
@@ -42,6 +42,15 @@ return {
 
           -- Add additional filetypes
           vim.list_extend(opts.filetypes, opts.filetypes_include or {})
+
+          -- Add init_options
+          opts.init_options = opts.init_options or {}
+          opts.init_options.userLanguages = vim.tbl_deep_extend(
+            "force",
+            {},
+            opts.init_options.userLanguages or {},
+            tw.default_config.init_options.userLanguages
+          )
         end,
       },
     },


### PR DESCRIPTION
## What is this PR for?

The tailwind extra currently doesn't work with elixir ex/heex files. Using the default `init_options` fixes this issue.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
