### PR TITLE
feat(extra.sql): add sql options docs

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/sql.lua
+++ b/lua/lazyvim/plugins/extras/lang/sql.lua
@@ -1,29 +1,32 @@
 if lazyvim_docs then
   -- Automatically configure connections without needing to manually input them each time.
-  vim.g.dbs = {
-    dev = "Replace with your database connection URL.",
-    staging = "Replace with your database connection URL.",
-  }
+  --    vim.g.dbs = {
+  --      dev = "Replace with your database connection URL.",
+  --      staging = "Replace with your database connection URL.",
+  --    }
   -- or
-  vim.g.dbs = {
-    { name = "dev", url = "Replace with your database connection URL." },
-    { name = "staging", url = "Replace with your database connection URL." },
-  }
+  --    vim.g.dbs = {
+  --      { name = "dev", url = "Replace with your database connection URL." },
+  --      { name = "staging", url = "Replace with your database connection URL." },
+  --    }
 
-  -- You can set your secrets directly through a Lua table. For example:
-  -- Create a secrets/db-env.lua file and return the connection table.
-  -- Or
-  -- Replace `secrets/db-env` with your own module path.
-  local ok, dbs = pcall(require, "secrests/db-env")
-  if ok then
-    vim.g.dbs = dbs
-  else
+  -- You can set your those configuration through a Lua table. For example:
+  -- Create a `.lazy.lua` file in your project and set your connections in it like this:
+  -- ```lua
+  --    vim.g.dbs = {...}
+  --
+  --    return {}
+  -- ```
+
+  local ok = pcall(dofile, vim.fn.getcwd() .. "/.lazy.lua")
+
+  if not ok then
     vim.g.dbs = {}
   end
 
   -- Alternatively, you can also use other ways to inject your environment variables.
 
-  -- After all, please make sure to protect your secrets and add them to your `.gitignore` file.
+  -- After all, please make sure to add `.lazy` to your global `.gitignore` file.
 end
 
 local sql_ft = { "sql", "mysql", "plsql" }

--- a/lua/lazyvim/plugins/extras/lang/sql.lua
+++ b/lua/lazyvim/plugins/extras/lang/sql.lua
@@ -1,32 +1,29 @@
 if lazyvim_docs then
-  -- Automatically configure connections without needing to manually input them each time.
+  -- The setup below will automatically configure connections without the need for manual input each time.
+
+  -- Example configuration using dictionary with keys:
   --    vim.g.dbs = {
   --      dev = "Replace with your database connection URL.",
   --      staging = "Replace with your database connection URL.",
   --    }
   -- or
+  -- Example configuration using a list of dictionaries:
   --    vim.g.dbs = {
   --      { name = "dev", url = "Replace with your database connection URL." },
   --      { name = "staging", url = "Replace with your database connection URL." },
   --    }
 
-  -- You can set your those configuration through a Lua table. For example:
-  -- Create a `.lazy.lua` file in your project and set your connections in it like this:
+  -- or
+  -- Create a `.lazy.lua` file in your project and set your connections like this:
   -- ```lua
   --    vim.g.dbs = {...}
   --
   --    return {}
   -- ```
 
-  local ok = pcall(dofile, vim.fn.getcwd() .. "/.lazy.lua")
+  -- Alternatively, you can also use other methods to inject your environment variables.
 
-  if not ok then
-    vim.g.dbs = {}
-  end
-
-  -- Alternatively, you can also use other ways to inject your environment variables.
-
-  -- After all, please make sure to add `.lazy` to your global `.gitignore` file.
+  -- Finally, please make sure to add `.lazy.lua` to your `.gitignore` file to protect your secrets.
 end
 
 local sql_ft = { "sql", "mysql", "plsql" }

--- a/lua/lazyvim/plugins/extras/lang/sql.lua
+++ b/lua/lazyvim/plugins/extras/lang/sql.lua
@@ -10,8 +10,10 @@ if lazyvim_docs then
     { name = "staging", url = "Replace with your database connection URL." },
   }
 
-  -- NOTICE: Replace `secrets/db-env` with your own module path.
-  -- You can set your secrets directly through a Lua table, for example:
+  -- You can set your secrets directly through a Lua table. For example:
+  -- Create a secrets/db-env.lua file and return the connection table.
+  -- Or
+  -- Replace `secrets/db-env` with your own module path.
   local ok, dbs = pcall(require, "secrests/db-env")
   if ok then
     vim.g.dbs = dbs

--- a/lua/lazyvim/plugins/extras/lang/sql.lua
+++ b/lua/lazyvim/plugins/extras/lang/sql.lua
@@ -17,6 +17,8 @@ if lazyvim_docs then
   local ok, dbs = pcall(require, "secrests/db-env")
   if ok then
     vim.g.dbs = dbs
+  else
+    vim.g.dbs = {}
   end
 
   -- Alternatively, you can also use other ways to inject your environment variables.

--- a/lua/lazyvim/plugins/extras/lang/sql.lua
+++ b/lua/lazyvim/plugins/extras/lang/sql.lua
@@ -10,9 +10,12 @@ if lazyvim_docs then
     { name = "staging", url = "Replace with your database connection URL." },
   }
 
-  -- NOTICE: Replace yourself path for module
+  -- NOTICE: Replace `secrets/db-env` with your own module path.
   -- You can set your secrets directly through a Lua table, for example:
-  vim.g.dbs = require("secrests/db-env")
+  local ok, dbs = pcall(require, "secrests/db-env")
+  if ok then
+    vim.g.dbs = dbs
+  end
 
   -- Alternatively, you can also use other ways to inject your environment variables.
 

--- a/lua/lazyvim/plugins/extras/lang/sql.lua
+++ b/lua/lazyvim/plugins/extras/lang/sql.lua
@@ -1,3 +1,24 @@
+if lazyvim_docs then
+  -- Automatically configure connections without needing to manually input them each time.
+  vim.g.dbs = {
+    dev = "Replace with your database connection URL.",
+    staging = "Replace with your database connection URL.",
+  }
+  -- or
+  vim.g.dbs = {
+    { name = "dev", url = "Replace with your database connection URL." },
+    { name = "staging", url = "Replace with your database connection URL." },
+  }
+
+  -- NOTICE: Replace yourself path for module
+  -- You can set your secrets directly through a Lua table, for example:
+  vim.g.dbs = require("secrests/db-env")
+
+  -- Alternatively, you can also use other ways to inject your environment variables.
+
+  -- After all, please make sure to protect your secrets and add them to your `.gitignore` file.
+end
+
 local sql_ft = { "sql", "mysql", "plsql" }
 
 return {


### PR DESCRIPTION
## What is this PR for?

A small contribution to enhance the documentation and make it easier to use.

While vim-dadbod and vim-dadbod-ui recommend using dotenv.vim for env file injection, we aim to provide a simpler method. Instead of implementing file parsing or relying on an external plugin (dotenv.vim), just try directly using a Lua table.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Does this PR fix an existing issue?

none!

<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
