### PR TITLE
fix(terminal): switch to terminal mode when entering a terminal buffer

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -113,3 +113,15 @@ vim.api.nvim_create_autocmd({ "BufWritePre" }, {
     vim.fn.mkdir(vim.fn.fnamemodify(file, ":p:h"), "p")
   end,
 })
+
+-- Switch to terminal mode when entering a terminal buffer (term://)
+-- NOTE: "BufEnter" is emitted when a user focuses to an _existing_ terminal buffer
+--  "TermOpen" when a new terminal buffer is created eg. with `:term`.
+--  Odd that "BufEnter" is not emitted for a "term://" buffer after `:term`
+vim.api.nvim_create_autocmd({ "BufEnter", "TermOpen" }, {
+  callback = function()
+    vim.cmd("startinsert")
+  end,
+  pattern = { "term://*" },
+  group = augroup("enter_term_mode_on_focus"),
+})


### PR DESCRIPTION

## What is this PR for?

The mode is now switched to "terminal" when entering a terminal buffer.
Before, if you entered a terminal buffer in normal mode, the mode would
stay normal, requiring the user to manually switch to terminal mode. Implementation is from comment https://github.com/neovim/neovim/issues/26881#issuecomment-2008021985.


### Note

It looks like neovim/neovim#25820 addressed
the issue in the neovim version 0.9 via a backport but it is still not
working on my machine (nvim version 0.10, LazyVim version 12.17.0).
It seems like other users are dealing with this as well, https://github.com/neovim/neovim/issues/26881#issuecomment-2008021985, and a subsequent neovim/neovim#26901 was closed, which makes me think the neovim team knows about the behavior and wants to leave it that way. This is why I made the PR here. 

### Example

For example, if a LazyVim user has a vertically split window with a regular
text file on the left hand side and a terminal buffer on the right, and
the user moves focus from the file buffer to the terminal buffer via `<C-l>`,
they will now enter terminal mode immediately so they can use the shell,
whereas before, the user stayed in Normal mode and had to enter terminal
mode via `i` or an equivalent key.

### Performance

For the autocmd implementation, I am concerned that pattern = "term://*"
combined with "BufEnter" event will put strain on neovim.

## Does this PR fix an existing issue?

Not in this repository. It addresses neovim/neovim#26881, however..

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
- [x] I've checked that my version contains neovim/neovim#25820 and the issue still persists
- [x] It seems like a newer PR neovim/neovim#26901 offered to fix the issue, but it was discouraged by the author of neovim/neovim#25820, so perhaps neovim core knows about this behavior and does not want to fix it upstream? This is why I made the PR here. 
