### PR TITLE
fix(egdy): do not add panes for not enabled neo-tree sources

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/edgy.lua
+++ b/lua/lazyvim/plugins/extras/ui/edgy.lua
@@ -67,24 +67,6 @@ return {
           },
           { title = "Neotest Summary", ft = "neotest-summary" },
           {
-            title = "Neo-Tree Git",
-            ft = "neo-tree",
-            filter = function(buf)
-              return vim.b[buf].neo_tree_source == "git_status"
-            end,
-            pinned = true,
-            open = "Neotree position=right git_status",
-          },
-          {
-            title = "Neo-Tree Buffers",
-            ft = "neo-tree",
-            filter = function(buf)
-              return vim.b[buf].neo_tree_source == "buffers"
-            end,
-            pinned = true,
-            open = "Neotree position=top buffers",
-          },
-          {
             title = "Neo-Tree Other",
             ft = "neo-tree",
             filter = function(buf)
@@ -112,6 +94,32 @@ return {
           end,
         },
       }
+
+      -- only add neo-tree sources if they are enabled in config
+      if vim.list_contains(LazyVim.opts("neo-tree").sources, "git_status") then
+        table.insert(opts.left, 3, {
+          title = "Neo-Tree Git",
+          ft = "neo-tree",
+          filter = function(buf)
+            return vim.b[buf].neo_tree_source == "git_status"
+          end,
+          pinned = true,
+          open = "Neotree position=right git_status",
+        })
+      end
+
+      if vim.list_contains(LazyVim.opts("neo-tree").sources, "buffers") then
+        table.insert(opts.left, 3, {
+          title = "Neo-Tree Buffers",
+          ft = "neo-tree",
+          filter = function(buf)
+            return vim.b[buf].neo_tree_source == "buffers"
+          end,
+          pinned = true,
+          open = "Neotree position=top buffers",
+        })
+      end
+
       for _, pos in ipairs({ "top", "bottom", "left", "right" }) do
         opts[pos] = opts[pos] or {}
         table.insert(opts[pos], {

--- a/lua/lazyvim/plugins/extras/ui/edgy.lua
+++ b/lua/lazyvim/plugins/extras/ui/edgy.lua
@@ -96,18 +96,6 @@ return {
       }
 
       -- only add neo-tree sources if they are enabled in config
-      if vim.list_contains(LazyVim.opts("neo-tree").sources, "git_status") then
-        table.insert(opts.left, 3, {
-          title = "Neo-Tree Git",
-          ft = "neo-tree",
-          filter = function(buf)
-            return vim.b[buf].neo_tree_source == "git_status"
-          end,
-          pinned = true,
-          open = "Neotree position=right git_status",
-        })
-      end
-
       if vim.list_contains(LazyVim.opts("neo-tree").sources, "buffers") then
         table.insert(opts.left, 3, {
           title = "Neo-Tree Buffers",
@@ -117,6 +105,18 @@ return {
           end,
           pinned = true,
           open = "Neotree position=top buffers",
+        })
+      end
+
+      if vim.list_contains(LazyVim.opts("neo-tree").sources, "git_status") then
+        table.insert(opts.left, 3, {
+          title = "Neo-Tree Git",
+          ft = "neo-tree",
+          filter = function(buf)
+            return vim.b[buf].neo_tree_source == "git_status"
+          end,
+          pinned = true,
+          open = "Neotree position=right git_status",
         })
       end
 


### PR DESCRIPTION
## What is this PR for?

When the user disables a specific neo-tree source (git_status or buffers), the panes are still created but throw an error when the user tries to open them

**NB**: This is currently not functional because `LazyVim.opts` is returning an empty table instead of the neo-tree opts. I'm hoping someone can give me a hand with this little problem

## Does this PR fix an existing issue?

<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
