### PR TITLE
feat(python): default to new ruff instead of ruff_lsp

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -2,11 +2,12 @@ if lazyvim_docs then
   -- LSP Server to use for Python.
   -- Set to "basedpyright" to use basedpyright instead of pyright.
   vim.g.lazyvim_python_lsp = "pyright"
-  vim.g.lazyvim_python_ruff = "ruff_lsp"
+  -- Set to "ruff_lsp" to use the old LSP implementation version.
+  vim.g.lazyvim_python_ruff = "ruff"
 end
 
 local lsp = vim.g.lazyvim_python_lsp or "pyright"
-local ruff = vim.g.lazyvim_python_ruff or "ruff_lsp"
+local ruff = vim.g.lazyvim_python_ruff or "ruff"
 
 return {
   recommended = function()
@@ -44,6 +45,12 @@ return {
         },
         ruff = {
           enabled = ruff == "ruff",
+          cmd_env = { RUFF_TRACE = "messages" },
+          init_options = {
+            settings = {
+              logLevel = "error",
+            },
+          },
         },
         [ruff] = {
           keys = {

--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -31,28 +31,22 @@ return {
     "neovim/nvim-lspconfig",
     opts = {
       servers = {
-        pyright = {
-          enabled = lsp == "pyright",
-        },
-        basedpyright = {
-          enabled = lsp == "basedpyright",
-        },
-        [lsp] = {
-          enabled = true,
-        },
-        ruff_lsp = {
-          enabled = ruff == "ruff_lsp",
-        },
         ruff = {
-          enabled = ruff == "ruff",
           cmd_env = { RUFF_TRACE = "messages" },
           init_options = {
             settings = {
               logLevel = "error",
             },
           },
+          keys = {
+            {
+              "<leader>co",
+              LazyVim.lsp.action["source.organizeImports"],
+              desc = "Organize Imports",
+            },
+          },
         },
-        [ruff] = {
+        ruff_lsp = {
           keys = {
             {
               "<leader>co",
@@ -71,6 +65,16 @@ return {
         end,
       },
     },
+  },
+  {
+    "neovim/nvim-lspconfig",
+    opts = function(_, opts)
+      local servers = { "pyright", "basedpyright", "ruff", "ruff_lsp", ruff, lsp }
+      for _, server in ipairs(servers) do
+        opts.servers[server] = opts.servers[server] or {}
+        opts.servers[server].enabled = server == lsp or server == ruff
+      end
+    end,
   },
   {
     "nvim-neotest/neotest",

--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -196,6 +196,9 @@ return {
         local server_opts = vim.tbl_deep_extend("force", {
           capabilities = vim.deepcopy(capabilities),
         }, servers[server] or {})
+        if server_opts.enabled == false then
+          return
+        end
 
         if opts.setup[server] then
           if opts.setup[server](server, server_opts) then


### PR DESCRIPTION
## Description

Change default python ruff lsp from `ruff_lsp` to `ruff`. It is now marked as stable. I have been using it for a few days without any problems. I use python for relatively small to medium projects. Maybe someone who is using python more rigorously has better feedback.

References:

https://github.com/astral-sh/ruff-lsp (see note)
https://github.com/astral-sh/ruff/releases/tag/0.5.3
https://docs.astral.sh/ruff/editors/setup/#neovim

Also the issue in https://github.com/LazyVim/LazyVim/pull/3057 has been resolved. I tested it and I only get 1 `ruff server` process per nvim instance. The processes close correctly when nvim is closed.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
