### PR TITLE
fix(toggle): make `diagnostics` compatible with nvim-0.9.5

### DIFF
--- a/lua/lazyvim/util/toggle.lua
+++ b/lua/lazyvim/util/toggle.lua
@@ -127,9 +127,32 @@ M.number = M.wrap({
 M.diagnostics = M.wrap({
   name = "Diagnostics",
   get = function()
-    return vim.diagnostic.is_enabled and vim.diagnostic.is_enabled()
+    local enabled
+    if vim.diagnostic.is_enabled then
+      enabled = vim.diagnostic.is_enabled()
+    else
+      enabled = not vim.diagnostic.is_disabled()
+    end
+    return enabled
   end,
-  set = vim.diagnostic.enable,
+  set = function()
+    local enabled
+    if vim.diagnostic.is_enabled then
+      enabled = vim.diagnostic.is_enabled()
+    else
+      enabled = not vim.diagnostic.is_disabled()
+    end
+    enabled = not enabled
+    if vim.fn.has("nvim-0.10") == 0 then
+      if enabled then
+        pcall(vim.diagnostic.enable)
+      else
+        vim.diagnostic.disable()
+      end
+    else
+      vim.diagnostic.enable(enabled)
+    end
+  end,
 })
 
 M.inlay_hints = M.wrap({


### PR DESCRIPTION
## Description
This makes `toggle.diagnostics` compatible with Neovim 0.9.5 (though not sure about the metatable callables, since `set` there accepts a boolean from `get` state). 

Please make whatever changes you deem necessary or disregard as a whole for a better approach I haven't been able to think of.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #4203
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
