### PR TITLE
feat(java): enable Lombok support in jdtls

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -71,6 +71,8 @@ return {
     dependencies = { "folke/which-key.nvim" },
     ft = java_filetypes,
     opts = function()
+      local mason_registry = require("mason-registry")
+      local lombok_jar = mason_registry.get_package("jdtls"):get_install_path() .. "/lombok.jar"
       return {
         -- How to find the root dir for a given filename. The default comes from
         -- lspconfig which provides a function specifically for java projects.
@@ -91,7 +93,10 @@ return {
 
         -- How to run jdtls. This can be overridden to a full java command-line
         -- if the Python wrapper script doesn't suffice.
-        cmd = { vim.fn.exepath("jdtls") },
+        cmd = {
+          vim.fn.exepath("jdtls"),
+          string.format("--jvm-arg=-javaagent:%s", lombok_jar),
+        },
         full_cmd = function(opts)
           local fname = vim.api.nvim_buf_get_name(0)
           local root_dir = opts.root_dir(fname)


### PR DESCRIPTION
jdtls needs an argument passed to the JVM to load Lombok as an agent.

Mason downloads `lombok.jar`so we can use that

## What is this PR for?

Configures Lombok support in `jdtls` ; this removes a lot of red underlines in Java projects that use it.

Changes this
![image](https://github.com/LazyVim/LazyVim/assets/368399/87dbe37a-7d2c-4410-a600-c702e3097f63)

To this
![image](https://github.com/LazyVim/LazyVim/assets/368399/db6ada27-82f3-4052-a0c8-1e62882aaffc)


- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
