### PR TITLE
feat(terminal): clear search highlight when opening a terminal

### DIFF
--- a/lua/lazyvim/util/terminal.lua
+++ b/lua/lazyvim/util/terminal.lua
@@ -87,6 +87,8 @@ function M.open(cmd, opts)
         vim.cmd.startinsert()
       end,
     })
+
+    vim.cmd("noh")
   end
 
   return terminals[termkey]


### PR DESCRIPTION
## Description

Often times when opening a terminal or lazygit when a search is active, words in the terminal are highlighted. In my opinion this is rarely, if not never intended. This attempts to fixes this behavior. The code of `terminal.lua` is a bit beyond me, but I believe I have added it to the right place.

## Related Issue(s)

N/A.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
