### PR TITLE
fix(fzf): disable `preview` for `vtsls`

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/fzf.lua
+++ b/lua/lazyvim/plugins/extras/editor/fzf.lua
@@ -131,7 +131,11 @@ return {
               -- height is number of items minus 15 lines for the preview, with a max of 80% screen height
               height = math.floor(math.min(vim.o.lines * 0.8 - 16, #items + 2) + 0.5) + 16,
               width = 0.5,
-              preview = {
+              preview = not vim.tbl_isempty(LazyVim.lsp.get_clients({ bufnr = 0, name = "vtsls" })) and {
+                layout = "vertical",
+                vertical = "down:15,border-top",
+                hidden = "hidden",
+              } or {
                 layout = "vertical",
                 vertical = "down:15,border-top",
               },


### PR DESCRIPTION
## What is this PR for?
Disable `preview` in `fzf-lua` Extra for `vtsls`. I tested it with Python and Typescript Extras and in Typescript pressing `<leader>ca` shows without previewer, while in Python the same shows with previewer. 

Kindly check also that this is correct and I didn't miss out anything else.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Does this PR fix an existing issue?
Fixes #3773
<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
