### PR TITLE
fix(flit): use which-key preset keymap descriptions

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/leap.lua
+++ b/lua/lazyvim/plugins/extras/editor/leap.lua
@@ -7,10 +7,10 @@ return {
     "ggandor/flit.nvim",
     enabled = true,
     keys = function()
-      ---@type LazyKeys[]
+      ---@type LazyKeysSpec[]
       local ret = {}
       for _, key in ipairs({ "f", "F", "t", "T" }) do
-        ret[#ret + 1] = { key, mode = { "n", "x", "o" }, desc = key }
+        ret[#ret + 1] = { key, mode = { "n", "x", "o" } }
       end
       return ret
     end,


### PR DESCRIPTION
## Description

The flit config overrides the descriptions provided by the which-key presets plugin for the `f`/`F`/`t`/`T` motions with an unhelpful description text (just the key itself).

Remove the `desc` argument so that which-key uses the existing description (e.g "Move before next char").

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

| Before | After |
| ------------- | ------------- |
| ![Before](https://github.com/user-attachments/assets/39b885fe-95c2-4a6e-8b22-4e5ddf1986a9) | ![After](https://github.com/user-attachments/assets/6042fde3-e135-48fa-b1fd-c6047277903a)  |


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
