### PR TITLE
feat(editor): replace nvim-spectre with grug-far.nvim

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## 12.x
 
+- [nvim-spectre](https://github.com/nvim-pack/nvim-spectre) has been removed in favor of [grug-far.nvim](https://github.com/MagicDuck/grug-far.nvim).
+  **grug-far.nvim** has a great UI and feels more intuitive to use.
+
 - This **news** is now also available on the website at [https://www.lazyvim.org/news](https://www.lazyvim.org/news)
 
 - **prettier** extra now works for all prettier supported filetypes

--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -55,6 +55,7 @@ vim.api.nvim_create_autocmd("FileType", {
   group = augroup("close_with_q"),
   pattern = {
     "PlenaryTestPopup",
+    "grug-far",
     "help",
     "lspinfo",
     "notify",

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -128,13 +128,22 @@ return {
 
   -- search/replace in multiple files
   {
-    "nvim-pack/nvim-spectre",
-    build = false,
-    cmd = "Spectre",
-    opts = { open_cmd = "noswapfile vnew" },
-    -- stylua: ignore
+    "MagicDuck/grug-far.nvim",
+    opts = { headerMaxWidth = 80 },
+    cmd = "GrugFar",
     keys = {
-      { "<leader>sr", function() require("spectre").open() end, desc = "Replace in Files (Spectre)" },
+      {
+        "<leader>sr",
+        function()
+          require("grug-far").grug_far({
+            prefills = {
+              search = vim.fn.expand("<cword>"),
+              filesFilter = "*." .. vim.fn.expand("%:e"),
+            },
+          })
+        end,
+        desc = "Search and Replace",
+      },
     },
   },
 

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -135,13 +135,16 @@ return {
       {
         "<leader>sr",
         function()
-          require("grug-far").grug_far({
-            prefills = {
-              search = vim.fn.expand("<cword>"),
-              filesFilter = "*." .. vim.fn.expand("%:e"),
-            },
+          local is_visual = vim.fn.mode():lower():find("v")
+          if is_visual then -- needed to make visual selection work
+            vim.cmd([[normal! v]])
+          end
+          local grug = require("grug-far");
+          (is_visual and grug.with_visual_selection or grug.grug_far)({
+            prefills = { filesFilter = "*." .. vim.fn.expand("%:e") },
           })
         end,
+        mode = { "n", "v" },
         desc = "Search and Replace",
       },
     },

--- a/lua/lazyvim/plugins/extras/ui/mini-animate.lua
+++ b/lua/lazyvim/plugins/extras/ui/mini-animate.lua
@@ -14,6 +14,13 @@ return {
       end, { expr = true })
     end
 
+    vim.api.nvim_create_autocmd("FileType", {
+      pattern = "grug-far",
+      callback = function()
+        vim.b.minianimate_disable = true
+      end,
+    })
+
     LazyVim.toggle.map("<leader>ua", {
       name = "Mini Animate",
       get = function()


### PR DESCRIPTION
## Description

I'm considering to replace [nvim-spectre](https://github.com/nvim-pack/nvim-spectre) with [grug-far.nvim](https://github.com/MagicDuck/grug-far.nvim).

It has a better ui and I like the workflow better.

I won't merge this right away. I'm mostly looking for feedback on whether this would be a good thing and whether the defaults option I've added seem ok.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

![image](https://github.com/user-attachments/assets/bc44e35b-e033-4769-ad40-cdfe9e3482f4)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
