### PR TITLE
fix(grug): grug_far -> grug.open

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -137,7 +137,7 @@ return {
         function()
           local grug = require("grug-far")
           local ext = vim.bo.buftype == "" and vim.fn.expand("%:e")
-          grug.grug_far({
+          grug.open({
             transient = true,
             prefills = {
               filesFilter = ext and ext ~= "" and "*." .. ext or nil,


### PR DESCRIPTION
## Description

Just a very simple fix to use the updated method in grug to set the options for the dependency. Just ran across the issue debuging search and replace on my setup (was not the issue). 

This is not breaking.  
## Related Issue(s)

N/A
## Screenshots
N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
