### PR TITLE
feat(fzf-lua): preview keymaps for git

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/fzf.lua
+++ b/lua/lazyvim/plugins/extras/editor/fzf.lua
@@ -53,6 +53,8 @@ return {
       config.defaults.keymap.fzf["ctrl-u"] = "half-page-up"
       config.defaults.keymap.fzf["ctrl-d"] = "half-page-down"
       config.defaults.keymap.fzf["ctrl-x"] = "jump"
+      config.defaults.keymap.fzf["ctrl-f"] = "preview-page-down"
+      config.defaults.keymap.fzf["ctrl-b"] = "preview-page-up"
       config.defaults.keymap.builtin["<c-f>"] = "preview-page-down"
       config.defaults.keymap.builtin["<c-b>"] = "preview-page-up"
 


### PR DESCRIPTION
## What is this PR for?
It seems that the preview keymaps set right now only support the builtin previewer. 

From searching through `fzf-lua` docs, I found [here](https://github.com/ibhagwan/fzf-lua/blob/3b91c1a471160bd8620bdca8f18743d954994daa/README.md?plain=1#L634-L638) that additional mappings should be set for the other previewers such as `git` (otherwise the defaults `<shift-down/up>` could be used).

I chose to use the same mappings for the `fzf` preview keymaps as they serve the same functionality. Please feel free to change if not to your liking.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Does this PR fix an existing issue?
Not an issue but a discussion #3895
<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
