### PR TITLE
feat(elixir): add elixirls code actions

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/elixir.lua
+++ b/lua/lazyvim/plugins/extras/lang/elixir.lua
@@ -11,70 +11,29 @@ return {
       servers = {
         elixirls = {
           keys = {
-            { "<leader>cp", ":ElixirToPipe<CR>", desc = "To Pipe" },
-            { "<leader>cP", ":ElixirFromPipe<CR>", desc = "From Pipe" },
-            { "<leader>ce", mode = { "v" }, ":ElixirExpandMacro<CR>", desc = "Expand Macro" },
+            {
+              "<leader>cp",
+              function()
+                local params = vim.lsp.util.make_position_params()
+                LazyVim.lsp.execute({
+                  command = "manipulatePipes:serverid",
+                  arguments = { "toPipe", params.textDocument.uri, params.position.line, params.position.character },
+                })
+              end,
+              desc = "To Pipe",
+            },
+            {
+              "<leader>cP",
+              function()
+                local params = vim.lsp.util.make_position_params()
+                LazyVim.lsp.execute({
+                  command = "manipulatePipes:serverid",
+                  arguments = { "fromPipe", params.textDocument.uri, params.position.line, params.position.character },
+                })
+              end,
+              desc = "From Pipe",
+            },
           },
-          on_attach = function(client, bufnr)
-            local manipulate_pipes = function(direction)
-              local get_cursor_position = function()
-                local rowcol = vim.api.nvim_win_get_cursor(0)
-                local row = rowcol[1] - 1
-                local col = rowcol[2]
-                return row, col
-              end
-
-              local row, col = get_cursor_position()
-              client.request_sync("workspace/executeCommand", {
-                command = "manipulatePipes:serverid",
-                arguments = { direction, "file://" .. vim.api.nvim_buf_get_name(0), row, col },
-              }, nil, 0)
-            end
-
-            vim.api.nvim_buf_create_user_command(bufnr, "ElixirFromPipe", function()
-              manipulate_pipes("fromPipe")
-            end, {})
-            vim.api.nvim_buf_create_user_command(bufnr, "ElixirToPipe", function()
-              manipulate_pipes("toPipe")
-            end, {})
-
-            vim.api.nvim_buf_create_user_command(bufnr, "ElixirExpandMacro", function()
-              local params = vim.lsp.util.make_given_range_params()
-
-              local text = vim.api.nvim_buf_get_text(
-                0,
-                params.range.start.line,
-                params.range.start.character,
-                params.range["end"].line,
-                params.range["end"].character,
-                {}
-              )
-
-              local resp = client.request_sync("workspace/executeCommand", {
-                command = "expandMacro:serverid",
-                arguments = { params.textDocument.uri, vim.fn.join(text, "\n"), params.range.start.line },
-              }, nil, 0)
-
-              local content = {}
-              if resp["result"] then
-                for k, v in pairs(resp.result) do
-                  vim.list_extend(content, { "# " .. k, "" })
-                  vim.list_extend(content, vim.split(v, "\n"))
-                end
-              else
-                table.insert(content, "Error")
-              end
-
-              vim.schedule(function()
-                local bufnr_floating, _ = vim.lsp.util.open_floating_preview(
-                  vim.lsp.util.trim_empty_lines(content),
-                  "elixir",
-                  { border = "single" }
-                )
-                vim.api.nvim_buf_set_option(bufnr_floating, "filetype", "elixir")
-              end)
-            end, { range = true })
-          end,
         },
       },
     },


### PR DESCRIPTION
This is a refactoring of #3846  with the changes:

- Use `Lazyvim.lsp.execute` on keymaps to make everything simpler;
- Remove expandMacro. 

Closes #3846
