### PR TITLE
fix(bufremove): fix `Cancel`

### DIFF
--- a/lua/lazyvim/util/ui.lua
+++ b/lua/lazyvim/util/ui.lua
@@ -231,7 +231,7 @@ function M.bufremove(buf)
 
   if vim.bo.modified then
     local choice = vim.fn.confirm(("Save changes to %q?"):format(vim.fn.bufname()), "&Yes\n&No\n&Cancel")
-    if choice == 0 then -- Cancel
+    if choice == 0 or choice == 3 then -- 0 for <Esc>/<C-c> and 3 for Cancel
       return
     end
     if choice == 1 then -- Yes


### PR DESCRIPTION
## What is this PR for?
When you hit `Cancel` and a buffer is modified, it should not delete the buffer.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Does this PR fix an existing issue?
Fixes #3832
<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
