### PR TITLE
fix(autocmds): error occurs when bigfile size is nil

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -119,7 +119,7 @@ vim.filetype.add({
   pattern = {
     [".*"] = {
       function(path, buf)
-	local bfs = vim.g.bigfile_size
+        local bfs = vim.g.bigfile_size
         return vim.bo[buf]
             and vim.bo[buf].filetype ~= "bigfile"
             and path

--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -119,10 +119,11 @@ vim.filetype.add({
   pattern = {
     [".*"] = {
       function(path, buf)
+	local bfs = vim.g.bigfile_size
         return vim.bo[buf]
             and vim.bo[buf].filetype ~= "bigfile"
             and path
-            and vim.fn.getfsize(path) > vim.g.bigfile_size
+            and (bfs and vim.fn.getfsize(path) > bfs or true)
             and "bigfile"
           or nil
       end,


### PR DESCRIPTION
> I'm using neovim
When `vim.g.bigfile_size == nil`, then an error will occur: `attempt to compare nil with number`.

After this fix, the comparison will not be made, so no error will occur.