### PR TITLE
revert: perf(markdown): only run markdownlint-cli2 formatter when there are markdownlint diagnostics for the buffer

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/markdown.lua
+++ b/lua/lazyvim/plugins/extras/lang/markdown.lua
@@ -24,14 +24,6 @@ return {
             end
           end,
         },
-        ["markdownlint-cli2"] = {
-          condition = function(_, ctx)
-            local diag = vim.tbl_filter(function(d)
-              return d.source == "markdownlint"
-            end, vim.diagnostic.get(ctx.buf))
-            return #diag > 0
-          end,
-        },
       },
       formatters_by_ft = {
         ["markdown"] = { "prettier", "markdownlint-cli2", "markdown-toc" },


### PR DESCRIPTION
This reverts commit 8a6875ab3bc79d5890cf0a65e3ef602c1567fa90.

## Description

This condition leads to an autoformatting loop if prettier and markdownlint disagree on how a file should be formatted.

MWE (Markdown file):

```example.md
# Heading

- Bullet point

```

This markdown file results in an `MD030` diagnostic from markdownlint, meaning markdownlint will be active as a formatter:

![Screenshot 2024-07-29 at 13 17 00](https://github.com/user-attachments/assets/1f6f1a83-2096-42d8-9e8f-ef33c409e0b1)

Saving the file applies markdownlint formatting, which results in the following contents (added spaces before the bullet point text):

```
# Heading

-   Bullet point
```

This file produces no markdownlint diagnostics, meaning markdownlint is disabled as a formatter:

![Screenshot 2024-07-29 at 13 18 46](https://github.com/user-attachments/assets/9e63bf0f-b06d-4805-97b2-6f34d72ddb1c)

However, when we now save this file again, prettier reverts the change that markdownlint made:

```
# Heading

- Bullet point
```

This triggers an `MD030` diagnostic again, re-enabling markdownlint.

Because prettier and markdownlint disagree here, we end up in an autoformatting loop where the file is continuously toggled between two styles on each save.

Removing prettier from `formatters_by_ft` would also fix this, but I believe we do want to keep it; we just want markdownlint to supersede it in case they disagree.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
