### PR TITLE
feat(rust): update rustaceanvim

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -42,7 +42,7 @@ return {
 
   {
     "mrcjkb/rustaceanvim",
-    version = "^4", -- Recommended
+    version = vim.fn.has("nvim-0.10.0") == 0 and "^4" or false,
     ft = { "rust" },
     opts = {
       server = {


### PR DESCRIPTION
The recommended version of rustaceanvim has changed to 5.x, which brings in a lot of improvements.

## Description

Version 5.x of rustaceanvim has a lot of improvements over 4.x, and is the recommended version according to its maintainer.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
