### PR TITLE
refactor(trouble): move options in keymaps for lsp and symbols to `opts`

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -256,16 +256,18 @@ return {
   {
     "folke/trouble.nvim",
     cmd = { "Trouble" },
-    opts = {},
+    opts = {
+      modes = {
+        lsp = {
+          win = { position = "right" },
+        },
+      },
+    },
     keys = {
       { "<leader>xx", "<cmd>Trouble diagnostics toggle<cr>", desc = "Diagnostics (Trouble)" },
       { "<leader>xX", "<cmd>Trouble diagnostics toggle filter.buf=0<cr>", desc = "Buffer Diagnostics (Trouble)" },
-      { "<leader>cs", "<cmd>Trouble symbols toggle focus=false<cr>", desc = "Symbols (Trouble)" },
-      {
-        "<leader>cS",
-        "<cmd>Trouble lsp toggle focus=false win.position=right<cr>",
-        desc = "LSP references/definitions/... (Trouble)",
-      },
+      { "<leader>cs", "<cmd>Trouble symbols toggle<cr>", desc = "Symbols (Trouble)" },
+      { "<leader>cS", "<cmd>Trouble lsp toggle<cr>", desc = "LSP references/definitions/... (Trouble)" },
       { "<leader>xL", "<cmd>Trouble loclist toggle<cr>", desc = "Location List (Trouble)" },
       { "<leader>xQ", "<cmd>Trouble qflist toggle<cr>", desc = "Quickfix List (Trouble)" },
       {


### PR DESCRIPTION
## What is this PR for?

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
A user won't also have to override the keymaps if they set options for `Trouble lsp` or `symbols` in `opts` (assuming they want the mode to always open with certain options).

## Does this PR fix an existing issue?
No.

<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

## Checklist

- [ x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.

----

The default for `Trouble symbols` already seems to be on the right, and neither lsp/symbols auto-focuses, so I left these out.