### PR TITLE
fix(tailwind): additional tailwind completion settings for phoenix projects

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/tailwind.lua
+++ b/lua/lazyvim/plugins/extras/lang/tailwind.lua
@@ -40,6 +40,17 @@ return {
             return not vim.tbl_contains(opts.filetypes_exclude or {}, ft)
           end, opts.filetypes)
 
+          -- Additional settings for Phoenix projects
+          opts.settings = {
+            tailwindCSS = {
+              includeLanguages = {
+                elixir = "html-eex",
+                eelixir = "html-eex",
+                heex = "html-eex",
+              },
+            },
+          }
+
           -- Add additional filetypes
           vim.list_extend(opts.filetypes, opts.filetypes_include or {})
         end,


### PR DESCRIPTION
## Description

Tailwind completions stopped working in Phoenix projects that have `HTML`, `HEEX` or `Elixir files with ~H sigils`. 

Broader discussion and recommended solution: https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1002

## Related Issue(s)


## Screenshots

![Screenshot 2024-07-08 at 9 05 45 PM](https://github.com/LazyVim/LazyVim/assets/379021/8572e6c1-12dd-454c-b60e-3b33ae448284)
![Screenshot 2024-07-08 at 9 05 08 PM](https://github.com/LazyVim/LazyVim/assets/379021/f93bdc28-813e-4485-b40d-146c1670b8c2)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
