### PR TITLE
fix(elixir): add missing lspconfig

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/elixir.lua
+++ b/lua/lazyvim/plugins/extras/lang/elixir.lua
@@ -6,6 +6,14 @@ return {
     })
   end,
   {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        elixirls = {},
+      },
+    },
+  },
+  {
     "nvim-treesitter/nvim-treesitter",
     opts = { ensure_installed = { "elixir", "heex", "eex" } },
   },


### PR DESCRIPTION
## What is this PR for?
add missing elixir lspconfig

## Does this PR fix an existing issue?

lspconfig is missing for elixir and since mason was removed in https://github.com/LazyVim/LazyVim/commit/f8268faa7c705cca7047fbaef5984905b47a7324, elixirls is no longer automatically installed.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
