### PR TITLE
fix(edgy): improve edgy.lua bufferline offset logic

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/edgy.lua
+++ b/lua/lazyvim/plugins/extras/ui/edgy.lua
@@ -152,14 +152,17 @@ return {
         local get = Offset.get
         Offset.get = function()
           if package.loaded.edgy then
+            local old_offset = get()
             local layout = require("edgy.config").layout
             local ret = { left = "", left_size = 0, right = "", right_size = 0 }
             for _, pos in ipairs({ "left", "right" }) do
               local sb = layout[pos]
+              local title = " Sidebar" .. string.rep(" ", sb.bounds.width - 8)
               if sb and #sb.wins > 0 then
-                local title = " Sidebar" .. string.rep(" ", sb.bounds.width - 8)
-                ret[pos] = "%#EdgyTitle#" .. title .. "%*" .. "%#WinSeparator#│%*"
-                ret[pos .. "_size"] = sb.bounds.width
+                ret[pos] = old_offset[pos .. "_size"] > 0 and old_offset[pos]
+                  or pos == "left" and ("%#Bold#" .. title .. "%*" .. "%#BufferLineOffsetSeparator#│%*")
+                  or pos == "right" and ("%#BufferLineOffsetSeparator#│%*" .. "%#Bold#" .. title .. "%*")
+                ret[pos .. "_size"] = old_offset[pos .. "_size"] > 0 and old_offset[pos .. "_size"] or sb.bounds.width
               end
             end
             ret.total_size = ret.left_size + ret.right_size


### PR DESCRIPTION
## What is this PR for?
Use already defined Bufferline offsets or use Edgy offset if none are found.

Also properly set offset separator position depending on offset/pane location.

## Does this PR fix an existing issue?
No

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
