### PR TITLE
feat(go): switch to neotest-golang

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -14,10 +14,6 @@ return {
     opts = {
       servers = {
         gopls = {
-          keys = {
-            -- Workaround for the lack of a DAP strategy in neotest-go: https://github.com/nvim-neotest/neotest-go/issues/12
-            { "<leader>td", "<cmd>lua require('dap-go').debug_test()<CR>", desc = "Debug Nearest (Go)" },
-          },
           settings = {
             gopls = {
               gofumpt = true,
@@ -129,14 +125,14 @@ return {
     "nvim-neotest/neotest",
     optional = true,
     dependencies = {
-      "nvim-neotest/neotest-go",
+      "fredrikaverpil/neotest-golang",
     },
     opts = {
       adapters = {
-        ["neotest-go"] = {
-          -- Here we can set options for neotest-go, e.g.
-          -- args = { "-tags=integration" }
-          recursive_run = true,
+        ["neotest-golang"] = {
+          -- Here we can set options for neotest-golang, e.g.
+          -- go_test_args = { "-v", "-race", "-count=1", "-timeout=60s" },
+          dap_go_enabled = true, -- requires leoluz/nvim-dap-go
         },
       },
     },

--- a/lua/lazyvim/plugins/extras/test/core.lua
+++ b/lua/lazyvim/plugins/extras/test/core.lua
@@ -10,10 +10,11 @@ return {
       -- or a table of adapter names, mapped to adapter configs.
       -- The adapter will then be automatically loaded with the config.
       adapters = {},
-      -- Example for loading neotest-go with a custom config
+      -- Example for loading neotest-golang with a custom config
       -- adapters = {
-      --   ["neotest-go"] = {
-      --     args = { "-tags=integration" },
+      --   ["neotest-golang"] = {
+      --     go_test_args = { "-v", "-race", "-count=1", "-timeout=60s" },
+      --     dap_go_enabled = true,
       --   },
       -- },
       status = { virtual_text = true },


### PR DESCRIPTION
## What is this PR for?

This PR switches [nvim-neotest/neotest-go](https://github.com/nvim-neotest/neotest-go) for [fredrikaverpil/neotest-golang](https://github.com/fredrikaverpil/neotest-golang).

## Does this PR fix an existing issue?

Neotest-go comes with some problems which are mitigated in neotest-golang. A full description/background is available in the project README, but here are some highlights:

### Neotest-go issues mitigated in neotest-golang

- Test Output in JSON, making it difficult to read:  [neotest-go#52](https://github.com/nvim-neotest/neotest-go/issues/52)
- "Run nearest" runs all tests:  [neotest-go#83](https://github.com/nvim-neotest/neotest-go/issues/83)
- Running test suite doesn't work:  [neotest-go#89](https://github.com/nvim-neotest/neotest-go/issues/89)
- Diagnostics for table tests on the line of failure:  [neotest-go#75](https://github.com/nvim-neotest/neotest-go/issues/75)
- Support for Nested Subtests:  [neotest-go#74](https://github.com/nvim-neotest/neotest-go/issues/74)
- DAP support:  [neotest-go#12](https://github.com/nvim-neotest/neotest-go/issues/12)

### Features

- Supports all [Neotest usage](https://github.com/nvim-neotest/neotest#usage).
- Integrates with [nvim-dap-go](https://github.com/leoluz/nvim-dap-go) for  debugging of tests using delve.
- Inline diagnostics.
- Works great with  [andythigpen/nvim-coverage](https://github.com/andythigpen/nvim-coverage) for  displaying coverage in the sign column (per-Go package, or per-test basis).
- Monorepo support (detect, run and debug tests in sub-projects).
- Supports table tests (relies on treesitter AST detection).
- Supports nested test functions.

## Notes

- I'm the author of [fredrikaverpil/neotest-golang](https://github.com/fredrikaverpil/neotest-golang).


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
