### PR TITLE
chore(markdown): markdown.nvim was renamed to render-markdown.nvim

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/markdown.lua
+++ b/lua/lazyvim/plugins/extras/lang/markdown.lua
@@ -92,7 +92,7 @@ return {
   },
 
   {
-    "MeanderingProgrammer/markdown.nvim",
+    "MeanderingProgrammer/render-markdown.nvim",
     opts = {
       file_types = { "markdown", "norg", "rmd", "org" },
       code = {

--- a/lua/lazyvim/util/plugin.lua
+++ b/lua/lazyvim/util/plugin.lua
@@ -33,6 +33,7 @@ M.renames = {
   ["null-ls.nvim"] = "none-ls.nvim",
   ["romgrk/nvim-treesitter-context"] = "nvim-treesitter/nvim-treesitter-context",
   ["glepnir/dashboard-nvim"] = "nvimdev/dashboard-nvim",
+  ["markdown.nvim"] = "render-markdown.nvim",
 }
 
 function M.save_core()


### PR DESCRIPTION
As described in https://github.com/MeanderingProgrammer/render-markdown.nvim/commit/aeb5cec617c3bd5738ab82ba2c3f9ccdc27656c2