### PR TITLE
fix(gitsigns): fix inconsistent signs

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -207,6 +207,13 @@ return {
         changedelete = { text = "▎" },
         untracked = { text = "▎" },
       },
+      signs_staged = {
+        add = { text = "▎" },
+        change = { text = "▎" },
+        delete = { text = "" },
+        topdelete = { text = "" },
+        changedelete = { text = "▎" },
+      },
       on_attach = function(buffer)
         local gs = package.loaded.gitsigns
 


### PR DESCRIPTION
## What is this PR for?

Fixing inconsistency with the `gitsigns` signs.

Since the signs are overridden ...

https://github.com/LazyVim/LazyVim/blob/5e1c474192372caca7d95d4a85dd5939fe95cca3/lua/lazyvim/plugins/editor.lua#L201-L209

The staged signs should be overridden too.

> ```
> signs_staged                                    *gitsigns-config-signs_staged*
>       Type: `table[extended]`
>       Default: >
>         {
>           add          = { text = '┃' },
>           change       = { text = '┃' },
>           delete       = { text = '▁' },
>           topdelete    = { text = '▔' },
>           changedelete = { text = '~' },
>         }
> <
>     Configuration for signs of staged hunks.
> 
>     See |gitsigns-config-signs|.
> ```


https://github.com/lewis6991/gitsigns.nvim/blob/0595724fa9516a35696ff6b1e3cb95b6462b38b1/doc/gitsigns.txt#L569-L579

> ``` 
> signs_staged_enable                      *gitsigns-config-signs_staged_enable*
>       Type: `boolean`, Default: `true`
> 
> 
>     Show signs for staged hunks.
> 
> 
>     When enabled the signs defined in |git-config-signs_staged|` are used.
> ``` 

https://github.com/lewis6991/gitsigns.nvim/blob/0595724fa9516a35696ff6b1e3cb95b6462b38b1/doc/gitsigns.txt#L584-L589

## Does this PR fix an existing issue?

Nopeskii

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
