### PR TITLE
fix(extra): luasnip wasn't lazyloaded

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/luasnip.lua
+++ b/lua/lazyvim/plugins/extras/coding/luasnip.lua
@@ -1,6 +1,7 @@
 return {
   {
     "L3MON4D3/LuaSnip",
+    lazy = true,
     build = (not LazyVim.is_win())
         and "echo 'NOTE: jsregexp is optional, so not a big deal if it fails to build'; make install_jsregexp"
       or nil,


### PR DESCRIPTION
## Description

this makes the extra luasnip lazy load at the same time as nvim cmp.
just putting `lazy = true` works because `nvim-cmp` when being loaded with `InsertEnter` also load `cmp-luasnip`, which itself load `LUASNIP`.

you can see the problem in the following discussion https://github.com/LazyVim/LazyVim/discussions/3966 where luasnip was not lazy loaded when starting lazyvim. This was also loading nvim-cmp and all its dep when starting lazyvim, which negatively impacted performance.

## Related Issue(s)

https://github.com/LazyVim/LazyVim/discussions/3966

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
