### PR TITLE
feat(extras): add biome formatter

### DIFF
--- a/lua/lazyvim/plugins/extras/formatting/biome.lua
+++ b/lua/lazyvim/plugins/extras/formatting/biome.lua
@@ -1,0 +1,59 @@
+---@diagnostic disable: inject-field
+if lazyvim_docs then
+  -- Enable this option to avoid conflicts with Prettier.
+  vim.g.lazyvim_prettier_needs_config = true
+end
+
+-- https://biomejs.dev/internals/language-support/
+local supported = {
+  "astro",
+  "css",
+  "graphql",
+  -- "html",
+  "javascript",
+  "javascriptreact",
+  "json",
+  "jsonc",
+  -- "markdown",
+  "svelte",
+  "typescript",
+  "typescriptreact",
+  "vue",
+  -- "yaml",
+}
+
+return {
+  {
+    "williamboman/mason.nvim",
+    opts = { ensure_installed = { "biome" } },
+  },
+
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    ---@param opts ConformOpts
+    opts = function(_, opts)
+      opts.formatters_by_ft = opts.formatters_by_ft or {}
+      for _, ft in ipairs(supported) do
+        opts.formatters_by_ft[ft] = opts.formatters_by_ft[ft] or {}
+        table.insert(opts.formatters_by_ft[ft], "biome")
+      end
+
+      opts.formatters = opts.formatters or {}
+      opts.formatters.biome = {
+        require_cwd = true,
+      }
+    end,
+  },
+
+  -- none-ls support
+  {
+    "nvimtools/none-ls.nvim",
+    optional = true,
+    opts = function(_, opts)
+      local nls = require("null-ls")
+      opts.sources = opts.sources or {}
+      table.insert(opts.sources, nls.builtins.formatting.biome)
+    end,
+  },
+}


### PR DESCRIPTION
## Description
This PR adds biome as a conform/null-ls formatter.

When using biome lsp formatting directly, the syntax highlighting is flickering. However, it works great when formatting is configured with conform.

To avoid conflicts with Prettier, it is recommended to set
`vim.g.lazyvim_prettier_needs_config = true` In this case, both prettier and biome formatters could be activated simultaneously. 

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
