### PR TITLE
fix(vue): can not inc-rename

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/vue.lua
+++ b/lua/lazyvim/plugins/extras/lang/vue.lua
@@ -19,7 +19,13 @@ return {
     "neovim/nvim-lspconfig",
     opts = {
       servers = {
-        volar = {},
+        volar = {
+          init_options = {
+            vue = {
+              hybridMode = false,
+            },
+          },
+        },
         vtsls = {},
       },
     },


### PR DESCRIPTION
can not inc-rename when volar is enabled.

After the configuration in commit was added, the inc-rename operation returned to normal.

I suspect that volar's Hybrid mode affects the rename operation.

https://github.com/vuejs/language-tools?tab=readme-ov-file#none-hybrid-modesimilar-to-takeover-mode-configuration-requires-vuelanguage-server-version-207