### PR TITLE
feat(lazygit): allow user to override LazyVim config with custom file

### DIFF
--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -20,9 +20,12 @@ vim.g.root_spec = { "lsp", { ".git", "lua" }, "cwd" }
 
 -- LazyVim automatically configures lazygit:
 --  * theme, based on the active colorscheme.
---  * editorPreset to nvim-remote
+--  * editPreset to nvim-remote
 --  * enables nerd font icons
 -- Set to false to disable.
+-- Set the options you want to override in `~/.config/lazygit/custom.yml`
+-- WARN: on Windows you might want to set `editPreset: "nvim"` due to
+-- this issue https://github.com/jesseduffield/lazygit/issues/3467
 vim.g.lazygit_config = true
 
 -- Options for the LazyVim statuscolumn

--- a/lua/lazyvim/util/lazygit.lua
+++ b/lua/lazyvim/util/lazygit.lua
@@ -70,6 +70,10 @@ function M.open(opts)
       if ok then
         M.config_dir = lines[1]
         vim.env.LG_CONFIG_FILE = LazyVim.norm(M.config_dir .. "/config.yml" .. "," .. M.theme_path)
+        local custom_config = LazyVim.norm(M.config_dir .. "/custom.yml")
+        if vim.uv.fs_stat(custom_config) and vim.uv.fs_stat(custom_config).type == "file" then
+          vim.env.LG_CONFIG_FILE = vim.env.LG_CONFIG_FILE .. "," .. custom_config
+        end
       else
         ---@diagnostic disable-next-line: cast-type-mismatch
         ---@cast lines string
@@ -130,9 +134,9 @@ gui:
   ---@type string[]
   local lines = {}
   for k, v in pairs(theme) do
-    lines[#lines + 1] = ("   %s:"):format(k)
+    lines[#lines + 1] = ("    %s:"):format(k)
     for _, c in ipairs(v) do
-      lines[#lines + 1] = ("     - %q"):format(c)
+      lines[#lines + 1] = ("      - %q"):format(c)
     end
   end
   config = config .. table.concat(lines, "\n")


### PR DESCRIPTION
## Description
This takes into consideration an additional file, if it exists, to extend `LG_CONFIG_FILE` environment variable, so that users can overwrite easier default LazyVim options set for lazygit in `lazygit-theme.yml`. It's not desirable to directly change `lazygit-theme.yml` as the values are hardcoded and regenerated upon colorscheme change.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #4364. Ideally, the problem about `nvim-remote` on Windows should be fixed on lazygit's side, so this is just kind of a hotfix in the meantime. Feel free to disregard this if not desirable.
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
