### PR TITLE
fix(vue): ensure css treesitter installed

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/astro.lua
+++ b/lua/lazyvim/plugins/extras/lang/astro.lua
@@ -17,7 +17,7 @@ return {
 
   {
     "nvim-treesitter/nvim-treesitter",
-    opts = { ensure_installed = { "astro" } },
+    opts = { ensure_installed = { "astro", "css" } },
   },
 
   -- LSP Servers

--- a/lua/lazyvim/plugins/extras/lang/vue.lua
+++ b/lua/lazyvim/plugins/extras/lang/vue.lua
@@ -11,7 +11,7 @@ return {
 
   {
     "nvim-treesitter/nvim-treesitter",
-    opts = { ensure_installed = { "vue" } },
+    opts = { ensure_installed = { "vue", "css" } },
   },
 
   -- Add LSP servers


### PR DESCRIPTION
## Description

If css treesitter is not installed(the current), <style> in vue file will use wrong commentstring, ts-comments.nvim or nvim-ts-context-commentstring both. so ensure it's installed.

## Related Issue(s)

explained: [in https://github.com/JoosepAlviste/nvim-ts-context-commentstring/issues/117](https://github.com/JoosepAlviste/nvim-ts-context-commentstring/issues/117#issuecomment-2287909324)
close https://github.com/LazyVim/LazyVim/issues/4292
