### PR TITLE
fix(yanky): Enable yank history in visual mode too

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/yanky.lua
+++ b/lua/lazyvim/plugins/extras/coding/yanky.lua
@@ -17,6 +17,7 @@ return {
           vim.cmd([[YankyRingHistory]])
         end
       end,
+      mode = { "n", "x" },
       desc = "Open Yank History",
     },
         -- stylua: ignore


### PR DESCRIPTION
## Description

Being able to select from the yank history is useful if you want to
paste over something else by first selecting the stuff you want to
remove in visual mode.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
