### PR TITLE
feat(lualine): allow for trouble_lualine to be overriden on buffer

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -199,9 +199,11 @@ return {
 
       -- do not add trouble symbols if aerial is enabled
       -- And allow it to be overriden for some buffer types (see autocmds)
-      local trouble_lualine_enabled = vim.b.trouble_lualine == nil or vim.b.trouble_lualine
-      trouble_lualine_enabled = trouble_lualine_enabled and vim.g.trouble_lualine
-      if trouble_lualine_enabled and LazyVim.has("trouble.nvim") then
+      if
+        vim.g.trouble_luline_enabed ~= false
+        and vim.b.trouble_lualine_enabled ~= false
+        and LazyVim.has("trouble.nvim")
+      then
         local trouble = require("trouble")
         local symbols = trouble.statusline
           and trouble.statusline({

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -198,7 +198,10 @@ return {
       }
 
       -- do not add trouble symbols if aerial is enabled
-      if vim.g.trouble_lualine and LazyVim.has("trouble.nvim") then
+      -- And allow it to be overriden for some buffer types (see autocmds)
+      local trouble_lualine_enabled = vim.b.trouble_lualine == nil or vim.b.trouble_lualine
+      trouble_lualine_enabled = trouble_lualine_enabled and vim.g.trouble_lualine
+      if trouble_lualine_enabled and LazyVim.has("trouble.nvim") then
         local trouble = require("trouble")
         local symbols = trouble.statusline
           and trouble.statusline({


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Right now there is a default `vim.g.trouble_lualine` being set to `true`, and only that variable is being checked when deciding if the trouble output is being appended to the `lualine_c` for the lualine plugin. This is normally nice in code files, where you can get output like `packages/src/index.ts > myFunction` but in some filetypes, the user may not wish for this. In particular, I found if you have files with the `markdown` type that include long headers, then you can easily lose the file name by it trying to include the headers in this location.

Considering that one of the `CONTRIBUTING.md` guidelines is `Ensure all configurations are overridable by the user, using Lazy's specs.`, I figured that allowing this to be overrideable at the user's discretion could be a valuable feature.

This would allow the user to override this on file type by including an autocmd like this in their `lua/config/autocmds.lua` or equivalent:

```lua
-- disable trouble symbols in lualine in text filetypes
vim.api.nvim_create_autocmd("FileType", {
  group = vim.api.nvim_create_augroup("disable_trouble_lualine", { clear = true }),
  pattern = { "text", "plaintex", "typst", "gitcommit", "markdown" },
  callback = function()
    vim.b.trouble_lualine = false
  end,
})
```

## Related Issue(s)

None

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
