### PR TITLE
feat(type): better hinting diagnostics option

### DIFF
--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -11,7 +11,7 @@ return {
       ---@class PluginLspOpts
       local ret = {
         -- options for vim.diagnostic.config()
-        ---@type vim.diagnostic.Opts
+        ---@type vim.diagnostic.config.Opts
         diagnostics = {
           underline = true,
           update_in_insert = false,

--- a/lua/lazyvim/types.lua
+++ b/lua/lazyvim/types.lua
@@ -22,3 +22,10 @@ _G.LazyVim = require("lazyvim.util")
 --- @param opts vim.api.keyset.create_autocmd.opts
 --- @return integer
 function vim.api.nvim_create_autocmd(event, opts) end
+
+
+---@class vim.diagnostic.config.Opts: vim.diagnostic.Opts
+---@field float? vim.diagnostic.config.Opts.Float
+---
+---@class vim.diagnostic.config.Opts.Float: vim.diagnostic.Opts.Float
+---@field border? string | string[] | string[][]


### PR DESCRIPTION
## Description

`nvim_open_win()` in fact support the following:

```lua
float = {"char", ...} | {{"char", "hlgroup"}, ...}
```

I have only tested this on 0.10+ and nightly build, so I'm not entirely sure about backward compat.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
