### PR TITLE
fix(project.nvim): correctly delete projects

### DIFF
--- a/lua/lazyvim/plugins/extras/util/project.lua
+++ b/lua/lazyvim/plugins/extras/util/project.lua
@@ -91,6 +91,15 @@ return {
     event = "VeryLazy",
     config = function(_, opts)
       require("project_nvim").setup(opts)
+      local history = require("project_nvim.utils.history")
+      history.delete_project = function(project)
+        for k, v in pairs(history.recent_projects) do
+          if v == project.value then
+            history.recent_projects[k] = nil
+            return
+          end
+        end
+      end
       LazyVim.on_load("telescope.nvim", function()
         require("telescope").load_extension("projects")
       end)


### PR DESCRIPTION
## Description
Unfortunately, the upstream Github repo hasn't been active for over a year. This overwrites the `history.delete_project` function to correctly be able to delete projects. Because of `ipairs` being used, when you delete the first key from the table the `for` loop iteration will just stop, since there will be a gap between the available indices. 
> will iterate over the pairs (`1,t[1]`), (`2,t[2]`), ..., up to the first integer key absent from the table.

There's also a [PR](https://github.com/ahmedkhalf/project.nvim/pull/106/files) for this upstream, but like I mentioned the Github repo hasn't been active for over a year.

Feel free to disregard, since this is obviously something that should be rather fixed upstream under normal circumstances. I just created this PR, since it's such a basic functionality with little change in LazyVim's codebase, that I thought it might be acceptable.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
No, rather a discussion #4310
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
