### PR TITLE
feat(util.mini): follow the user's mappings instead of hardcoded values

### DIFF
--- a/lua/lazyvim/util/mini.lua
+++ b/lua/lazyvim/util/mini.lua
@@ -92,8 +92,22 @@ function M.ai_whichkey()
   }
 
   local ret = { mode = { "o", "x" } }
-  local mappings = LazyVim.opts("mini.ai").mappings
+  local default_mappings = {
+    around = "a",
+    inside = "i",
+
+    around_next = "an",
+    inside_next = "in",
+    around_last = "al",
+    inside_last = "il",
+  }
+  local user_mappings = LazyVim.opts("mini.ai").mappings
+  local mappings = vim.tbl_extend("force", default_mappings, user_mappings)
+
   for name, prefix in pairs(mappings) do
+    if name:match("next$") or name:match("last$") then
+      name = name:gsub("^around_", ""):gsub("^inside_", "")
+    end
     ret[#ret + 1] = { prefix, group = name }
     for _, obj in ipairs(objects) do
       local desc = obj.desc

--- a/lua/lazyvim/util/mini.lua
+++ b/lua/lazyvim/util/mini.lua
@@ -92,14 +92,8 @@ function M.ai_whichkey()
   }
 
   local ret = { mode = { "o", "x" } }
-  for prefix, name in pairs({
-    i = "inside",
-    a = "around",
-    il = "last",
-    ["in"] = "next",
-    al = "last",
-    an = "next",
-  }) do
+  local mappings = LazyVim.opts("mini.ai").mappings
+  for name, prefix in pairs(mappings) do
     ret[#ret + 1] = { prefix, group = name }
     for _, obj in ipairs(objects) do
       local desc = obj.desc


### PR DESCRIPTION
Because I use the Colemak-DH keyboard layout, I have mapped 'i' to 'h'. Therefore, the current mini.ai which_key prompts are inconsistent with my keymap.


## Description

The names and prefixes used in mini.ai_whichkey() are hardcoded and should follow the user's mappings.

## Related Issue(s)

No

## Screenshots

No

## Checklist

- [ x ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.

