### PR TITLE
fix(statuscolumn): fix `folds_open = true`

### DIFF
--- a/lua/lazyvim/util/ui.lua
+++ b/lua/lazyvim/util/ui.lua
@@ -124,7 +124,7 @@ function M.statuscolumn()
       elseif
         show_open_folds
         and not LazyVim.ui.skip_foldexpr[buf]
-        and vim.treesitter.foldexpr(vim.v.lnum):sub(1, 1) == ">"
+        and tostring(vim.treesitter.foldexpr(vim.v.lnum)):sub(1, 1) == ">"
       then -- fold start
         fold = { text = vim.opt.fillchars:get().foldopen or "", texthl = githl }
       end


### PR DESCRIPTION
After some recent changes in https://github.com/neovim/neovim/pull/28709 I was getting an error when the user had `folds_open = true` in his personal configuration whenever he pressed `o/O`. This is an attempt to fix that.

## What is this PR for?

I was getting an error with `folds_open = true` in the user configuration whenever pressing `o/O` or pressing `Enter` for a new line.
The error was `Error executing lua: ...e/jrn23/projects/plugins/LazyVim/lua/lazyvim/util/ui.lua:127: attempt to index a number value`.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Does this PR fix an existing issue?
No
<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
