### PR TITLE
feat(hipattern): add the hsl highlight feature

### DIFF
--- a/lua/lazyvim/plugins/extras/util/mini-hipatterns.lua
+++ b/lua/lazyvim/plugins/extras/util/mini-hipatterns.lua
@@ -46,6 +46,18 @@ M.plugin = {
           end,
           extmark_opts = { priority = 2000 },
         },
+        hsl_color = {
+          pattern = "[hsl%(]?%d+%.?%d?,? %d+%.?%d?%%?,? %d+%.?%d?%%?%)?",
+          group = function(_, match)
+            --- @type string, string, string
+            local nh, ns, nl = match:match("[hsl%(]?(%d+%.?%d?),? (%d+%.?%d?)%%?,? (%d+%.?%d?)%%?%)?")
+            --- @type number?, number?, number?
+            local h, s, l = tonumber(nh), tonumber(ns), tonumber(nl)
+            --- @type string
+            local hex_color = LazyVim.mini.hipattern_hslToHex(h, s, l)
+            return MiniHipatterns.compute_hex_color_group(hex_color, "bg")
+          end,
+        },
       },
     }
   end,

--- a/lua/lazyvim/util/mini.lua
+++ b/lua/lazyvim/util/mini.lua
@@ -167,4 +167,109 @@ function M.pairs(opts)
   end
 end
 
+--[[
+ * Converts an HSL color value to RGB. Conversion formula
+ * adapted from http://en.wikipedia.org/wiki/HSL_color_space.
+ * Assumes h, s, and l are contained in the set [0, 1] and
+ * returns r, g, and b in the set [0, 255].
+ *
+ * @param   Number  h       The hue
+ * @param   Number  s       The saturation
+ * @param   Number  l       The lightness
+ * @return  Array           The RGB representation
+]]
+function M.hipatternHslToRgb(h, s, l)
+  local r, g, b
+
+  if s == 0 then
+    r, g, b = l, l, l -- achromatic
+  else
+    local function hue2rgb(p, q, t)
+      if t < 0 then
+        t = t + 1
+      end
+      if t > 1 then
+        t = t - 1
+      end
+      if t < 1 / 6 then
+        return p + (q - p) * 6 * t
+      end
+      if t < 1 / 2 then
+        return q
+      end
+      if t < 2 / 3 then
+        return p + (q - p) * (2 / 3 - t) * 6
+      end
+      return p
+    end
+
+    local q
+    if l < 0.5 then
+      q = l * (1 + s)
+    else
+      q = l + s - l * s
+    end
+    local p = 2 * l - q
+
+    r = hue2rgb(p, q, h + 1 / 3)
+    g = hue2rgb(p, q, h)
+    b = hue2rgb(p, q, h - 1 / 3)
+  end
+
+  return r * 255, g * 255, b * 255
+end
+
+--[[
+ * Converts an HSL color value to RGB in Hex representation.
+ * @param   Number  hue       The hue
+ * @param   Number  sat       The saturation
+ * @param   Number  lum       The lightness
+ * @return  String            The hex representation
+]]
+function M.hipattern_hslToHex(hue, sat, lum)
+  local function hslToRgb(h, s, l)
+    local r, g, b
+
+    if s == 0 then
+      r, g, b = l, l, l -- achromatic
+    else
+      local function hue2rgb(p, q, t)
+        if t < 0 then
+          t = t + 1
+        end
+        if t > 1 then
+          t = t - 1
+        end
+        if t < 1 / 6 then
+          return p + (q - p) * 6 * t
+        end
+        if t < 1 / 2 then
+          return q
+        end
+        if t < 2 / 3 then
+          return p + (q - p) * (2 / 3 - t) * 6
+        end
+        return p
+      end
+
+      local q
+      if l < 0.5 then
+        q = l * (1 + s)
+      else
+        q = l + s - l * s
+      end
+      local p = 2 * l - q
+
+      r = hue2rgb(p, q, h + 1 / 3)
+      g = hue2rgb(p, q, h)
+      b = hue2rgb(p, q, h - 1 / 3)
+    end
+
+    return r * 255, g * 255, b * 255
+  end
+  local r, g, b = hslToRgb(hue / 360, sat / 100, lum / 100)
+
+  return string.format("#%02x%02x%02x", r, g, b)
+end
+
 return M


### PR DESCRIPTION
## Description

Add the HSL highlight feature to the extras.util.hipattern
This allow highlight on string such as :
- `hsl(150, 34%, 23%)` (classic hsl() notation)
-  `150 34% 23%` (notation you can find on shadcn theme)

Each number can accept one decimal.

## Screenshots

![Screenshot 2024-08-02 at 14 12 21](https://github.com/user-attachments/assets/ad088750-56a7-43fe-9894-6432b9501251)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
