### PR TITLE
fix(conform): `lsp_format` breaking changes

### DIFF
--- a/lua/lazyvim/plugins/formatting.lua
+++ b/lua/lazyvim/plugins/formatting.lua
@@ -66,7 +66,7 @@ return {
           timeout_ms = 3000,
           async = false, -- not recommended to change
           quiet = false, -- not recommended to change
-          lsp_fallback = true, -- not recommended to change
+          lsp_format = "fallback", -- not recommended to change
         },
         ---@type table<string, conform.FormatterUnit[]>
         formatters_by_ft = {


### PR DESCRIPTION
## What is this PR for?

`conform.nvim` had breaking changes, that renamed `lsp_fallback` to `lsp_format` as can be seen [here](https://github.com/stevearc/conform.nvim/commit/9228b2ff4efd58b6e081defec643bf887ebadff6)

## Does this PR fix an existing issue?

  Fixes #3706

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
