### PR TITLE
fix(snippet): don't set navigation mappings in nightly

### DIFF
--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -102,26 +102,17 @@ return {
         table.insert(opts.sources, { name = "snippets" })
       end
     end,
-    keys = {
-      {
-        "<Tab>",
-        function()
+    init = function()
+      -- Neovim enabled snippet navigation mappings by default in v0.11
+      if vim.fn.has("nvim-0.11") == 0 then
+        vim.keymap.set({ "i", "s" }, "<Tab>", function()
           return vim.snippet.active({ direction = 1 }) and "<cmd>lua vim.snippet.jump(1)<cr>" or "<Tab>"
-        end,
-        expr = true,
-        silent = true,
-        mode = { "i", "s" },
-      },
-      {
-        "<S-Tab>",
-        function()
+        end, { expr = true, silent = true })
+        vim.keymap.set({ "i", "s" }, "<S-Tab>", function()
           return vim.snippet.active({ direction = -1 }) and "<cmd>lua vim.snippet.jump(-1)<cr>" or "<S-Tab>"
-        end,
-        expr = true,
-        silent = true,
-        mode = { "i", "s" },
-      },
-    },
+        end, { expr = true, silent = true })
+      end
+    end,
   },
 
   -- auto pairs


### PR DESCRIPTION
## Description

Since [this commit in Neovim](https://github.com/neovim/neovim/pull/27339), snippet navigation mappings are set by default to `<tab>` and `<s-tab>`, and hence don't need to be redefined here. Moreover, the core implementation makes sure that those snippet navigation mappings are active only when snippet expansion is happening, and if other user bindings are using those keys, they're restored when snippet navigation ends.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
