### PR TITLE
fix(omnisharp): use Go To Definition with fzf.lua

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/omnisharp.lua
+++ b/lua/lazyvim/plugins/extras/lang/omnisharp.lua
@@ -52,8 +52,10 @@ return {
           keys = {
             {
               "gd",
-              function()
+              LazyVim.has("telescope.nvim") and function()
                 require("omnisharp_extended").telescope_lsp_definitions()
+              end or function()
+                require("omnisharp_extended").lsp_definitions()
               end,
               desc = "Goto Definition",
             },


### PR DESCRIPTION
## Description

There was a problem with Omnisharp with fzf.lua enabled instead of telescope. As discussed in #4258, this change makes Go To Definition work with fzf.lua.

## Related Issue(s)

  - Fixes #4258 

## Checklist

- [x ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
