### PR TITLE
feat(fzf): add ability to send additional flags to ripgrep

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/fzf.lua
+++ b/lua/lazyvim/plugins/extras/editor/fzf.lua
@@ -167,6 +167,15 @@ return {
           },
         },
         grep = {
+          rg_glob = true,
+          -- first returned string is the new search query
+          -- second returned string are (optional) additional rg flags
+          -- @return string, string?
+          rg_glob_fn = function(query)
+            local regex, flags = query:match("^(.-)%s%-%-(.*)$")
+            -- If no separator is detected will return the original query
+            return (regex or query), flags
+          end,
           actions = {
             ["alt-i"] = { actions.toggle_ignore },
             ["alt-h"] = { actions.toggle_hidden },


### PR DESCRIPTION
## What is this PR for?

This PR adds the ability to send optional additional flags to ripgrep. 

**Demo**

[lazyvim-rg-flags.webm](https://github.com/LazyVim/LazyVim/assets/3210082/c1bc4359-a85e-4bb7-9b75-acae778e7323)


## Does this PR fix an existing issue?

Nope

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
