### PR TITLE
fix(java): fix `config_overrides` for tests

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -227,13 +227,17 @@ return {
                   ["<leader>t"] = { name = "+test" },
                   ["<leader>tt"] = {
                     function()
-                      require("jdtls.dap").test_class({ config_overrides = opts.test.config_overrides })
+                      require("jdtls.dap").test_class({
+                        config_overrides = type(opts.test) ~= "boolean" and opts.test.config_overrides or nil,
+                      })
                     end,
                     "Run All Test",
                   },
                   ["<leader>tr"] = {
                     function()
-                      require("jdtls.dap").test_nearest_method({ config_overrides = opts.test.config_overrides })
+                      require("jdtls.dap").test_nearest_method({
+                        config_overrides = type(opts.test) ~= "boolean" and opts.test.config_overrides or nil,
+                      })
                     end,
                     "Run Nearest Test",
                   },


### PR DESCRIPTION
## Description
Problem
In the default configuration `opts.test` is a boolean and the code tries to access `opts.test.config_overrides` which results in an error.

Solution
Use control flow to return nil in the case of `opts.test` being boolean.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
  - Fixes #3965.

## Checklist

- [ x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
