### PR TITLE
feat(catppuccin): enable grug-far integration

### DIFF
--- a/lua/lazyvim/plugins/colorscheme.lua
+++ b/lua/lazyvim/plugins/colorscheme.lua
@@ -19,6 +19,7 @@ return {
         cmp = true,
         dashboard = true,
         flash = true,
+        grug_far = true,
         gitsigns = true,
         headlines = true,
         illuminate = true,


### PR DESCRIPTION
## Description

This enables the recently added `grug-far` integration in catppuccin - https://github.com/catppuccin/nvim/pull/735

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.