### PR TITLE
feat(extras): improve ruby extra by letting user chose

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/ruby.lua
+++ b/lua/lazyvim/plugins/extras/lang/ruby.lua
@@ -11,9 +11,16 @@ return {
   },
   {
     "neovim/nvim-lspconfig",
+    ---@class PluginLspOpts
     opts = {
+      ---@type lspconfig.options
       servers = {
-        solargraph = {},
+        -- disable solargraph from auto running when you open ruby files
+        solargraph = {
+          autostart = false,
+        },
+        -- ruby_lsp will be automatically installed with mason and loaded with lspconfig
+        ruby_lsp = {},
       },
     },
   },

--- a/lua/lazyvim/plugins/extras/lang/ruby.lua
+++ b/lua/lazyvim/plugins/extras/lang/ruby.lua
@@ -45,6 +45,10 @@ return {
     },
   },
   {
+    "williamboman/mason.nvim",
+    opts = { ensure_installed = { "erb-formatter", "erb-lint" } },
+  },
+  {
     "mfussenegger/nvim-dap",
     optional = true,
     dependencies = {

--- a/lua/lazyvim/plugins/extras/lang/ruby.lua
+++ b/lua/lazyvim/plugins/extras/lang/ruby.lua
@@ -6,6 +6,10 @@ if lazyvim_docs then
 end
 
 local lsp = vim.g.lazyvim_ruby_lsp or "ruby_lsp"
+if vim.fn.has("nvim-0.10") == 0 then
+  -- ruby_lsp does not work well with Neovim < 0.10
+  lsp = vim.g.lazyvim_ruby_lsp or "solarpath"
+end
 local formatter = vim.g.lazyvim_ruby_formatter or "rubocop"
 
 return {

--- a/lua/lazyvim/plugins/extras/lang/ruby.lua
+++ b/lua/lazyvim/plugins/extras/lang/ruby.lua
@@ -8,7 +8,7 @@ end
 local lsp = vim.g.lazyvim_ruby_lsp or "ruby_lsp"
 if vim.fn.has("nvim-0.10") == 0 then
   -- ruby_lsp does not work well with Neovim < 0.10
-  lsp = vim.g.lazyvim_ruby_lsp or "solarpath"
+  lsp = vim.g.lazyvim_ruby_lsp or "solargraph"
 end
 local formatter = vim.g.lazyvim_ruby_formatter or "rubocop"
 

--- a/lua/lazyvim/plugins/extras/lang/ruby.lua
+++ b/lua/lazyvim/plugins/extras/lang/ruby.lua
@@ -1,3 +1,13 @@
+if lazyvim_docs then
+  -- LSP Server to use for Ruby.
+  -- Set to "solargraph" to use solargraph instead of ruby_lsp.
+  vim.g.lazyvim_ruby_lsp = "ruby_lsp"
+  vim.g.lazyvim_ruby_formatter = "rubocop"
+end
+
+local lsp = vim.g.lazyvim_ruby_lsp or "ruby_lsp"
+local formatter = vim.g.lazyvim_ruby_formatter or "rubocop"
+
 return {
   recommended = function()
     return LazyVim.extras.wants({
@@ -15,12 +25,18 @@ return {
     opts = {
       ---@type lspconfig.options
       servers = {
-        -- disable solargraph from auto running when you open ruby files
-        solargraph = {
-          autostart = false,
+        ruby_lsp = {
+          enabled = lsp == "ruby_lsp",
         },
-        -- ruby_lsp will be automatically installed with mason and loaded with lspconfig
-        ruby_lsp = {},
+        solargraph = {
+          enabled = lsp == "solargraph",
+        },
+        rubocop = {
+          enabled = formatter == "rubocop",
+        },
+        standardrb = {
+          enabled = formatter == "standardrb",
+        },
       },
     },
   },

--- a/lua/lazyvim/plugins/extras/lang/ruby.lua
+++ b/lua/lazyvim/plugins/extras/lang/ruby.lua
@@ -51,6 +51,16 @@ return {
     },
   },
   {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        ruby = { formatter },
+        eruby = { "erb-format" },
+      },
+    },
+  },
+  {
     "nvim-neotest/neotest",
     optional = true,
     dependencies = {


### PR DESCRIPTION
## What is this PR for?

Shopify started working on its own LSP (https://github.com/Shopify/ruby-lsp) and it performs way better than Solargraph which has a lot of limitations. This paired with sorbet gives better IntelliSense when navigating the code.

This PR follows the same approach as Python and lets the user configure through vim.g options the lsp and formatter for ruby, without overriding any configuration.

## Does this PR fix an existing issue?

One caveat though is that RubyLsp does not work very well with NeoVim < 0.10 https://github.com/Shopify/ruby-lsp/blob/main/EDITORS.md#neovim

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
