### PR TITLE
feat(R): added new which-key group for new install feature

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/r.lua
+++ b/lua/lazyvim/plugins/extras/lang/r.lua
@@ -19,7 +19,6 @@ return {
           vim.keymap.set("n", "<Enter>", "<Plug>RDSendLine", { buffer = true })
           vim.keymap.set("v", "<Enter>", "<Plug>RSendSelection", { buffer = true })
 
-          -- Increase the width of which-key to handle the longer r-nvim descriptions
           local wk = require("which-key")
           wk.add({
             { "<localleader>a", group = "all" },
@@ -27,6 +26,7 @@ return {
             { "<localleader>c", group = "chunks" },
             { "<localleader>f", group = "functions" },
             { "<localleader>g", group = "goto" },
+            { "<localleader>i", group = "install" },
             { "<localleader>k", group = "knit" },
             { "<localleader>p", group = "paragraph" },
             { "<localleader>q", group = "quarto" },

--- a/lua/lazyvim/plugins/extras/lang/r.lua
+++ b/lua/lazyvim/plugins/extras/lang/r.lua
@@ -21,6 +21,7 @@ return {
 
           local wk = require("which-key")
           wk.add({
+            buffer = true,
             { "<localleader>a", group = "all" },
             { "<localleader>b", group = "between marks" },
             { "<localleader>c", group = "chunks" },


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

A new feature was added to `r.nvim` that added a new key bind. This pr adds that key bind (and group in case more are added) to the current which-key config.

(I also removed a comment that I made previously for increasing the width of the which-key window to fit the longer keybind descriptions, something that eventually was taken out of the previous PR long ago)

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

None

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

<img width="154" alt="Screenshot 2024-07-16 at 9 24 54 AM" src="https://github.com/user-attachments/assets/70336846-cf42-458e-89f3-3e7cf1b94c3f">

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
