### PR TITLE
Add left right keymaps to always open folds

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -10,6 +10,10 @@ map({ "n", "x" }, "<Down>", "v:count == 0 ? 'gj' : 'j'", { desc = "Down", expr =
 map({ "n", "x" }, "k", "v:count == 0 ? 'gk' : 'k'", { desc = "Up", expr = true, silent = true })
 map({ "n", "x" }, "<Up>", "v:count == 0 ? 'gk' : 'k'", { desc = "Up", expr = true, silent = true })
 
+-- Open folds on left/right
+map("n", "h", "foldclosed('.') > 0 ? 'zoh' : 'h'", { expr = true, silent = true })
+map("n", "l", "foldclosed('.') > 0 ? 'zol' : 'l'", { expr = true, silent = true })
+
 -- Move to window using the <ctrl> hjkl keys
 map("n", "<C-h>", "<C-w>h", { desc = "Go to Left Window", remap = true })
 map("n", "<C-j>", "<C-w>j", { desc = "Go to Lower Window", remap = true })


### PR DESCRIPTION
## Description

h and l open closed folds unless h is pressed when cursor is far left or when l is pressed when cursor is far right.

## Related Issue(s)

Fixes https://github.com/LazyVim/LazyVim/issues/4451

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
