### PR TITLE
fix(extras): .env* files shouldn't warn about unused vars

### DIFF
--- a/lua/lazyvim/plugins/extras/util/dot.lua
+++ b/lua/lazyvim/plugins/extras/util/dot.lua
@@ -32,7 +32,12 @@ return {
       end
 
       vim.filetype.add({
-        extension = { rasi = "rasi", rofi = "rasi", wofi = "rasi" },
+        extension = {
+          env = "conf",
+          rasi = "rasi",
+          rofi = "rasi",
+          wofi = "rasi",
+        },
         filename = {
           ["vifmrc"] = "vim",
         },
@@ -41,7 +46,7 @@ return {
           [".*/mako/config"] = "dosini",
           [".*/kitty/.+%.conf"] = "bash",
           [".*/hypr/.+%.conf"] = "hyprlang",
-          ["%.env%.[%w_.-]+"] = "sh",
+          ["%.env%.[%w_.-]+"] = "conf",
         },
       })
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

As `.env` files are configured as `filetype: "sh"` through the Dot Files extra, `shellcheck` linting kicks in which causes very noisy rendering, full of `[VAR] appears unused. Verify use (or export if used externally). [SC2034]`.

This PR changes their `filetype` to `conf` instead. Pros: significantly less noisy. Cons: loses some syntax highlighting / formatting features. I think it's an "OK" immediate compromise, but it'd perhaps be better to configure `shellcheck` to specifically ignore `SC2034` for `.env*` files by default. Alas, not much time to dig into it nowadays.


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

No issue I could find, but related discussion https://github.com/LazyVim/LazyVim/discussions/4027

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

### Before
![Screenshot 2024-09-20 at 09 39 28](https://github.com/user-attachments/assets/2d09a44a-e6c9-49c1-abd4-bbe34b1ae6c2)

### After
![Screenshot 2024-09-20 at 09 40 26](https://github.com/user-attachments/assets/022af211-65e3-4ab0-ab82-21591918b547)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
