### PR TITLE
feat(extras): added lazyvim extra for laravel blade support

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/blade.lua
+++ b/lua/lazyvim/plugins/extras/lang/blade.lua
@@ -1,0 +1,64 @@
+-- require("lazyvim.plugins").extras.lang.blade.setup({
+--   -- Your existing configuration
+--   recommended = false, -- Add or ensure this line is present
+-- })
+
+return {
+  recommended = {
+    ft = "blade",
+    root = { "composer.json", "artisan" },
+  },
+  {
+    "nvim-tressiter/nvim-treesitter",
+    opts = function(_, opts)
+      if type(opts.ensure_installed) == "table" then
+        vim.list_extend(opts.ensure_installed, { "blade", "php" })
+      end
+
+      local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
+      parser_config.blade = {
+        install_info = {
+          url = "https://github.com/EmranMR/tree-sitter-blade",
+          files = { "src/parser.c" },
+          branch = "main",
+        },
+        filetype = "blade",
+      }
+
+      vim.api.nvim_create_autocmd({ "BufReadPost", "BufNewFile" }, {
+        pattern = { "*.blade.php" },
+        callback = function()
+          vim.treesitter.start(nil, "blade")
+          vim.opt.filetype = "blade"
+        end,
+      })
+    end,
+  },
+  {
+    "williamboman/mason.nvim",
+    opts = {
+      ensure_installed = {
+        "tlint",
+        "blade-formatter",
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        blade = { "tlint" },
+      },
+    },
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        blade = { "blade-formatter" },
+      },
+    },
+  },
+}

--- a/queries/blade/highlights.scm
+++ b/queries/blade/highlights.scm
@@ -1,0 +1,9 @@
+(directive) @function
+(directive_start) @function
+(directive_end) @function
+(comment) @comment
+((parameter) @include (#set! "priority" 110)) 
+((php_only) @include (#set! "priority" 110)) 
+((bracket_start) @function (#set! "priority" 120)) 
+((bracket_end) @function (#set! "priority" 120)) 
+(keyword) @function

--- a/queries/blade/injections.scm
+++ b/queries/blade/injections.scm
@@ -1,0 +1,4 @@
+((text) @injection.content
+    (#not-has-ancestor? @injection.content "envoy")
+    (#set! injection.combined)
+    (#set! injection.language php))


### PR DESCRIPTION
## Description

This pull request will be a great lift for laravel developers. It is going to 
- add a new filtype for all ```.blade.php``` 
- Add new treesitter query highlights for ```blade```
- Add treesitter query injections for ```blade```
- nvim users will now be able to use ```TSInstall blade``` to install blade.
- Added new lazyvim ```extras``` for the ```blade```
- Configures ```formatting``` with conform.nvim
- Configures ```linting``` with nvim-lint

## Related Issue(s)

[feature: lazy extra for Laravel blade and php](https://github.com/LazyVim/LazyVim/issues/3386)

## Screenshots


https://github.com/user-attachments/assets/c449a430-f989-4279-8685-a1815597d78b


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
