### PR TITLE
feat(scala): add key for worksheet hover

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/scala.lua
+++ b/lua/lazyvim/plugins/extras/lang/scala.lua
@@ -34,6 +34,13 @@ return {
               end,
               desc = "Metals compile cascade",
             },
+            {
+              "<leader>mh",
+              function()
+                require("metals").hover_worksheet()
+              end,
+              desc = "Metals hover worksheet",
+            },
           },
           init_options = {
             statusBarProvider = "off",


### PR DESCRIPTION
## What is this PR for?

Worksheet hovering is a useful feature provided by `metals` to see not just the end result, but also the entire output of a function call, as can be seen here for example:
https://youtu.be/Jv9B1crzpWM?t=16m20s

Having a default key assigned not only makes it more convenient, but also increases discoverability.

(I was also contemplating `<leader>mK` as the mapping to be in line with `K` for regular hover, but I wasn't convinced that the consistency is worth the extra keypress.)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
