### PR TITLE
feat(extras): allow using intelephense instead of phpactor in php extras

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/php.lua
+++ b/lua/lazyvim/plugins/extras/lang/php.lua
@@ -1,3 +1,11 @@
+if lazyvim_docs then
+  -- LSP Server to use for PHP.
+  -- Set to "intelephense" to use intelephense instead of phpactor.
+  vim.g.lazyvim_php_lsp = "intelephense"
+end
+
+local lsp = vim.g.lazyvim_php_lsp or "phpactor"
+
 return {
   recommended = {
     ft = "php",
@@ -13,7 +21,15 @@ return {
     "neovim/nvim-lspconfig",
     opts = {
       servers = {
-        phpactor = {},
+        phpactor = {
+          enabled = lsp == "phpactor",
+        },
+        intelephense = {
+          enabled = lsp == "intelephense",
+        },
+        [lsp] = {
+          enabled = true,
+        },
       },
     },
   },


### PR DESCRIPTION
## What is this PR for?

- Allows setting intelephense instead of phpactor for PHP's LSP

## Does this PR fix an existing issue?

No. But I personally use intelephesen myself and when researching on how to use the PHP extras but swap phpactor (too verbose, imo) for intelephense, I found this [comment here](https://github.com/LazyVim/LazyVim/pull/3397#issuecomment-2141950186) which suggested making it configurable like the Python extras. That's what I'm doing here.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
