### PR TITLE
feat(rust): add formatter for rust

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -114,6 +114,21 @@ return {
   },
 
   {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters = {
+        rustfmt = {
+          command = "rustfmt",
+        },
+      },
+      formatters_by_ft = {
+        ["rust"] = { "rustfmt" },
+      },
+    },
+  },
+
+  {
     "nvim-neotest/neotest",
     optional = true,
     opts = {


### PR DESCRIPTION
## What is this PR for?

Adding formatter for rust, using `rustfmt` that comes with `rust-analyzer` installation.
Configuration requires manual installation of `rust-analyzer` anyway (or at least present in the PATH), so adding a formatter looks like a good idea. 
Installing `rust-analyzer` comes with the `rustfmt` formatter anyway.

## Does this PR fix an existing issue?

Missing formatter for rust 

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.

## Additional Comment

I'm open to feedback from the implementation. It's my first PR contribution to OSS, so pardon me for any errors I might make. 
Thanks in advance
