### PR TITLE
fix(lang): incorporate latest changes from `rustaceanvim`

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -65,11 +65,7 @@ return {
               },
             },
             -- Add clippy lints for Rust.
-            checkOnSave = {
-              allFeatures = true,
-              command = "clippy",
-              extraArgs = { "--no-deps" },
-            },
+            checkOnSave = true,
             procMacro = {
               enable = true,
               ignored = {


### PR DESCRIPTION
## What is this PR for?

After recent changes in `rustaceanvim` in https://github.com/mrcjkb/rustaceanvim/pull/403, `checkOnSave` is supposed to be boolean and the table that we were passing to `checkOnSave` previously should be passed to `check` instead. I left the `check` table undefined, because the options that we were passing to `checkOnSave` before are the default ones being passed to `check`. So, only if the user wants to change something should he change the values of the `check` table according to what he wants.

## Does this PR fix an existing issue?

No
## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
