### PR TITLE
fix(lint): make prepend_args opt work when default args is empty

### DIFF
--- a/lua/lazyvim/plugins/linting.lua
+++ b/lua/lazyvim/plugins/linting.lua
@@ -35,6 +35,7 @@ return {
         if type(linter) == "table" and type(lint.linters[name]) == "table" then
           lint.linters[name] = vim.tbl_deep_extend("force", lint.linters[name], linter)
           if type(linter.prepend_args) == "table" then
+            lint.linters[name].args = lint.linters[name].args or {}
             vim.list_extend(lint.linters[name].args, linter.prepend_args)
           end
         else


### PR DESCRIPTION
## What is this PR for?

There's some logic in `linting.lua` to allow for easy setting of linter args, but it doesn't work when default args is empty. This hopefully fixes it.

## Does this PR fix an existing issue?

N/A.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
