### PR TITLE
fix(lazygit): fix browsing private git hostings

### DIFF
--- a/lua/lazyvim/util/lazygit.lua
+++ b/lua/lazyvim/util/lazygit.lua
@@ -166,7 +166,7 @@ function M.browse()
   for _, line in ipairs(lines) do
     local name, url = line:match("(%S+)%s+(%S+)%s+%(fetch%)")
     if name and url then
-      if url:find("git@github.com") or url:find("git@bitbucket.org") or url:find("git@gitlab.com") then
+      if url:find("git@") == 1 then
         url = url:gsub("git@(%S+):", "https://%1/"):gsub(".git$", "")
       end
       table.insert(remotes, { name = name, url = url })


### PR DESCRIPTION
## What is this PR for?

Current implementation of `Git Browse` doesn't work with onprem gitlab (and any other git hosting except gitlab, github and  bitbucket).
With this little fix, it should work with any git hosting.

## Does this PR fix an existing issue?

No

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
