### PR TITLE
fix(editor): filesFilter expression

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -141,7 +141,7 @@ return {
           end
           local grug = require("grug-far");
           (is_visual and grug.with_visual_selection or grug.grug_far)({
-            prefills = { filesFilter = "*." .. vim.fn.expand("%:e") },
+            prefills = { filesFilter = "*.*" .. vim.fn.expand("%:e") },
           })
         end,
         mode = { "n", "v" },


### PR DESCRIPTION
## Description

With the current default filter, when opening nvim with `nvim .` I get:

```
rg: No files were searched, which means ripgrep probably applied a filter you didn't expect.
Running with --debug will show why files are being skipped.
```

I get expected results with `*.*`.

## Related Issue(s)

## Screenshots

![grafik](https://github.com/user-attachments/assets/1e70fb83-9c97-4a04-82d7-4a8100ac1370)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
