### PR TITLE
feat(cmp): attempt for dynamic width and trimming between fields

### DIFF
--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -74,10 +74,10 @@ return {
             -- Truncate the completion entry text if it's longer than the
             -- max content width. We subtract 3 from the max content width
             -- to account for the "..." that will be appended to it.
-            if #item.abbr > (max_content_width / 2) then
+            if item.menu and #item.abbr > (max_content_width * 0.7) then
               item.abbr = vim.fn.strcharpart(item.abbr, 0, math.floor(max_content_width * 0.7) - 3) .. "..."
             end
-            if item.menu and #item.menu > (max_content_width / 2) then
+            if item.menu and #item.menu > (max_content_width * 0.7) then
               item.menu = vim.fn.strcharpart(item.menu, 0, math.floor(max_content_width * 0.7) - 3) .. "..."
             end
 

--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -54,9 +54,33 @@ return {
             if icons[item.kind] then
               item.kind = icons[item.kind] .. item.kind
             end
-            if entry.context.filetype == "rust" then
-              item.menu = nil
+
+            -- Set 'fixed_width' to false if not provided.
+            local fixed_width = vim.g.cmp_fixed_width or false
+
+            -- Set the fixed completion window width.
+            if fixed_width then
+              vim.o.pumwidth = fixed_width
             end
+
+            -- Get the width of the current window.
+            local win_width = vim.api.nvim_win_get_width(0)
+
+            -- Set the max content width based on either: 'fixed_width'
+            -- or a percentage of the window width, in this case 20%.
+            -- We subtract 10 from 'fixed_width' to leave room for 'kind' fields.
+            local max_content_width = fixed_width and fixed_width - 10 or math.floor(win_width * 0.25)
+
+            -- Truncate the completion entry text if it's longer than the
+            -- max content width. We subtract 3 from the max content width
+            -- to account for the "..." that will be appended to it.
+            if #item.abbr > (max_content_width / 2) then
+              item.abbr = vim.fn.strcharpart(item.abbr, 0, math.floor(max_content_width * 0.7) - 3) .. "..."
+            end
+            if item.menu and #item.menu > (max_content_width / 2) then
+              item.menu = vim.fn.strcharpart(item.menu, 0, math.floor(max_content_width * 0.7) - 3) .. "..."
+            end
+
             return item
           end,
         },

--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -55,14 +55,15 @@ return {
               item.kind = icons[item.kind] .. item.kind
             end
 
-            local abbr_width = vim.g.cmp_widths and vim.g.cmp_widths.abbr or 30
-            local menu_width = vim.g.cmp_widths and vim.g.cmp_widths.menu or 30
+            local widths = {
+              abbr = vim.g.cmp_widths and vim.g.cmp_widths.abbr or 40,
+              menu = vim.g.cmp_widths and vim.g.cmp_widths.menu or 30,
+            }
 
-            if item.menu then
-              if vim.fn.strdisplaywidth(item.abbr) > abbr_width then
-                item.abbr = vim.fn.strcharpart(item.abbr, 0, abbr_width - 1) .. "…"
+            for key, width in pairs(widths) do
+              if item[key] and vim.fn.strdisplaywidth(item[key]) > width then
+                item[key] = vim.fn.strcharpart(item[key], 0, width - 1) .. "…"
               end
-              item.menu = vim.fn.strcharpart(item.menu, 0, menu_width - 1) .. "…"
             end
 
             return item

--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -75,10 +75,10 @@ return {
             -- max content width. We subtract 3 from the max content width
             -- to account for the "..." that will be appended to it.
             if item.menu and #item.abbr > (max_content_width * 0.7) then
-              item.abbr = vim.fn.strcharpart(item.abbr, 0, math.floor(max_content_width * 0.7) - 3) .. "..."
+              item.abbr = vim.fn.strcharpart(item.abbr, 0, math.floor(max_content_width * 0.7) - 3) .. "…"
             end
             if item.menu and #item.menu > (max_content_width * 0.7) then
-              item.menu = vim.fn.strcharpart(item.menu, 0, math.floor(max_content_width * 0.7) - 3) .. "..."
+              item.menu = vim.fn.strcharpart(item.menu, 0, math.floor(max_content_width * 0.7) - 3) .. "…"
             end
 
             return item

--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -55,30 +55,14 @@ return {
               item.kind = icons[item.kind] .. item.kind
             end
 
-            -- Set 'fixed_width' to false if not provided.
-            local fixed_width = vim.g.cmp_fixed_width or false
+            local abbr_width = vim.g.cmp_widths and vim.g.cmp_widths.abbr or 30
+            local menu_width = vim.g.cmp_widths and vim.g.cmp_widths.menu or 30
 
-            -- Set the fixed completion window width.
-            if fixed_width then
-              vim.o.pumwidth = fixed_width
-            end
-
-            -- Get the width of the current window.
-            local win_width = vim.api.nvim_win_get_width(0)
-
-            -- Set the max content width based on either: 'fixed_width'
-            -- or a percentage of the window width, in this case 20%.
-            -- We subtract 10 from 'fixed_width' to leave room for 'kind' fields.
-            local max_content_width = fixed_width and fixed_width - 10 or math.floor(win_width * 0.25)
-
-            -- Truncate the completion entry text if it's longer than the
-            -- max content width. We subtract 3 from the max content width
-            -- to account for the "..." that will be appended to it.
-            if item.menu and #item.abbr > (max_content_width * 0.7) then
-              item.abbr = vim.fn.strcharpart(item.abbr, 0, math.floor(max_content_width * 0.7) - 3) .. "…"
-            end
-            if item.menu and #item.menu > (max_content_width * 0.7) then
-              item.menu = vim.fn.strcharpart(item.menu, 0, math.floor(max_content_width * 0.7) - 3) .. "…"
+            if item.menu then
+              if vim.fn.strdisplaywidth(item.abbr) > abbr_width then
+                item.abbr = vim.fn.strcharpart(item.abbr, 0, abbr_width - 1) .. "…"
+              end
+              item.menu = vim.fn.strcharpart(item.menu, 0, menu_width - 1) .. "…"
             end
 
             return item


### PR DESCRIPTION
## What is this PR for?
Attempt for dynamic width and trimming between fields.
Testing was done on my 15.6 laptop screen so maybe values could be raised in dynamic calculation? Also provides a `vim.g.cmp_fixed_width` for the users to be able to define a fixed width in their personal configuration if they'd like to.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Does this PR fix an existing issue?
Attempts to rectify a concern raised in #3858
<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
