### PR TITLE
fix(navic): use the same background color as lualine section_c

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/navic.lua
+++ b/lua/lazyvim/plugins/extras/editor/navic.lua
@@ -30,14 +30,7 @@ return {
     optional = true,
     opts = function(_, opts)
       if not vim.g.trouble_lualine then
-        table.insert(opts.sections.lualine_c, {
-          function()
-            return require("nvim-navic").get_location()
-          end,
-          cond = function()
-            return package.loaded["nvim-navic"] and require("nvim-navic").is_available()
-          end,
-        })
+        table.insert(opts.sections.lualine_c, { "navic", color_correction = "dynamic" })
       end
     end,
   },


### PR DESCRIPTION
## Description

Prior to this, when using the navic Extra, the symbol breadcrumbs shown
in lualine section_c had a background color different from the
background of lualine_c, causing it to standout and not blend in with
some colorschemes.

There were ways around this problem, but hose involved overriding a lot
of highlights. See https://github.com/LazyVim/LazyVim/issues/328

This change uses the new (as of April 2023) lualine component built in
to SmiteshP/nvim-navic, which has a `color_correction` option to fix the
problem described above. This built-in component replaces the manual
method of calling `require("nvim-navic").is_available()` and
`require("nvim-navic").get_location()`.

* https://github.com/SmiteshP/nvim-navic/commit/711e9f117a0936c9d4420a135d658d2ca53a9e99
* https://github.com/SmiteshP/nvim-navic/commit/bf587250f8e399da75b4efe12261e18d8783ecef

With `color_correction` set to "static" or "dynamic", navic uses the
lualine section's background color when building the breadcrumbs text.

* https://github.com/SmiteshP/nvim-navic/blob/bf587250f8e399da75b4efe12261e18d8783ecef/doc/navic.txt#L83-L88

I chose to set color_correction to "dynamic" to provide the best user
experience as that will update the background any time the lualine
section's background changes (e.g. when switching modes).

## Related Issue(s)

* Fixes #328

## Screenshots

Before this fix, the breadcrumb's background did not match lualine section_c's:
![before](https://github.com/user-attachments/assets/b30e9844-5aac-4ec8-96fd-a5243de8cded)

After this fix, the breadcrumb's background does match:
![after](https://github.com/user-attachments/assets/63945c48-2edc-4aea-8144-ae0bff1ed952)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
