### PR TITLE
fix(neotest): support adapter key on adapter for playwright

### DIFF
--- a/lua/lazyvim/plugins/extras/test/core.lua
+++ b/lua/lazyvim/plugins/extras/test/core.lua
@@ -86,6 +86,9 @@ return {
               local meta = getmetatable(adapter)
               if adapter.setup then
                 adapter.setup(config)
+              elseif adapter.adapter then
+                adapter.adapter(config)
+                adapter = adapter.adapter
               elseif meta and meta.__call then
                 adapter(config)
               else


### PR DESCRIPTION
## What is this PR for?

Similar to https://github.com/LazyVim/LazyVim/issues/847 , only this adapter adds a setup function into the 'adapter' key in the plugin table ([source](https://github.com/thenbe/neotest-playwright/blob/f61463f5c74d53fc5975b7e086b7c6e9356d9215/lua/neotest-playwright/init.lua#L31-L33)).

It is somewhat annoying that neotest does not provide a recommended way for adapters to define their configuration function (at least not explicitly)...

Perhaps we should work around it temporarily, but reach out to either neotest or neotest-playwright authors?

## Does this PR fix an existing issue?

I didn't see anyone complaining about playwright adapter in issues or discussions :/

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
