### PR TITLE
Fix #3973: Fixed pattern for autocomand lazyvim_wrap_spell

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -87,7 +87,7 @@ vim.api.nvim_create_autocmd("FileType", {
 -- wrap and check for spell in text filetypes
 vim.api.nvim_create_autocmd("FileType", {
   group = augroup("wrap_spell"),
-  pattern = { "*.txt", "*.tex", "*.typ", "gitcommit", "markdown" },
+  pattern = { "text", "plaintex", "typst", "gitcommit", "markdown" },
   callback = function()
     vim.opt_local.wrap = true
     vim.opt_local.spell = true


### PR DESCRIPTION
## Description

Autocommand group lazyvim_wrap_spell was not triggering for all of the specified file types.  

The autocommand will now trigger for types "text", "plaintex", "typst", "gitcommit", "markdown" as intended.

## Related Issue(s)

 - Fixes #3973 


## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
