### PR TITLE
fix(dial): move date related augends to default group

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/dial.lua
+++ b/lua/lazyvim/plugins/extras/editor/dial.lua
@@ -115,20 +115,19 @@ return {
           augend.integer.alias.decimal, -- nonnegative decimal number (0, 1, 2, 3, ...)
           augend.integer.alias.hex, -- nonnegative hex number  (0x01, 0x1a1f, etc.)
           augend.date.alias["%Y/%m/%d"], -- date (2022/02/19, etc.)
+          ordinal_numbers,
+          weekdays,
+          months,
         },
         typescript = {
           augend.integer.alias.decimal, -- nonnegative and negative decimal number
           augend.constant.alias.bool, -- boolean value (true <-> false)
           logical_alias,
           augend.constant.new({ elements = { "let", "const" } }),
-          ordinal_numbers,
-          weekdays,
-          months,
         },
         yaml = {
           augend.integer.alias.decimal, -- nonnegative and negative decimal number
           augend.constant.alias.bool, -- boolean value (true <-> false)
-          ordinal_numbers,
         },
         css = {
           augend.integer.alias.decimal, -- nonnegative and negative decimal number
@@ -141,9 +140,6 @@ return {
         },
         markdown = {
           augend.misc.alias.markdown_header,
-          ordinal_numbers,
-          weekdays,
-          months,
         },
         json = {
           augend.integer.alias.decimal, -- nonnegative and negative decimal number
@@ -157,17 +153,11 @@ return {
             word = true, -- if false, "sand" is incremented into "sor", "doctor" into "doctand", etc.
             cyclic = true, -- "or" is incremented into "and".
           }),
-          ordinal_numbers,
-          weekdays,
-          months,
         },
         python = {
           augend.integer.alias.decimal, -- nonnegative and negative decimal number
           capitalized_boolean,
           logical_alias,
-          ordinal_numbers,
-          weekdays,
-          months,
         },
       },
     }


### PR DESCRIPTION
## What is this PR for?

Move augends `ordinal_numbers`, `weekdays` and `months` to the default group, making them available to all filetypes. I don't think there is a concrete reason to restrict them to specific filetypes.

## Does this PR fix an existing issue?

N/A.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
