### PR TITLE
feat(core): defer clipboard because xsel and pbcopy can be slow

### DIFF
--- a/lua/lazyvim/config/init.lua
+++ b/lua/lazyvim/config/init.lua
@@ -161,6 +161,7 @@ end
 
 ---@type LazyVimOptions
 local options
+local lazy_clipboard
 
 ---@param opts? LazyVimOptions
 function M.setup(opts)
@@ -181,6 +182,9 @@ function M.setup(opts)
         M.load("autocmds")
       end
       M.load("keymaps")
+      if lazy_clipboard ~= nil then
+        vim.opt.clipboard = lazy_clipboard
+      end
 
       LazyVim.format.setup()
       LazyVim.news.setup()
@@ -285,6 +289,9 @@ function M.init()
   -- this is needed to make sure options will be correctly applied
   -- after installing missing plugins
   M.load("options")
+  -- defer built-in clipboard handling: "xsel" and "pbcopy" can be slow
+  lazy_clipboard = vim.opt.clipboard
+  vim.opt.clipboard = ""
 
   if vim.g.deprecation_warnings == false then
     vim.deprecate = function() end


### PR DESCRIPTION

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

See [this](https://github.com/LazyVim/LazyVim/discussions/4112) discussion

TLDR: 
Startup time performance is affected quite significantly when the clipboard provider is `xsel`(linux) or `pbcopy`(macos). I expect an improvement in these cases, especially on older pc's.

This PR resets `vim.opt.clipboard` after the `options` are loaded. Then, on `VeryLazy`, the setting is restored.

I also tested with `yanky`.

Relevant prints:

1. Before resetting `vim.opt.clipboard` in `init`, `vim.print(vim.opt.clipboard)` yields a table which will be captured:

```lua
--- fields
_name = "clipboard",
_value = "unnamedplus",
--- more fields
```

2. Set `vim.opt.clipboard = ""` and `vim.print(vim.opt.clipboard)`, also yields a table:

```lua
--- fields
_name = "clipboard",
_value = "",
--- more fields
```


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
