### PR TITLE
fix(gitsigns): change name of filetype blame

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -68,7 +68,7 @@ vim.api.nvim_create_autocmd("FileType", {
     "neotest-summary",
     "neotest-output-panel",
     "dbout",
-    "gitsigns.blame",
+    "gitsigns-blame",
   },
   callback = function(event)
     vim.bo[event.buf].buflisted = false


### PR DESCRIPTION
## Description
There was a change in `gitsigns` filetype name for blame.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
No
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
