### PR TITLE
feat(extras): switch to markdownlint-cli2

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/markdown.lua
+++ b/lua/lazyvim/plugins/extras/lang/markdown.lua
@@ -15,14 +15,14 @@ return {
     optional = true,
     opts = {
       formatters_by_ft = {
-        ["markdown"] = { { "prettierd", "prettier" }, "markdownlint", "markdown-toc" },
-        ["markdown.mdx"] = { { "prettierd", "prettier" }, "markdownlint", "markdown-toc" },
+        ["markdown"] = { { "prettierd", "prettier" }, "markdownlint-cli2", "markdown-toc" },
+        ["markdown.mdx"] = { { "prettierd", "prettier" }, "markdownlint-cli2", "markdown-toc" },
       },
     },
   },
   {
     "williamboman/mason.nvim",
-    opts = { ensure_installed = { "markdownlint", "markdown-toc" } },
+    opts = { ensure_installed = { "markdownlint-cli2", "markdown-toc" } },
   },
   {
     "nvimtools/none-ls.nvim",
@@ -30,7 +30,7 @@ return {
     opts = function(_, opts)
       local nls = require("null-ls")
       opts.sources = vim.list_extend(opts.sources or {}, {
-        nls.builtins.diagnostics.markdownlint,
+        nls.builtins.diagnostics.markdownlint_cli2,
       })
     end,
   },
@@ -39,7 +39,7 @@ return {
     optional = true,
     opts = {
       linters_by_ft = {
-        markdown = { "markdownlint" },
+        markdown = { "markdownlint-cli2" },
       },
     },
   },


### PR DESCRIPTION
## What is this PR for?
This PR switches makrdownlint-cli to markdownlint-cli2.
markdownlint-cli2 should be a bit faster than markdownlint-cli and has a more flexible configuration through files in the whole directory tree.
The cli is maintained by David Anson who also wrote the markdown style checker itself which is used by the "old" cli and cli2.

Blog post from David Anson regarding the new cli itself:
https://dlaa.me/blog/post/markdownlintcli2

## Does this PR fix an existing issue?
 No

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
