### PR TITLE
chore(mason): Refactor ensure_installed to remove unnecessary network calls

### DIFF
--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -286,14 +286,12 @@ return {
         end, 100)
       end)
 
-      mr.refresh(function()
-        for _, tool in ipairs(opts.ensure_installed) do
+      for _, tool in ipairs(opts.ensure_installed) do
+        if not mr.is_installed(tool) then
           local p = mr.get_package(tool)
-          if not p:is_installed() then
-            p:install()
-          end
+          p:install()
         end
-      end)
+      end
     end,
   },
 }


### PR DESCRIPTION
## Description

The main reason for this change is to avoid network calls/auto registry update on the startup. Refresh would perform registry update once per day which is not necessary.
Refresh is not needed because under the hood mason would [perform the refresh](https://github.com/williamboman/mason.nvim/blob/e2f7f9044ec30067bc11800a9e266664b88cda22/lua/mason-registry/sources/github.lua#L101
) 

Another change is using [MasonRegistry.is_installed](https://github.com/williamboman/mason.nvim/blob/e2f7f9044ec30067bc11800a9e266664b88cda22/lua/mason-registry/init.lua#L15) method that does not create `Package` instance without a need.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
