### PR TITLE
feat(dashboard): center dashboard vertically

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -312,9 +312,8 @@ return {
            ╚══════╝╚═╝  ╚═╝╚══════╝   ╚═╝     ╚═══╝  ╚═╝╚═╝     ╚═╝           
       ]]
 
-      logo = string.rep("\n", 8) .. logo .. "\n\n"
-
       local opts = {
+        logo = logo,
         theme = "doom",
         hide = {
           -- this is taken care of by lualine
@@ -322,7 +321,6 @@ return {
           statusline = false,
         },
         config = {
-          header = vim.split(logo, "\n"),
           -- stylua: ignore
           center = {
             { action = 'lua LazyVim.pick()()',                           desc = " Find File",       icon = " ", key = "f" },
@@ -360,6 +358,17 @@ return {
       end
 
       return opts
+    end,
+    config = function(_, opts)
+      local win_height = vim.api.nvim_win_get_height(0) + 2 -- plus 2 for status bar
+      local _, logo_count = string.gsub(opts.logo, "\n", "") -- count newlines in logo
+      local logo_height = logo_count + 3 -- logo size + newlines
+      local actions_height = #opts.config.center * 2 - 1 -- minus 1 for last item
+      local total_height = logo_height + actions_height + 2 -- plus for 2 for footer
+      local margin = math.floor((win_height - total_height) / 2)
+      local logo = string.rep("\n", margin) .. opts.logo .. "\n\n"
+      opts.config.header = vim.split(logo, "\n")
+      require("dashboard").setup(opts)
     end,
   },
 }


### PR DESCRIPTION
## What is this PR for?

Center dashboard.nvim vertically dynamically, based on the logo height and items.
This is a PoC PR. The code works well and consistently with any logo height and number of items, but I'm not sure if you like the way I did it. Feel free to modify as you like.

## Does this PR fix an existing issue?

N/A.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.

## Screenshots (before and after)

Normal font size:
![normal_font_size](https://github.com/LazyVim/LazyVim/assets/17456867/a8c9258c-ccb0-478a-9a6d-2627f40c6142)

Large font size:
![large_font_size](https://github.com/LazyVim/LazyVim/assets/17456867/47720231-65b9-4295-8bcc-27cabd09fb04)

Small font size:
![small_font_size](https://github.com/LazyVim/LazyVim/assets/17456867/cd95bbbe-3ed7-45fd-adcf-b97489aa0743)

Different logo and number of items:
![2024-06-23T12:38:50,495121070+03:00](https://github.com/LazyVim/LazyVim/assets/17456867/7ec0b236-3352-41bb-a956-66fb1bc66670)
