### PR TITLE
fix(php): `php_cs_fixer` is the correct name

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/php.lua
+++ b/lua/lazyvim/plugins/extras/lang/php.lua
@@ -74,13 +74,13 @@ return {
         php = { "phpcs" },
       },
     },
-    {
-      "stevearc/conform.nvim",
-      optional = true,
-      opts = {
-        formatters_by_ft = {
-          php = { "php-cs-fixer" },
-        },
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        php = { "php_cs_fixer" },
       },
     },
   },


### PR DESCRIPTION
## Description
`conform.nvim` was not using the correct formatter name for `php-cs-fixer` (which is the name of the binary). 
Also move `conform.nvim` spec outside of `nvim-lint` spec.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #3985
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
