### PR TITLE
fix(extras.astro): support `astro.config.ts` root

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/astro.lua
+++ b/lua/lazyvim/plugins/extras/lang/astro.lua
@@ -3,9 +3,11 @@ return {
     return LazyVim.extras.wants({
       ft = "astro",
       root = {
+        -- https://docs.astro.build/en/guides/configuring-astro/#supported-config-file-types
         "astro.config.js",
         "astro.config.mjs",
         "astro.config.cjs",
+        "astro.config.ts",
       },
     })
   end,


### PR DESCRIPTION
## What is this PR for?

Support [`astro.config.ts`](https://docs.astro.build/en/guides/configuring-astro/#supported-config-file-types) as a root file for the Astro extra.

## Does this PR fix an existing issue?

N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
