### PR TITLE
fix(pick): move some leftovers from `editor.lua` to `editor.telescope`

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -1,6 +1,3 @@
-local have_make = vim.fn.executable("make") == 1
-local have_cmake = vim.fn.executable("cmake") == 1
-
 return {
 
   -- file explorer

--- a/lua/lazyvim/plugins/extras/editor/telescope.lua
+++ b/lua/lazyvim/plugins/extras/editor/telescope.lua
@@ -1,3 +1,6 @@
+local have_make = vim.fn.executable("make") == 1
+local have_cmake = vim.fn.executable("cmake") == 1
+
 ---@type LazyPicker
 local picker = {
   name = "telescope",


### PR DESCRIPTION
## What is this PR for?

`have_make` and `have_cmake` were left over at `/lua/plugins/editor.lua`, so move them to `extras.editor.telescope` instead.

## Does this PR fix an existing issue?

No

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
