### PR TITLE
fix(mini.starter): lazyvim startuptime in mini.starter

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/mini-starter.lua
+++ b/lua/lazyvim/plugins/extras/ui/mini-starter.lua
@@ -69,7 +69,7 @@ return {
           local pad_footer = string.rep(" ", 8)
           starter.config.footer = pad_footer .. "⚡ Neovim loaded " .. stats.count .. " plugins in " .. ms .. "ms"
           -- INFO: based on @echasnovski's recommendation (thanks a lot!!!)
-          if vim.bo[ev.buf].filetype == "starter" then
+          if vim.bo[ev.buf].filetype == "ministarter" then
             pcall(starter.refresh)
           end
         end,


### PR DESCRIPTION
## What is this PR for?

In a fresh install of lazyvim (with` neovim nightly or stable), the startup time is not shown in the mini.starter extra. This fixes it.
The filetype name has changed in mini.starter
https://github.com/echasnovski/mini.starter/commit/394994b2bec10a997c69575825d5c444957b9ff9

## Does this PR fix an existing issue?

Did not find an issue for it.

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.