### PR TITLE
feat(ui): use `mini.icons` instead of `nvim-wev-devicons`

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -303,41 +303,7 @@ return {
   },
 
   -- icons
-  {
-    "echasnovski/mini.icons",
-    lazy = true,
-    opts = {},
-    init = function()
-      package.preload["nvim-web-devicons"] = function()
-        local Icons = require("mini.icons")
-        local ret = {}
-        package.loaded["nvim-web-devicons"] = ret
-        Icons.mock_nvim_web_devicons()
-
-        local function get(cat)
-          local all = {}
-          for _, name in ipairs(Icons.list(cat)) do
-            local icon, color = ret.get_icon_color(cat == "file" and name, cat == "extension" and name)
-            all[name] = { icon = icon, color = color }
-          end
-          return all
-        end
-
-        ret.get_icons_by_extension = function()
-          return get("extension")
-        end
-
-        ret.get_icons_by_filename = function()
-          return get("file")
-        end
-
-        ret.get_icons = function()
-          return vim.tbl_extend("force", get("file"), get("extension"))
-        end
-        return ret
-      end
-    end,
-  },
+  { "echasnovski/mini.icons", lazy = true, opts = {}, init = LazyVim.mini.devicons },
 
   -- ui components
   { "MunifTanjim/nui.nvim", lazy = true },

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -303,7 +303,17 @@ return {
   },
 
   -- icons
-  { "echasnovski/mini.icons", lazy = true, opts = {}, init = LazyVim.mini.devicons },
+  {
+    "echasnovski/mini.icons",
+    lazy = true,
+    opts = {},
+    init = function()
+      package.preload["nvim-web-devicons"] = function()
+        require("mini.icons").mock_nvim_web_devicons()
+        return package.loaded["nvim-web-devicons"]
+      end
+    end,
+  },
 
   -- ui components
   { "MunifTanjim/nui.nvim", lazy = true },

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -309,10 +309,32 @@ return {
     opts = {},
     init = function()
       package.preload["nvim-web-devicons"] = function()
-        -- needed since it will be false when loading and mini will fail
-        package.loaded["nvim-web-devicons"] = {}
-        require("mini.icons").mock_nvim_web_devicons()
-        return package.loaded["nvim-web-devicons"]
+        local Icons = require("mini.icons")
+        local ret = {}
+        package.loaded["nvim-web-devicons"] = ret
+        Icons.mock_nvim_web_devicons()
+
+        local function get(cat)
+          local all = {}
+          for _, name in ipairs(Icons.list(cat)) do
+            local icon, color = ret.get_icon_color(cat == "file" and name, cat == "extension" and name)
+            all[name] = { icon = icon, color = color }
+          end
+          return all
+        end
+
+        ret.get_icons_by_extension = function()
+          return get("extension")
+        end
+
+        ret.get_icons_by_filename = function()
+          return get("file")
+        end
+
+        ret.get_icons = function()
+          return vim.tbl_extend("force", get("file"), get("extension"))
+        end
+        return ret
       end
     end,
   },

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -303,7 +303,19 @@ return {
   },
 
   -- icons
-  { "nvim-tree/nvim-web-devicons", lazy = true },
+  {
+    "echasnovski/mini.icons",
+    lazy = true,
+    opts = {},
+    init = function()
+      package.preload["nvim-web-devicons"] = function()
+        -- needed since it will be false when loading and mini will fail
+        package.loaded["nvim-web-devicons"] = {}
+        require("mini.icons").mock_nvim_web_devicons()
+        return package.loaded["nvim-web-devicons"]
+      end
+    end,
+  },
 
   -- ui components
   { "MunifTanjim/nui.nvim", lazy = true },

--- a/lua/lazyvim/util/mini.lua
+++ b/lua/lazyvim/util/mini.lua
@@ -148,35 +148,4 @@ function M.pairs(opts)
   end
 end
 
-function M.devicons()
-  package.preload["nvim-web-devicons"] = function()
-    local Icons = require("mini.icons")
-    local ret = {}
-    package.loaded["nvim-web-devicons"] = ret
-    Icons.mock_nvim_web_devicons()
-
-    local function get(cat)
-      local all = {}
-      for _, name in ipairs(Icons.list(cat)) do
-        local icon, color = ret.get_icon_color(cat == "file" and name, cat == "extension" and name)
-        all[name] = { icon = icon, color = color }
-      end
-      return all
-    end
-
-    ret.get_icons_by_extension = function()
-      return get("extension")
-    end
-
-    ret.get_icons_by_filename = function()
-      return get("file")
-    end
-
-    ret.get_icons = function()
-      return vim.tbl_extend("force", get("file"), get("extension"))
-    end
-    return ret
-  end
-end
-
 return M

--- a/lua/lazyvim/util/mini.lua
+++ b/lua/lazyvim/util/mini.lua
@@ -148,4 +148,35 @@ function M.pairs(opts)
   end
 end
 
+function M.devicons()
+  package.preload["nvim-web-devicons"] = function()
+    local Icons = require("mini.icons")
+    local ret = {}
+    package.loaded["nvim-web-devicons"] = ret
+    Icons.mock_nvim_web_devicons()
+
+    local function get(cat)
+      local all = {}
+      for _, name in ipairs(Icons.list(cat)) do
+        local icon, color = ret.get_icon_color(cat == "file" and name, cat == "extension" and name)
+        all[name] = { icon = icon, color = color }
+      end
+      return all
+    end
+
+    ret.get_icons_by_extension = function()
+      return get("extension")
+    end
+
+    ret.get_icons_by_filename = function()
+      return get("file")
+    end
+
+    ret.get_icons = function()
+      return vim.tbl_extend("force", get("file"), get("extension"))
+    end
+    return ret
+  end
+end
+
 return M


### PR DESCRIPTION
## What is this PR for?

Replace the icon support with the new mini library

## Blockers

- [ ] https://github.com/echasnovski/mini.nvim/issues/1007#issuecomment-2206553024