### PR TITLE
fix(project): properly close window after changing directory

### DIFF
--- a/lua/lazyvim/plugins/extras/util/project.lua
+++ b/lua/lazyvim/plugins/extras/util/project.lua
@@ -62,7 +62,7 @@ pick = function()
             local path = selected[1]
             local ok = project.set_pwd(path)
             if ok then
-              vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", true)
+              vim.api.nvim_win_close(0, false)
               LazyVim.info("Change project dir to " .. path)
             end
           end,


### PR DESCRIPTION
## What is this PR for?

In project extra, when using `<c-w>` in the project selection menu to change directory, the window used to show the command's exit code would not close. This fixes it.

## Does this PR fix an existing issue?

N/A.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
