### PR TITLE
feat(c#): route references and implementation lsp calls through omnisharp-extended

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/omnisharp.lua
+++ b/lua/lazyvim/plugins/extras/lang/omnisharp.lua
@@ -46,7 +46,13 @@ return {
         omnisharp = {
           handlers = {
             ["textDocument/definition"] = function(...)
-              return require("omnisharp_extended").handler(...)
+              return require("omnisharp_extended").definition_handler(...)
+            end,
+            ["textDocument/references"] = function(...)
+              return require("omnisharp_extended").references_handler(...)
+            end,
+            ["textDocument/implementation"] = function(...)
+              return require("omnisharp_extended").implementation_handler(...)
             end,
           },
           keys = {
@@ -56,6 +62,20 @@ return {
                 require("omnisharp_extended").telescope_lsp_definitions()
               end,
               desc = "Goto Definition",
+            },
+            {
+              "gr",
+              function()
+                require("omnisharp_extended").telescope_lsp_references()
+              end,
+              desc = "References",
+            },
+            {
+              "gI",
+              function()
+                require("omnisharp_extended").telescope_lsp_implementation()
+              end,
+              desc = "Goto Implementation",
             },
           },
           enable_roslyn_analyzers = true,


### PR DESCRIPTION
## What is this PR for?

[omnisharp-extended-lsp.nvim](https://github.com/Hoffs/omnisharp-extended-lsp.nvim) has recently (~3 months ago) been extended to support go-to-references and go-to-implementation calls, next to the (already configured) go-to-definitions. Routing these calls through omnisharp-extended allows users to get better results than by using generic LSP calls, e.g. enabling decompiled sources or source-generated files to be visible.

## Does this PR fix an existing issue?

Nope.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
