### PR TITLE
feat(ai): add `codecompanion.nvim` as alternative to `copilotchat.nvim`

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/codecompanion.lua
+++ b/lua/lazyvim/plugins/extras/coding/codecompanion.lua
@@ -1,0 +1,47 @@
+return {
+  {
+    "olimorris/codecompanion.nvim",
+    cmd = { "CodeCompanion", "CodeCompanionActions", "CodeCompanionToggle", "CodeCompanionAdd", "CodeCompanionChat" },
+
+    opts = function()
+      local options = require("codecompanion.config")
+      local user = vim.env.USER or "User"
+
+      options.strategies.chat.roles = {
+        llm = "  CodeCompanion",
+        user = "  " .. user:sub(1, 1):upper() .. user:sub(2),
+      }
+
+      options.strategies.chat.keymaps.close.modes = {
+        n = "q",
+        i = "<C-c>",
+      }
+      options.strategies.chat.keymaps.stop.modes.n = "<C-c>"
+      options.strategies.chat.keymaps.save.modes.n = "gS"
+
+      return options
+    end,
+
+    keys = {
+      { "<leader>a", "", desc = "+ai", mode = { "n", "v" } },
+      { "<leader>aA", "<cmd>CodeCompanionActions<cr>", mode = { "n", "v" }, desc = "Prompt Actions (CodeCompanion)" },
+      { "<leader>aa", "<cmd>CodeCompanionToggle<cr>", mode = { "n", "v" }, desc = "Toggle (CodeCompanion)" },
+      { "<leader>ac", "<cmd>CodeCompanionAdd<cr>", mode = "v", desc = "Add code to CodeCompanion" },
+      { "<leader>ap", "<cmd>CodeCompanion<cr>", mode = "n", desc = "Inline prompt (CodeCompanion)" },
+    },
+  },
+
+  -- Edgy integration
+  {
+    "folke/edgy.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.right = opts.right or {}
+      table.insert(opts.right, {
+        ft = "codecompanion",
+        title = "CodeCompanion Chat",
+        size = { width = 50 },
+      })
+    end,
+  },
+}


### PR DESCRIPTION
Add https://github.com/olimorris/codecompanion.nvim as an alternative to CopilotChat.
CodeCompanion makes it easier to add your own custom prompts and agentic workflow.

I've remapped some keys to better integrate with LazyVim (especially closing with `q`).