### PR TITLE
[lazyvim.plugins.extras.lang.typescript.lua] treesitter - ensure_installed typescript

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -12,7 +12,10 @@ return {
       root = { "tsconfig.json", "package.json", "jsconfig.json" },
     })
   end,
-
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = { ensure_installed = { "typescript", "javascript" } },
+  },
   -- correctly setup lspconfig
   {
     "neovim/nvim-lspconfig",


### PR DESCRIPTION
## Description

When enabling language extras, most other extras automatically install the treesitter modules for syntax highlighting for the language.
The typescript module was missing this `"nvim-treesitter/nvim-treesitter", opts = { ensure_installed = { "typescript", "javascript" } },` config.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
