### PR TITLE
Removes unused code that prevents the config to load in OCaml files

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/ocaml.lua
+++ b/lua/lazyvim/plugins/extras/lang/ocaml.lua
@@ -18,9 +18,6 @@ return {
     opts = {
       servers = {
         ocamllsp = {
-          get_language_id = function(_, ftype)
-            return language_id_of[ftype]
-          end,
           root_dir = function(fname)
             return require("lspconfig.util").root_pattern(
               "*.opam",


### PR DESCRIPTION
Removes unused code that prevents the config to load in OCaml files.

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
