### PR TITLE
feat(cmp): use mini.icons when it is added

### DIFF
--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -50,9 +50,16 @@ return {
         }),
         formatting = {
           format = function(entry, item)
-            local icons = LazyVim.config.icons.kinds
-            if icons[item.kind] then
-              item.kind = icons[item.kind] .. item.kind
+            local icon = LazyVim.config.icons.kinds[item.kind]
+            if LazyVim.has("mini.icons") then
+              local mini_icon, _, _ = require("mini.icons").get("lsp", item.kind)
+              if mini_icon then
+                icon = mini_icon .. " "
+              end
+            end
+
+            if icon then
+              item.kind = icon .. item.kind
             end
 
             local widths = {


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Use mini.icons in cmp list
## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots
- before
<img width="597" alt="SCR-20240721-siiy" src="https://github.com/user-attachments/assets/fb76b7de-ee35-4a51-aeb1-6d9fa7e4991f">




- mini.icons
<img width="595" alt="SCR-20240721-sici" src="https://github.com/user-attachments/assets/f8612436-05af-4461-9249-9f7fb50c8837">

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
