### PR TITLE
feat(markdown): align language name in code blocks to the right

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/markdown.lua
+++ b/lua/lazyvim/plugins/extras/lang/markdown.lua
@@ -99,6 +99,7 @@ return {
         sign = false,
         width = "block",
         right_pad = 1,
+        position = "right",
       },
       heading = {
         sign = false,


### PR DESCRIPTION
New feature in Markdown.nvim:
https://github.com/MeanderingProgrammer/markdown.nvim/commit/4d8b6032b659a45582089de8bcd839f8ccc4161d

![SCR-20240801-idih](https://github.com/user-attachments/assets/24d30261-47f0-4cbf-8bdf-50d6f50e4ed0)
