### PR TITLE
feat(rust): more keymaps

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -44,13 +44,12 @@ return {
     ft = { "rust" },
     opts = {
       server = {
+        -- stylua: ignore
         on_attach = function(_, bufnr)
-          vim.keymap.set("n", "<leader>cR", function()
-            vim.cmd.RustLsp("codeAction")
-          end, { desc = "Code Action", buffer = bufnr })
-          vim.keymap.set("n", "<leader>dr", function()
-            vim.cmd.RustLsp("debuggables")
-          end, { desc = "Rust Debuggables", buffer = bufnr })
+          vim.keymap.set("n", "<leader>cR", function() vim.cmd.RustLsp("codeAction") end, { desc = "Code Action (Rust)", buffer = bufnr })
+          vim.keymap.set("n", "<leader>ce", function() vim.cmd.RustLsp("expandMacro") end, { desc = "Expand Macro (Rust)", buffer = bufnr })
+          vim.keymap.set("n", "<leader>co", function() vim.cmd.RustLsp("openDocs") end, { desc = "Open Docs (Rust)", buffer = bufnr })
+          vim.keymap.set("n", "<leader>dr", function() vim.cmd.RustLsp("debuggables") end, { desc = "Debuggables (Rust)", buffer = bufnr })
         end,
         default_settings = {
           -- rust-analyzer language server configuration

--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -46,6 +46,7 @@ return {
       server = {
         -- stylua: ignore
         on_attach = function(_, bufnr)
+          vim.keymap.set("n", "K", function() vim.cmd.RustLsp({"hover", "actions"}) end, { desc = "Hover (Rust)", buffer = bufnr })
           vim.keymap.set("n", "<leader>ce", function() vim.cmd.RustLsp("expandMacro") end, { desc = "Expand Macro (Rust)", buffer = bufnr })
           vim.keymap.set("n", "<leader>co", function() vim.cmd.RustLsp("openDocs") end, { desc = "Open Docs (Rust)", buffer = bufnr })
           vim.keymap.set("n", "<leader>cO", function() vim.cmd.RustLsp("openCargo") end, { desc = "Open Cargo.toml (Rust)", buffer = bufnr })

--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -50,7 +50,7 @@ return {
           vim.keymap.set("n", "<leader>co", function() vim.cmd.RustLsp("openDocs") end, { desc = "Open Docs (Rust)", buffer = bufnr })
           vim.keymap.set("n", "<leader>cO", function() vim.cmd.RustLsp("openCargo") end, { desc = "Open Cargo.toml (Rust)", buffer = bufnr })
           vim.keymap.set("n", "<leader>cp", function() vim.cmd.RustLsp("parentModule") end, { desc = "Open Parent Module (Rust)", buffer = bufnr })
-          vim.keymap.set("n", "<leader>dr", function() vim.cmd.RustLsp("debuggables") end, { desc = "Debuggables (Rust)", buffer = bufnr })
+          vim.keymap.set("n", "<leader>dR", function() vim.cmd.RustLsp("debuggables") end, { desc = "Debuggables (Rust)", buffer = bufnr })
         end,
         default_settings = {
           -- rust-analyzer language server configuration

--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -46,9 +46,10 @@ return {
       server = {
         -- stylua: ignore
         on_attach = function(_, bufnr)
-          vim.keymap.set("n", "<leader>cR", function() vim.cmd.RustLsp("codeAction") end, { desc = "Code Action (Rust)", buffer = bufnr })
           vim.keymap.set("n", "<leader>ce", function() vim.cmd.RustLsp("expandMacro") end, { desc = "Expand Macro (Rust)", buffer = bufnr })
           vim.keymap.set("n", "<leader>co", function() vim.cmd.RustLsp("openDocs") end, { desc = "Open Docs (Rust)", buffer = bufnr })
+          vim.keymap.set("n", "<leader>cO", function() vim.cmd.RustLsp("openCargo") end, { desc = "Open Cargo.toml (Rust)", buffer = bufnr })
+          vim.keymap.set("n", "<leader>cp", function() vim.cmd.RustLsp("parentModule") end, { desc = "Open Parent Module (Rust)", buffer = bufnr })
           vim.keymap.set("n", "<leader>dr", function() vim.cmd.RustLsp("debuggables") end, { desc = "Debuggables (Rust)", buffer = bufnr })
         end,
         default_settings = {


### PR DESCRIPTION
Add some extra keybinds for rust:

- `<leader>co` for `:RustLsp openDocs` 
- `<leader>ce` for `:RustLsp expandMacro`

I was also considering changing the current binding for `<leader>cR`, which conflicts with the default Rename File binding. Any suggestions for alternatives?
