### PR TITLE
fix(chezmoi): missing support for fzf file picker

### DIFF
--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -1,3 +1,27 @@
+local pick_chezmoi = function()
+  if LazyVim.pick.picker.name == "telescope" then
+    require("telescope").extensions.chezmoi.find_files()
+  elseif LazyVim.pick.picker.name == "fzf" then
+    local fzf_lua = require("fzf-lua")
+    local results = require("chezmoi.commands").list()
+    local chezmoi = require("chezmoi.commands")
+
+    local opts = {
+      fzf_opts = {},
+      fzf_colors = true,
+      actions = {
+        ["default"] = function(selected)
+          chezmoi.edit({
+            targets = { "~/" .. selected[1] },
+            args = { "--watch" },
+          })
+        end,
+      },
+    }
+    fzf_lua.fzf_exec(results, opts)
+  end
+end
+
 return {
   {
     -- highlighting for chezmoi files template files
@@ -12,9 +36,7 @@ return {
     keys = {
       {
         "<leader>sz",
-        function()
-          require("telescope").extensions.chezmoi.find_files()
-        end,
+        pick_chezmoi,
         desc = "Chezmoi",
       },
     },
@@ -47,7 +69,7 @@ return {
     optional = true,
     opts = function(_, opts)
       local projects = {
-        action = "Telescope chezmoi find_files",
+        action = pick_chezmoi,
         desc = "  Config",
         icon = "",
         key = "c",


### PR DESCRIPTION
## What is this PR for?

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
  
This fixes an issue with the chezmoi extra that won't work if the LazyVim picker is fzf-lua instead of Telescope. Fx if you have the `editor.fzf` and `util.chezmoi` extras enabled at the same time, trying to open the config from the dashboard will result in the following error because Telescope has been replaced with fzf:
```
E5108: Error executing lua: vim/_editor.lua:0: nvim_exec2(): Vim:E492: Not an editor command: Telescope chezmoi find_files
stack traceback:
	[C]: in function 'nvim_exec2'
	vim/_editor.lua: in function 'cmd'
	...re/nvim/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:24: in function <...re/nvim/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:20>

```
This PR fixes the issue by checking which LazyVim picker is in use. 

Before: 

https://github.com/LazyVim/LazyVim/assets/53434466/31cade36-1655-438f-9aa8-c3de8fec881f

After: 

https://github.com/LazyVim/LazyVim/assets/53434466/55f7d0c7-9632-4d52-8a6e-dfba17b14ed4


## Does this PR fix an existing issue?

<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
