### PR TITLE
fix(neo-tree): remove `branch`, since it obstructs updating to latest version

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -3,7 +3,6 @@ return {
   -- file explorer
   {
     "nvim-neo-tree/neo-tree.nvim",
-    branch = "v3.x",
     cmd = "Neotree",
     keys = {
       {


### PR DESCRIPTION
## What is this PR for?
`branch` was obstructing from being able to update to latest HEAD like in other plugins. This was necessary when the initial development was being done on this branch and `main` was used for the old stable release, but this is not necessary any more. Also, @folke now you can use `always_show_by_pattern`, which you might find useful to show the git tracked hidden files like you wanted but couldn't do before. 
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Does this PR fix an existing issue?
No
<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
