### PR TITLE
fix(statuscolumn): `%r` deprecated in nightly and `%l` handles everything

### DIFF
--- a/lua/lazyvim/util/ui.lua
+++ b/lua/lazyvim/util/ui.lua
@@ -140,10 +140,14 @@ function M.statuscolumn()
   local is_num = vim.wo[win].number
   local is_relnum = vim.wo[win].relativenumber
   if (is_num or is_relnum) and vim.v.virtnum == 0 then
-    if vim.v.relnum == 0 then
-      components[2] = is_num and "%l" or "%r" -- the current line
+    if vim.fn.has("nvim-0.11") == 1 then
+      components[2] = "%l" -- 0.11 handles both the current and other lines with %l
     else
-      components[2] = is_relnum and "%r" or "%l" -- other lines
+      if vim.v.relnum == 0 then
+        components[2] = is_num and "%l" or "%r" -- the current line
+      else
+        components[2] = is_relnum and "%r" or "%l" -- other lines
+      end
     end
     components[2] = "%=" .. components[2] .. " " -- right align
   end


### PR DESCRIPTION
## What is this PR for?

Fix correctly showing relative numbers in `statuscolumn` after recent breaking changes on [nightly](https://github.com/neovim/neovim/pull/29357).

Please feel free to disregard this PR if a better solution is possible.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Does this PR fix an existing issue?
Fixes #3721 
<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
