### PR TITLE
fix(dap): only load `mason-nvim-dap` when not disabled

### DIFF
--- a/lua/lazyvim/plugins/extras/dap/core.lua
+++ b/lua/lazyvim/plugins/extras/dap/core.lua
@@ -49,7 +49,9 @@ return {
 
     config = function()
       -- load mason-nvim-dap here, after all adapters have been setup
-      require("mason-nvim-dap").setup(LazyVim.opts("mason-nvim-dap.nvim"))
+      if LazyVim.has("mason-nvim-dap.nvim") then
+        require("mason-nvim-dap").setup(LazyVim.opts("mason-nvim-dap.nvim"))
+      end
 
       vim.api.nvim_set_hl(0, "DapStoppedLine", { default = true, link = "Visual" })
 


### PR DESCRIPTION
## What is this PR for?
Only `require("mason-nvim-dap")` when it's not disabled
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Does this PR fix an existing issue?
Fixes #3783
<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
