### PR TITLE
fix(omnisharp): don't detach coreclr debug adapter

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/omnisharp.lua
+++ b/lua/lazyvim/plugins/extras/lang/omnisharp.lua
@@ -75,6 +75,9 @@ return {
           type = "executable",
           command = vim.fn.exepath("netcoredbg"),
           args = { "--interpreter=vscode" },
+          options = {
+            detached = false,
+          },
         }
       end
       for _, lang in ipairs({ "cs", "fsharp", "vb" }) do


### PR DESCRIPTION
## Description

Debugging c# with the Omnisharp plugin doesn't work, as described by myself in #4004. Turns out this is a known issue with how nvim-dap calls the mason netcoredbg cmd script. [The solution](https://github.com/jay-babu/mason-nvim-dap.nvim/issues/132) is to pass `detach = false` as an option to the debug adapter. I've tested and it works on my windows machine.

## Related Issue(s)

#4004

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
