### PR TITLE
fix(extra): make copilot-chat.lua fallback to the latest model

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/copilot-chat.lua
+++ b/lua/lazyvim/plugins/extras/coding/copilot-chat.lua
@@ -23,7 +23,6 @@ return {
       local user = vim.env.USER or "User"
       user = user:sub(1, 1):upper() .. user:sub(2)
       return {
-        model = "gpt-4",
         auto_insert_mode = true,
         show_help = true,
         question_header = "  " .. user .. " ",


### PR DESCRIPTION
## Description

CopilotChat upgraded to gpt-4o early in August https://github.com/CopilotC-Nvim/CopilotChat.nvim/commit/2c4d2954f9b56945dc8d053903b16759d08f9f37 but the LazyVim plugin is still running with opts of gpt-4. I thought about changing model to the latest here, but I feel this means more maintainability for an option which generally is expected to point to the latest model, and the upstream opts of CopilotChat seem to keep up with that already.

## Related Issue(s)
None

## Screenshots
None

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
