### PR TITLE
feat(extras.lang.json): add json-nvim

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/json.lua
+++ b/lua/lazyvim/plugins/extras/lang/json.lua
@@ -61,7 +61,6 @@ return {
       { "<localleader>M", "<cmd>JsonMinifySelection<cr>", ft = "json", desc = "Minify JSON in selected text" },
       { "<localleader>u", "<cmd>JsonUnescapeFile<cr>", ft = "json", desc = "Unescape JSON in entire file" },
       { "<localleader>U", "<cmd>JsonUnescapeSelection<cr>", ft = "json", desc = "Unescape JSON in selected text" },
-      
     },
   },
 

--- a/lua/lazyvim/plugins/extras/lang/json.lua
+++ b/lua/lazyvim/plugins/extras/lang/json.lua
@@ -43,4 +43,35 @@ return {
       },
     },
   },
+
+  -- add json-nvim for alternative
+  {
+    "VPavliashvili/json-nvim", -- requires jq (installed with mason later)
+    ft = "json",
+    keys = {
+      { "<localleader>e", "<cmd>JsonEscapeFile<cr>", ft = "json", desc = "Escape JSON in entire file" },
+      { "<localleader>E", "<cmd>JsonEscapeSelection<cr>", ft = "json", desc = "Escape JSON in selected text" },
+      { "<localleader>f", "<cmd>JsonFormatFile<cr>", ft = "json", desc = "Format JSON in entire file" },
+      { "<localleader>F", "<cmd>JsonFormatSelection<cr>", ft = "json", desc = "Format JSON in selected text" },
+      { "<localleader>t", "<cmd>JsonFormatToken<cr>", ft = "json", desc = "Format JSON token under cursor" },
+      { "<localleader>c", "<cmd>JsonKeysToCamelCase<cr>", ft = "json", desc = "Convert JSON keys to camelCase" },
+      { "<localleader>p", "<cmd>JsonKeysToPascalCase<cr>", ft = "json", desc = "Convert JSON keys to PascalCase" },
+      { "<localleader>s", "<cmd>JsonKeysToSnakeCase<cr>", ft = "json", desc = "Convert JSON keys to snake_case" },
+      { "<localleader>m", "<cmd>JsonMinifyFile<cr>", ft = "json", desc = "Minify JSON in entire file" },
+      { "<localleader>M", "<cmd>JsonMinifySelection<cr>", ft = "json", desc = "Minify JSON in selected text" },
+      { "<localleader>u", "<cmd>JsonUnescapeFile<cr>", ft = "json", desc = "Unescape JSON in entire file" },
+      { "<localleader>U", "<cmd>JsonUnescapeSelection<cr>", ft = "json", desc = "Unescape JSON in selected text" },
+      
+    },
+  },
+
+  -- ensure mason installs jq (formatter)
+  {
+    "williamboman/mason.nvim",
+    opts = function(_, opts)
+      vim.list_extend(opts.ensure_installed, {
+        "jq", -- formatter
+      })
+    end,
+  },
 }


### PR DESCRIPTION
## What is this PR for?

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Updates the existing JSON config to utilize [json-nvim](https://github.com/VPavliashvili/json-nvim).
This minor addition adds new features such as minifying and converting JSON files with the use of `jq`.

Since it uses `jq`, I added another dependency for mason which installs it. I know mason auto-installs lsp's if they are defined in `nvim-lspconfig`, but mason classifies `jq` as a formatter, so I manually added it as an `opts.ensure_installed`.

## Does this PR fix an existing issue?

<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

Nope

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
