### PR TITLE
fix(outline): use new object for `symbols.filter`

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/outline.lua
+++ b/lua/lazyvim/plugins/extras/editor/outline.lua
@@ -16,7 +16,7 @@ return {
       local opts = {
         symbols = {
           icons = {},
-          filter = LazyVim.config.kind_filter,
+          filter = vim.deepcopy(LazyVim.config.kind_filter),
         },
         keymaps = {
           up_and_jump = "<up>",


### PR DESCRIPTION
## Description
In `outline.nvim` we have `symbols.filter = LazyVim.config.kind_filter`. `outline.nvim` adds an entry `exclude = false` by default when it's a table. This entry propagates to `LazyVim.config.kind_filter` and when using `LazyVim.config.get_kind_filter()` in Telescope `<leader>ss` that entry is there as well and causes the error in https://github.com/nvim-telescope/telescope.nvim/blob/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a/lua/telescope/utils.lua#L143. Use `vim.deepcopy` to create a new object for `symbols.filter` in `outline.nvim`, so that the additional entries don't propagate to default `LazyVim.config.kind_filter`.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #4003
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
