### PR TITLE
fix(keymaps): don't use gj and gk in V-LINE and V-BLOCK modes

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -5,10 +5,14 @@
 local map = LazyVim.safe_keymap_set
 
 -- better up/down
-map({ "n", "x" }, "j", "v:count == 0 ? 'gj' : 'j'", { desc = "Down", expr = true, silent = true })
-map({ "n", "x" }, "<Down>", "v:count == 0 ? 'gj' : 'j'", { desc = "Down", expr = true, silent = true })
-map({ "n", "x" }, "k", "v:count == 0 ? 'gk' : 'k'", { desc = "Up", expr = true, silent = true })
-map({ "n", "x" }, "<Up>", "v:count == 0 ? 'gk' : 'k'", { desc = "Up", expr = true, silent = true })
+map("n", "j", "v:count == 0 ? 'gj' : 'j'", { desc = "Down", expr = true, silent = true })
+map("n", "<Down>", "v:count == 0 ? 'gj' : 'j'", { desc = "Down", expr = true, silent = true })
+map("n", "k", "v:count == 0 ? 'gk' : 'k'", { desc = "Up", expr = true, silent = true })
+map("n", "<Up>", "v:count == 0 ? 'gk' : 'k'", { desc = "Up", expr = true, silent = true })
+map("x", "j", "mode() ==# 'v' && v:count == 0 ? 'gj' : 'j'", { desc = "Down", expr = true, silent = true })
+map("x", "<Down>", "mode() ==# 'v' && v:count == 0 ? 'gj' : 'j'", { desc = "Down", expr = true, silent = true })
+map("x", "k", "mode() ==# 'v' && v:count == 0 ? 'gk' : 'k'", { desc = "Up", expr = true, silent = true })
+map("x", "<Up>", "mode() ==# 'v' && v:count == 0 ? 'gk' : 'k'", { desc = "Up", expr = true, silent = true })
 
 -- Move to window using the <ctrl> hjkl keys
 map("n", "<C-h>", "<C-w>h", { desc = "Go to Left Window", remap = true })


### PR DESCRIPTION
## Description

In regular visual mode gk and gj make sense as the default, but when doing block or line selects regular j and k are better defaults. When you use gk or gj in visual-line mode, nothing new gets selected if stay in the same wrapped line, so all it accomplishes is requiring more inputs to select the next line. In visual-block mode it's even worse as you generally want to select a block, but by using gk/gj on a wrapped line your selection changes horizontally instead of vertically.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
