### PR TITLE
feat(telescope): add keymap for quickfixhistory

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/fzf.lua
+++ b/lua/lazyvim/plugins/extras/editor/fzf.lua
@@ -231,6 +231,7 @@ return {
       { "<leader>sm", "<cmd>FzfLua marks<cr>", desc = "Jump to Mark" },
       { "<leader>sR", "<cmd>FzfLua resume<cr>", desc = "Resume" },
       { "<leader>sq", "<cmd>FzfLua quickfix<cr>", desc = "Quickfix List" },
+      { "<leader>xh", "<cmd>FzfLua quickfix_stack<cr>", desc = "Quickfix Stack" },
       { "<leader>sw", LazyVim.pick("grep_cword"), desc = "Word (Root Dir)" },
       { "<leader>sW", LazyVim.pick("grep_cword", { root = false }), desc = "Word (cwd)" },
       { "<leader>sw", LazyVim.pick("grep_visual"), mode = "v", desc = "Selection (Root Dir)" },

--- a/lua/lazyvim/plugins/extras/editor/telescope.lua
+++ b/lua/lazyvim/plugins/extras/editor/telescope.lua
@@ -124,6 +124,7 @@ return {
       { "<leader>so", "<cmd>Telescope vim_options<cr>", desc = "Options" },
       { "<leader>sR", "<cmd>Telescope resume<cr>", desc = "Resume" },
       { "<leader>sq", "<cmd>Telescope quickfix<cr>", desc = "Quickfix List" },
+      { "<leader>xh", "<cmd>Telescope quickfixhistory<cr>", desc = "Quickfix History" },
       { "<leader>sw", LazyVim.pick("grep_string", { word_match = "-w" }), desc = "Word (Root Dir)" },
       { "<leader>sW", LazyVim.pick("grep_string", { root = false, word_match = "-w" }), desc = "Word (cwd)" },
       { "<leader>sw", LazyVim.pick("grep_string"), mode = "v", desc = "Selection (Root Dir)" },


### PR DESCRIPTION
##  Add keymap for ":Telescope quickfixhistory"

This address the core issue discussed on #3813 and follow the guidance given by [dpetka2001](https://github.com/dpetka2001).

## Does this PR fix an existing issue?

Now, there is an easy to use keymap for the Telescope builtin function.

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
