### PR TITLE
fix(lualine): weird path truncation when not under cwd/root

### DIFF
--- a/lua/lazyvim/util/lualine.lua
+++ b/lua/lazyvim/util/lualine.lua
@@ -96,7 +96,7 @@ function M.pretty_path(opts)
 
     if opts.relative == "cwd" and path:find(cwd, 1, true) == 1 then
       path = path:sub(#cwd + 2)
-    else
+    elseif opts.relative == "root" and path:find(root, 1, true) == 1 then
       path = path:sub(#root + 2)
     end
 


### PR DESCRIPTION
## Description

It does not make sense to truncate unless root *actually* in path.

Also, should check if `opts.relative == "root"`
otherwise the substitution can be surprising
(since user expects substitution only wrt. cwd)

## Related Issue(s)

N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
