### PR TITLE
fix(dap): don't mess up DAP adapters provided by nvim-dap-python

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -138,4 +138,15 @@ return {
       table.insert(opts.auto_brackets, "python")
     end,
   },
+
+  -- Don't mess up DAP adapters provided by nvim-dap-python
+  {
+    "jay-babu/mason-nvim-dap.nvim",
+    optional = true,
+    opts = {
+      handlers = {
+        python = function() end,
+      },
+    },
+  },
 }


### PR DESCRIPTION
## Description

* mason-nvim-dap.nvim ships a `Python: Launch file` adapter which does the same thing as `Launch file` of nvim-dap-python, providing both doesn't make sense and confuses the users.
* mason-nvim-dap.nvim unexpectedly overrides nvim-dap-python's adapters and breaks its venv detection. As a result, user programs are always executed in mason debugpy venv rather than the activated one.


<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

Fixes #3064

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
