### PR TITLE
feat(elixir): add support for livebook files (`*.livemd`)

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/elixir.lua
+++ b/lua/lazyvim/plugins/extras/lang/elixir.lua
@@ -1,7 +1,7 @@
 return {
   recommended = function()
     return LazyVim.extras.wants({
-      ft = { "elixir", "eelixir", "heex", "surface" },
+      ft = { "elixir", "eelixir", "heex", "surface", "livebook" },
       root = "mix.exs",
     })
   end,
@@ -40,7 +40,11 @@ return {
   },
   {
     "nvim-treesitter/nvim-treesitter",
-    opts = { ensure_installed = { "elixir", "heex", "eex" } },
+    opts = function(_, opts)
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "elixir", "heex", "eex" })
+      vim.treesitter.language.register("markdown", "livebook")
+    end,
   },
   {
     "nvim-neotest/neotest",
@@ -83,6 +87,13 @@ return {
           end,
         },
       }
+    end,
+  },
+  {
+    "MeanderingProgrammer/render-markdown.nvim",
+    optional = true,
+    ft = function(_, ft)
+      vim.list_extend(ft, { "livebook" })
     end,
   },
 }


### PR DESCRIPTION
Livebook is a subset of Markdown, so we can safely use markdown's treesitter for it.
