### PR TITLE
feat(eslint): add option to disable eslint auto format

### DIFF
--- a/lua/lazyvim/plugins/extras/linting/eslint.lua
+++ b/lua/lazyvim/plugins/extras/linting/eslint.lua
@@ -1,3 +1,10 @@
+if lazyvim_docs then
+  -- Set to false to disable auto format
+  vim.g.lazyvim_eslint_auto_format = true
+end
+
+local auto_format = vim.g.lazyvim_eslint_auto_format == nil or vim.g.lazyvim_eslint_auto_format
+
 return {
   {
     "neovim/nvim-lspconfig",
@@ -9,11 +16,16 @@ return {
           settings = {
             -- helps eslint find the eslintrc when it's placed in a subfolder instead of the cwd root
             workingDirectories = { mode = "auto" },
+            format = auto_format,
           },
         },
       },
       setup = {
         eslint = function()
+          if not auto_format then
+            return
+          end
+
           local function get_client(buf)
             return LazyVim.lsp.get_clients({ name = "eslint", bufnr = buf })[1]
           end


### PR DESCRIPTION
## Description

This adds an option to disable eslint's autoformatting. The reasons for not wanting an auto format by eslint are:
1. It is generally not recommended not to use a linter as a formatter as highlighted by https://typescript-eslint.io/users/what-about-formatting/#:~:text=We%20recommend%20against%20using%20ESLint,dprint%2C%20or%20an%20equivalent%20instead 
2. A personal preference not to have a linter change my code which I'm sure other people share.
3. As highlighted in the link above, eslint auto format can be quite slow.

I would even argue that this should be the default, but I've left it as is in order not to break anyone's config or ruffle anyone's feathers.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
