### PR TITLE
fix(outline): use the correct symbols and filter config format

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/outline.lua
+++ b/lua/lazyvim/plugins/extras/editor/outline.lua
@@ -14,28 +14,21 @@ return {
     opts = function()
       local defaults = require("outline.config").defaults
       local opts = {
-        symbols = {},
-        symbol_blacklist = {},
+        symbols = {
+          icons = {},
+          filter = LazyVim.config.kind_filter,
+        },
         keymaps = {
           up_and_jump = "<up>",
           down_and_jump = "<down>",
         },
       }
-      local filter = LazyVim.config.kind_filter
 
-      if type(filter) == "table" then
-        filter = filter.default
-        if type(filter) == "table" then
-          for kind, symbol in pairs(defaults.symbols) do
-            opts.symbols[kind] = {
-              icon = LazyVim.config.icons.kinds[kind] or symbol.icon,
-              hl = symbol.hl,
-            }
-            if not vim.tbl_contains(filter, kind) then
-              table.insert(opts.symbol_blacklist, kind)
-            end
-          end
-        end
+      for kind, symbol in pairs(defaults.symbols.icons) do
+        opts.symbols.icons[kind] = {
+          icon = LazyVim.config.icons.kinds[kind] or symbol.icon,
+          hl = symbol.hl,
+        }
       end
       return opts
     end,


### PR DESCRIPTION

## What is this PR for?

The symbols-outline extra was removed in favor of outline.nvim in #2535 (thanks!), but the configuration for symbols in outline.nvim [is not backwards-compatible](https://github.com/hedyhli/outline.nvim/issues/12).

This fixes the configuration for the symbols icons and filter to be usable by outline.nvim.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Does this PR fix an existing issue?

<!--
  If this PR fixes any issues, please link to the issue here.
  Fixes #<issue_number>
-->

It doesn't seem like anyone has encountered this issue, but I can confirm that the config currently used by LazyVim is incorrect. The symbols table is at `symbols` for symbols-outline.nvim, but it's now at `symbols.icons` for outline.nvim.

There is no such `symbols_blacklist` key. Instead, `symbols.filter` is used, which is a kind of "whitelist".

Coincidentally, outline.nvim fully supports the LazyVim `kind_filter` config table structure. It can either be a list of strings (kinds), or a list of strings for each filetype key. Setting to nil or false makes it so all symbols are included, just like in LazyVim.

See [the docs on the `symbols.filter`](https://github.com/hedyhli/outline.nvim?tab=readme-ov-file#symbols-table) structure.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
