### PR TITLE
fix(lualine): use the new ministarter file type to disable in mini.starter

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -120,7 +120,7 @@ return {
         options = {
           theme = "auto",
           globalstatus = vim.o.laststatus == 3,
-          disabled_filetypes = { statusline = { "dashboard", "alpha", "starter" } },
+          disabled_filetypes = { statusline = { "dashboard", "alpha", "ministarter" } },
         },
         sections = {
           lualine_a = { "mode" },


### PR DESCRIPTION
## What is this PR for?

`mini.starter` recently had a breaking change to set the file type to `ministarter` instead of the old `starter`; so, `lualine` is enabled in the dashboard because it's using the old file type.

## Does this PR fix an existing issue?

No.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.