### PR TITLE
refactor(util): use available get_plugin() function

### DIFF
--- a/lua/lazyvim/util/init.lua
+++ b/lua/lazyvim/util/init.lua
@@ -117,7 +117,7 @@ end
 
 ---@param name string
 function M.opts(name)
-  local plugin = require("lazy.core.config").spec.plugins[name]
+  local plugin = M.get_plugin(name)
   if not plugin then
     return {}
   end


### PR DESCRIPTION
## What is this PR for?

Small refactor to use the already available `get_plugin()` function.

## Does this PR fix an existing issue?

No.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
