### PR TITLE
feat(lang): add Typst language support

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typst.lua
+++ b/lua/lazyvim/plugins/extras/lang/typst.lua
@@ -1,0 +1,53 @@
+return {
+  recommended = function()
+    return LazyVim.extras.wants({
+      ft = { "typst" },
+    })
+  end,
+
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = {
+      ensure_installed = { "typst" },
+    },
+  },
+
+  -- Wait until this package is available in the mason-registry
+  -- {
+  --   "williamboman/mason.nvim",
+  --   opts = {
+  --     ensure_installed = { "typstyle" },
+  --   },
+  -- },
+
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        tinymist = {},
+      },
+    },
+  },
+
+  {
+    "stevearc/conform.nvim",
+    opts = {
+      formatters_by_ft = {
+        typst = { "typstyle" },
+      },
+    },
+  },
+
+  {
+    "chomosuke/typst-preview.nvim",
+    cmd = { "TypstPreview" },
+    build = function()
+      require("typst-preview").update()
+    end,
+    opts = {
+      dependencies_bin = {
+        ["typst-preview"] = "tinymist",
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Description

This pull request adds robust support for the Typst language to LazyVim, integrating several tools to enhance the Typst development experience:

1. **LSP Support**: Integrated with [tinymist](https://github.com/Myriad-Dreamin/tinymist) to provide comprehensive language server protocol support.
2. **Code Formatting**: Planned integration with [typstyle](https://github.com/Enter-tainer/typstyle) for automatic code formatting. Please note that typstyle is currently not available in the mason-registry. We are awaiting the merging of [this PR](https://github.com/mason-org/mason-registry/pull/6479) to enable this feature.
3. **Preview Support**: Added [typst-preview.nvim](https://github.com/chomosuke/typst-preview.nvim) for live preview of Typst documents.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.