### PR TITLE
fix(elixir): fix credo detection for elixir linters.

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/elixir.lua
+++ b/lua/lazyvim/plugins/extras/lang/elixir.lua
@@ -33,12 +33,13 @@ return {
     "nvimtools/none-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      if vim.fn.executable("credo") == 0 then
-        return
-      end
       local nls = require("null-ls")
       opts.sources = vim.list_extend(opts.sources or {}, {
-        nls.builtins.diagnostics.credo,
+        nls.builtins.diagnostics.credo.with({
+          condition = function(utils)
+            return utils.root_has_file(".credo.exs")
+          end,
+        }),
       })
     end,
   },
@@ -46,11 +47,16 @@ return {
     "mfussenegger/nvim-lint",
     optional = true,
     opts = function(_, opts)
-      if vim.fn.executable("credo") == 0 then
-        return
-      end
       opts.linters_by_ft = {
         elixir = { "credo" },
+      }
+
+      opts.linters = {
+        credo = {
+          condition = function(ctx)
+            return vim.fs.find({ ".credo.exs" }, { path = ctx.filename, upward = true })[1]
+          end,
+        },
       }
     end,
   },


### PR DESCRIPTION
## What is this PR for?
Fix detection of elixir `credo` linter. 

`vim.fn.executable("credo") == 0` will never succeed because `credo` is not binary/executable. It is a `mix` package and only available via `mix credo` command.

Instead, the plugins(both `none-ls` and `nvim-lint`) will check for the presence of the `.credo.exs` file.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Does this PR fix an existing issue?
Fixes #3808 
<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist
- [x] Both linters display credo warnings if `credo` is installed and the `.credo.exs` config exists in a project.
- [x] There are no errors if the `.credo.exs` file does not exist in the project.
- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
