### PR TITLE
feat(cmp): disable `item.menu` for Rust filetypes

### DIFF
--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -49,10 +49,13 @@ return {
           { name = "buffer" },
         }),
         formatting = {
-          format = function(_, item)
+          format = function(entry, item)
             local icons = LazyVim.config.icons.kinds
             if icons[item.kind] then
               item.kind = icons[item.kind] .. item.kind
+            end
+            if entry.context.filetype == "rust" then
+              item.menu = nil
             end
             return item
           end,


### PR DESCRIPTION
## What is this PR for?
Tries to improve aesthetics for `nvim-cmp` in Rust by disabling `item.menu` since it contains the `return` types that take up too much space.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Does this PR fix an existing issue?
Fixes #3855
<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
