### PR TITLE
Add `name` to markdown.nvim config

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/markdown.lua
+++ b/lua/lazyvim/plugins/extras/lang/markdown.lua
@@ -93,6 +93,7 @@ return {
 
   {
     "MeanderingProgrammer/markdown.nvim",
+    name = "render-markdown",
     opts = {
       file_types = { "markdown", "norg", "rmd", "org" },
       code = {


### PR DESCRIPTION
## Description

The latest update uses [markdown.nvim](https://github.com/MeanderingProgrammer/markdown.nvim), which crashed for me because `render-markdown` could not be found. 

This pull request adds the `name = "render-markdown",` according to their documentation, which solves it for me. Also tried to use `main` without success.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
