### PR TITLE
fix(extras.python): avoid launching extra console with dap on Windows

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -93,7 +93,7 @@ return {
       },
       config = function()
         if vim.fn.has("win32") == 1 then
-          require("dap-python").setup(LazyVim.get_pkg_path("debugpy", "/venv/Scripts/python.exe"))
+          require("dap-python").setup(LazyVim.get_pkg_path("debugpy", "/venv/Scripts/pythonw.exe"))
         else
           require("dap-python").setup(LazyVim.get_pkg_path("debugpy", "/venv/bin/python"))
         end


### PR DESCRIPTION
On Windows, when using dap, python.exe will launch an extra console. If you target pythonw.exe this avoids that. Explanation source: https://stackoverflow.com/questions/9705982/pythonw-exe-or-python-exe

## What is this PR for?

Modify which exe is targeted for python + dap on windows. If you use python.exe an extra console launches (eg, nvim is runnining on Wezterm, boot up dap, and as a result an external console (usually through windows terminal or built-in console terminal) will launch (dap still runs in the original window). This is avoided with pythonw.exe

## Does this PR fix an existing issue?

No

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
