### PR TITLE
feat(indent-blankline): add which-key toggles

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -225,28 +225,66 @@ return {
   {
     "lukas-reineke/indent-blankline.nvim",
     event = "LazyFile",
-    opts = {
-      indent = {
-        char = "│",
-        tab_char = "│",
-      },
-      scope = { show_start = false, show_end = false },
-      exclude = {
-        filetypes = {
-          "help",
-          "alpha",
-          "dashboard",
-          "neo-tree",
-          "Trouble",
-          "trouble",
-          "lazy",
-          "mason",
-          "notify",
-          "toggleterm",
-          "lazyterm",
+    opts = function()
+      local ibl = require("ibl")
+      local conf = require("ibl.config")
+
+      LazyVim.toggle.map("<leader>ug", {
+        name = "Indention Guides",
+        get = function()
+          if conf.get_config(0).enabled then
+            return true
+          end
+          return false
+        end,
+        set = function(state)
+          if state then
+            ibl.setup_buffer(0, { enabled = true })
+          else
+            ibl.setup_buffer(0, { enabled = false })
+          end
+        end,
+      })
+      LazyVim.toggle.map("<leader>uS", {
+        name = "Scope Highlight",
+        get = function()
+          if conf.get_config(0).scope.enabled then
+            return true
+          end
+          return false
+        end,
+        set = function(state)
+          if state then
+            ibl.setup_buffer(0, { scope = { enabled = true } })
+          else
+            ibl.setup_buffer(0, { scope = { enabled = false } })
+          end
+        end,
+      })
+
+      return {
+        indent = {
+          char = "│",
+          tab_char = "│",
         },
-      },
-    },
+        scope = { show_start = false, show_end = false },
+        exclude = {
+          filetypes = {
+            "help",
+            "alpha",
+            "dashboard",
+            "neo-tree",
+            "Trouble",
+            "trouble",
+            "lazy",
+            "mason",
+            "notify",
+            "toggleterm",
+            "lazyterm",
+          },
+        },
+      }
+    end,
     main = "ibl",
   },
 

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -226,39 +226,13 @@ return {
     "lukas-reineke/indent-blankline.nvim",
     event = "LazyFile",
     opts = function()
-      local ibl = require("ibl")
-      local conf = require("ibl.config")
-
       LazyVim.toggle.map("<leader>ug", {
         name = "Indention Guides",
         get = function()
-          if conf.get_config(0).enabled then
-            return true
-          end
-          return false
+          return require("ibl.config").get_config(0).enabled
         end,
         set = function(state)
-          if state then
-            ibl.setup_buffer(0, { enabled = true })
-          else
-            ibl.setup_buffer(0, { enabled = false })
-          end
-        end,
-      })
-      LazyVim.toggle.map("<leader>uS", {
-        name = "Scope Highlight",
-        get = function()
-          if conf.get_config(0).scope.enabled then
-            return true
-          end
-          return false
-        end,
-        set = function(state)
-          if state then
-            ibl.setup_buffer(0, { scope = { enabled = true } })
-          else
-            ibl.setup_buffer(0, { scope = { enabled = false } })
-          end
+          require("ibl").setup_buffer(0, { enabled = state })
         end,
       })
 


### PR DESCRIPTION
## Description

Add which-key toggle mappings for toggling both the indention guides, and also scope highlight on a per buffer basis.

## Screenshots

![2024-07-20_08-16](https://github.com/user-attachments/assets/7b282868-c035-4f71-97dd-5738cd953713)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
