### PR TITLE
fix(issue template): repro.lua didn't work

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
         -- install plugins
         local plugins = {
           "folke/tokyonight.nvim",
-          "folke/LazyVim",
+          { "LazyVim/LazyVim", import = "lazyvim.plugins" },
           -- add any other plugins here
         }
         require("lazy").setup(plugins, {


### PR DESCRIPTION
## What is this PR for?

repro.lua didn't work. at least i don't think it's the intended behaviour.
it installed lazy.vim, lazy.nvim, tokyonight.
but didn't actually load lazyvim, and so none of it's plugins config etc...

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
