### PR TITLE
feat(chezmoi): replace leader-fc with chezmoi edit

### DIFF
--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -1,10 +1,13 @@
+-- exclude directories and externals
+local chezmoi_list_args = { "--include", "files", "--exclude", "externals" }
+
 ---@param targets? string|string[]
 local function fzf_chezmoi(targets)
   local fzf_lua = require("fzf-lua")
   local chezmoi = require("chezmoi.commands")
   local results = chezmoi.list({
     targets = targets or {},
-    args = { "--include", "files" }, -- exclude directories
+    args = chezmoi_list_args,
   })
   local opts = {
     fzf_opts = {},
@@ -36,7 +39,7 @@ local pick_config = function()
   local config_dir = vim.fn.stdpath("config")
   local managed_config_files = chezmoi.list({
     targets = config_dir,
-    args = { "--path-style", "absolute", "--include", "files" },
+    args = { "--path-style", "absolute", unpack(chezmoi_list_args) },
   })
 
   if vim.tbl_isempty(managed_config_files) then

--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -1,26 +1,84 @@
+---@param targets? string|string[]
+local function fzf_chezmoi(targets)
+  local fzf_lua = require("fzf-lua")
+  local chezmoi = require("chezmoi.commands")
+  local results = chezmoi.list({
+    targets = targets or {},
+    args = { "--include", "files" }, -- exclude directories
+  })
+  local opts = {
+    fzf_opts = {},
+    fzf_colors = true,
+    actions = {
+      ["default"] = function(selected)
+        if not vim.tbl_isempty(selected) then
+          chezmoi.edit({
+            targets = "~/" .. selected[1],
+          })
+        end
+      end,
+    },
+  }
+  fzf_lua.fzf_exec(results, opts)
+end
+
 local pick_chezmoi = function()
   if LazyVim.pick.picker.name == "telescope" then
     require("telescope").extensions.chezmoi.find_files()
   elseif LazyVim.pick.picker.name == "fzf" then
-    local fzf_lua = require("fzf-lua")
-    local results = require("chezmoi.commands").list({
-      args = { "--include", "files" }, -- exclude directories
-    })
-    local chezmoi = require("chezmoi.commands")
+    fzf_chezmoi()
+  end
+end
 
-    local opts = {
-      fzf_opts = {},
-      fzf_colors = true,
-      actions = {
-        ["default"] = function(selected)
-          chezmoi.edit({
-            targets = { "~/" .. selected[1] },
-            args = { "--watch" },
-          })
-        end,
-      },
-    }
-    fzf_lua.fzf_exec(results, opts)
+--- pick nvim config
+local pick_config = function()
+  local chezmoi = require("chezmoi.commands")
+  local config_dir = vim.fn.stdpath("config")
+  local managed_config_files = chezmoi.list({
+    targets = config_dir,
+    args = { "--path-style", "absolute", "--include", "files" },
+  })
+
+  if vim.tbl_isempty(managed_config_files) then
+    LazyVim.pick.config_files()()
+    return
+  end
+
+  if LazyVim.pick.picker.name == "telescope" then
+    local actions = require("telescope.actions")
+    local action_state = require("telescope.actions.state")
+    local config = require("chezmoi").config
+
+    require("telescope.builtin").find_files({
+      prompt_title = "Config Files",
+      cwd = config_dir,
+      attach_mappings = function(prompt_bufnr, map)
+        local edit_action = function()
+          actions.close(prompt_bufnr)
+          local selection = action_state.get_selected_entry()
+          if selection then
+            chezmoi.edit({
+              targets = config_dir .. "/" .. selection.value,
+            })
+          end
+        end
+
+        for _, v in ipairs(config.telescope.select) do
+          map("i", v, "select_default")
+        end
+
+        -- it's possible that only part of nvim config files are managed with chezmoi
+        -- pick all and just edit if unmanaged
+        actions.select_default:replace_if(function()
+          local selection = action_state.get_selected_entry()
+          return selection and vim.tbl_contains(managed_config_files, config_dir .. "/" .. selection.value)
+        end, edit_action)
+        return true
+      end,
+    })
+  elseif LazyVim.pick.picker.name == "fzf" then
+    -- only pick the managed config files
+    fzf_chezmoi(config_dir)
   end
 end
 
@@ -36,11 +94,8 @@ return {
   {
     "xvzc/chezmoi.nvim",
     keys = {
-      {
-        "<leader>sz",
-        pick_chezmoi,
-        desc = "Chezmoi",
-      },
+      { "<leader>sz", pick_chezmoi, desc = "Chezmoi" },
+      { "<leader>fc", pick_config, desc = "Find Config File" },
     },
     opts = {
       edit = {
@@ -66,6 +121,17 @@ return {
       })
     end,
   },
+  {
+    "ibhagwan/fzf-lua",
+    optional = true,
+    keys = { { "<leader>fc", false } },
+  },
+  {
+    "nvim-telescope/telescope.nvim",
+    optional = true,
+    keys = { { "<leader>fc", false } },
+  },
+
   {
     "nvimdev/dashboard-nvim",
     optional = true,

--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -68,15 +68,15 @@ return {
     "nvimdev/dashboard-nvim",
     optional = true,
     opts = function(_, opts)
-      local projects = {
+      local chezmoi = {
         action = pick_chezmoi,
         desc = "  Config",
         icon = "",
         key = "c",
       }
 
-      projects.desc = projects.desc .. string.rep(" ", 43 - #projects.desc)
-      projects.key_format = "  %s"
+      chezmoi.desc = chezmoi.desc .. string.rep(" ", 43 - #chezmoi.desc)
+      chezmoi.key_format = "  %s"
 
       -- remove lazyvim config property
       for i = #opts.config.center, 1, -1 do
@@ -85,7 +85,7 @@ return {
         end
       end
 
-      table.insert(opts.config.center, 5, projects)
+      table.insert(opts.config.center, 5, chezmoi)
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -3,7 +3,9 @@ local pick_chezmoi = function()
     require("telescope").extensions.chezmoi.find_files()
   elseif LazyVim.pick.picker.name == "fzf" then
     local fzf_lua = require("fzf-lua")
-    local results = require("chezmoi.commands").list()
+    local results = require("chezmoi.commands").list({
+      args = { "--include", "files" }, -- exclude directories
+    })
     local chezmoi = require("chezmoi.commands")
 
     local opts = {


### PR DESCRIPTION
## Description

People who use chezmoi generally use it to maintain nvim config files. Direct modification of the target file by `leader-fc` will produce unnecessary differences and cause confusion.

New `leader-fc` behavior:
- If user doesn't maintain nvim config files with chezmoi at all, old behavior.
- If user maintain only some of (not all) nvim config files with chezmoi, pick them all and edit with or without chezmoi.
- If user maintain all nvim config files with chezmoi, edit with chezmoi.

Copied some codes from chezmoi.nvim [here](https://github.com/xvzc/chezmoi.nvim/blob/main/lua/telescope/_extensions/find_files.lua#L34).

## Related Issue(s)

none

## Screenshots

UI is unchanged except that it no longer displays the directories for fzf-lua on `leader-sz`.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
