### PR TITLE
fix(telescope): buffers to start at final item

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/telescope.lua
+++ b/lua/lazyvim/plugins/extras/editor/telescope.lua
@@ -94,7 +94,11 @@ return {
       { "<leader>:", "<cmd>Telescope command_history<cr>", desc = "Command History" },
       { "<leader><space>", LazyVim.pick("files"), desc = "Find Files (Root Dir)" },
       -- find
-      { "<leader>fb", "<cmd>Telescope buffers sort_mru=true<cr>", desc = "Buffers" },
+      {
+        "<leader>fb",
+        "<cmd>Telescope buffers sort_mru=true sort_lastused=true ignore_current_buffer=true<cr>",
+        desc = "Buffers",
+      },
       { "<leader>fc", LazyVim.pick.config_files(), desc = "Find Config File" },
       { "<leader>ff", LazyVim.pick("files"), desc = "Find Files (Root Dir)" },
       { "<leader>fF", LazyVim.pick("files", { root = false }), desc = "Find Files (cwd)" },

--- a/lua/lazyvim/plugins/extras/editor/telescope.lua
+++ b/lua/lazyvim/plugins/extras/editor/telescope.lua
@@ -94,7 +94,7 @@ return {
       { "<leader>:", "<cmd>Telescope command_history<cr>", desc = "Command History" },
       { "<leader><space>", LazyVim.pick("files"), desc = "Find Files (Root Dir)" },
       -- find
-      { "<leader>fb", "<cmd>Telescope buffers sort_mru=true sort_lastused=true<cr>", desc = "Buffers" },
+      { "<leader>fb", "<cmd>Telescope buffers sort_mru=true<cr>", desc = "Buffers" },
       { "<leader>fc", LazyVim.pick.config_files(), desc = "Find Config File" },
       { "<leader>ff", LazyVim.pick("files"), desc = "Find Files (Root Dir)" },
       { "<leader>fF", LazyVim.pick("files", { root = false }), desc = "Find Files (cwd)" },


### PR DESCRIPTION
## Description

Currently hitting `<leader>fb` triggers the telescope buffers command but because we're passing the `sort_lastused=true` flag the index starts at the second item. 

This happens because of this line of code in telescope.nvim:

https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/builtin/__internal.lua#L941-L943

This makes it annoying to actually use the tool to find buffers because you have to first type your query then exit insert mode, then scroll one item down, and then hitting enter:


https://github.com/user-attachments/assets/4126d017-df4b-48dc-b6d4-f7d9b8f491ff

When removing that flag it makes the function much more usable in terms of UX since now you can just write your query and hit enter to go straight to it.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
