### PR TITLE
feat(vue): enabled hybrid mode to avoid 2 typescript lsp running at same time

### DIFF
--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -49,11 +49,6 @@ vim.g.bigfile_size = 1024 * 1024 * 1.5 -- 1.5 MB
 -- Show the current document symbols location from Trouble in lualine
 vim.g.trouble_lualine = true
 
--- Enable hybrid mode for Vue files
--- If the hybrid mode is enabled, a sperate vtsls will run for Vue files
--- If the hybrid mode is disabled, volar will run a tsserver under the hood
-vim.g.vue_hybrid_mode = true
-
 local opt = vim.opt
 
 opt.autowrite = true -- Enable auto write

--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -49,6 +49,11 @@ vim.g.bigfile_size = 1024 * 1024 * 1.5 -- 1.5 MB
 -- Show the current document symbols location from Trouble in lualine
 vim.g.trouble_lualine = true
 
+-- Enable hybrid mode for Vue files
+-- If the hybrid mode is enabled, a sperate vtsls will run for Vue files
+-- If the hybrid mode is disabled, volar will run a tsserver under the hood
+vim.g.vue_hybrid_mode = true
+
 local opt = vim.opt
 
 opt.autowrite = true -- Enable auto write

--- a/lua/lazyvim/plugins/extras/lang/vue.lua
+++ b/lua/lazyvim/plugins/extras/lang/vue.lua
@@ -22,7 +22,7 @@ return {
         volar = {
           init_options = {
             vue = {
-              hybridMode = false,
+              hybridMode = true,
             },
           },
         },

--- a/lua/lazyvim/plugins/extras/lang/vue.lua
+++ b/lua/lazyvim/plugins/extras/lang/vue.lua
@@ -1,5 +1,3 @@
-local enableHybridMode = vim.g.vue_hybrid_mode
-
 return {
   recommended = function()
     return LazyVim.extras.wants({
@@ -24,7 +22,7 @@ return {
         volar = {
           init_options = {
             vue = {
-              hybridMode = enableHybridMode,
+              hybridMode = false,
             },
           },
         },
@@ -37,18 +35,16 @@ return {
   {
     "neovim/nvim-lspconfig",
     opts = function(_, opts)
-      if enableHybridMode then
-        table.insert(opts.servers.vtsls.filetypes, "vue")
-        LazyVim.extend(opts.servers.vtsls, "settings.vtsls.tsserver.globalPlugins", {
-          {
-            name = "@vue/typescript-plugin",
-            location = LazyVim.get_pkg_path("vue-language-server", "/node_modules/@vue/language-server"),
-            languages = { "vue" },
-            configNamespace = "typescript",
-            enableForWorkspaceTypeScriptVersions = true,
-          },
-        })
-      end
+      table.insert(opts.servers.vtsls.filetypes, "vue")
+      LazyVim.extend(opts.servers.vtsls, "settings.vtsls.tsserver.globalPlugins", {
+        {
+          name = "@vue/typescript-plugin",
+          location = LazyVim.get_pkg_path("vue-language-server", "/node_modules/@vue/language-server"),
+          languages = { "vue" },
+          configNamespace = "typescript",
+          enableForWorkspaceTypeScriptVersions = true,
+        },
+      })
     end,
   },
 }

--- a/lua/lazyvim/plugins/extras/lang/vue.lua
+++ b/lua/lazyvim/plugins/extras/lang/vue.lua
@@ -1,3 +1,5 @@
+local enableHybridMode = vim.g.vue_hybrid_mode
+
 return {
   recommended = function()
     return LazyVim.extras.wants({
@@ -22,7 +24,7 @@ return {
         volar = {
           init_options = {
             vue = {
-              hybridMode = false,
+              hybridMode = enableHybridMode,
             },
           },
         },
@@ -35,16 +37,18 @@ return {
   {
     "neovim/nvim-lspconfig",
     opts = function(_, opts)
-      table.insert(opts.servers.vtsls.filetypes, "vue")
-      LazyVim.extend(opts.servers.vtsls, "settings.vtsls.tsserver.globalPlugins", {
-        {
-          name = "@vue/typescript-plugin",
-          location = LazyVim.get_pkg_path("vue-language-server", "/node_modules/@vue/language-server"),
-          languages = { "vue" },
-          configNamespace = "typescript",
-          enableForWorkspaceTypeScriptVersions = true,
-        },
-      })
+      if enableHybridMode then
+        table.insert(opts.servers.vtsls.filetypes, "vue")
+        LazyVim.extend(opts.servers.vtsls, "settings.vtsls.tsserver.globalPlugins", {
+          {
+            name = "@vue/typescript-plugin",
+            location = LazyVim.get_pkg_path("vue-language-server", "/node_modules/@vue/language-server"),
+            languages = { "vue" },
+            configNamespace = "typescript",
+            enableForWorkspaceTypeScriptVersions = true,
+          },
+        })
+      end
     end,
   },
 }


### PR DESCRIPTION
## What is this PR for?

At the moment, the config for vue set hybrid mode to `false` which volar will run a typescript server under the hook. ( hybrid mode false is the takeover mode in v1, was introduced in `2.0.7` see more information here: https://github.com/vuejs/language-tools/pull/4119 ).

However, another vtsls with vue language plugin also attached to vue files, this will cause two typescript server running at the same time. It can be very easily observed with tools like `htop` volar and vtsls will have similar memory usage which is abnormal because volar should be very light by itself. This will introduce issues like duplicate diagnostics, see  https://github.com/vuejs/language-tools/issues/4159#issuecomment-2208101079

In this pull request, I set the hybrid mode to true as default because the hybrid mode is the "correct" way moving forward, thus it would be more stable. Let me know if you feel it should stay as `false` to be default.

## Does this PR fix an existing issue?

No existing issue.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
