### PR TITLE
fix(pick): remove the unused commands attribute

### DIFF
--- a/lua/lazyvim/util/pick.lua
+++ b/lua/lazyvim/util/pick.lua
@@ -20,11 +20,6 @@ local M = setmetatable({}, {
 ---@type LazyPicker?
 M.picker = nil
 
----@type table<string, string>
-M.commands = {
-  files = "find_files",
-}
-
 ---@param picker LazyPicker
 function M.register(picker)
   -- this only happens when using :LazyExtras


### PR DESCRIPTION
## What is this PR for?
When we register a picker, such as a Telescope picker or a fzf-lua picker, 

we use commands within their own picker. For example, we use M.picker.commands instead of M.pick.commands.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Does this PR fix an existing issue?
no

<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
