### PR TITLE
fix(ocaml): get_language_id

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/ocaml.lua
+++ b/lua/lazyvim/plugins/extras/lang/ocaml.lua
@@ -18,9 +18,14 @@ return {
     opts = {
       servers = {
         ocamllsp = {
-          get_language_id = function(_, ftype)
-            return language_id_of[ftype]
-          end,
+          filetypes = {
+            "ocaml",
+            "ocaml.menhir",
+            "ocaml.interface",
+            "ocaml.ocamllex",
+            "reason",
+            "dune",
+          },
           root_dir = function(fname)
             return require("lspconfig.util").root_pattern(
               "*.opam",


### PR DESCRIPTION
## Description
This fixes the error users get from local function `get_language_id`. 

From looking into [nvim-lspconfig ocamllsp](https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/ocamllsp.lua) and other googling around, namely [tjdevries config files](https://github.com/tjdevries/config.nvim/blob/9b790b90c1ac68cf7e60d6537baf9395523d6b01/lua/custom/plugins/lsp.lua#L108-L115) and [another one](https://github.com/nyinyithann/neovim-ocaml/blob/e31c0d61fd78a2d367bacfae2886629a2c7a88d7/nvim/after/plugin/lspconfig.lua#L67), it seems that we can directly set these as filetypes foregoing the mapping via the additional local function which would also need the [nvim-lspconfig language_id mapping](https://github.com/neovim/nvim-lspconfig/blob/d4814330b207a4e05ba9515e453b0e87f20357ec/lua/lspconfig/server_configurations/ocamllsp.lua#L3-L10).

Please bear in mind I don't do any Ocaml, so it would be great if other users who do Ocaml could test this PR.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Closes #4326
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
