### PR TITLE
fix(lean): pin lean.nvim to a functional commit

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/lean.lua
+++ b/lua/lazyvim/plugins/extras/lang/lean.lua
@@ -6,6 +6,7 @@ return {
     })
   end,
   "Julian/lean.nvim",
+  commit = 'fd7262270c68667fae85ad4703ac84e34c84d5e1', -- See https://github.com/Julian/lean.nvim/issues/353
   event = { "BufReadPre *.lean", "BufNewFile *.lean" },
   dependencies = {
     "nvim-lua/plenary.nvim",

--- a/lua/lazyvim/plugins/extras/lang/lean.lua
+++ b/lua/lazyvim/plugins/extras/lang/lean.lua
@@ -6,7 +6,7 @@ return {
     })
   end,
   "Julian/lean.nvim",
-  commit = 'fd7262270c68667fae85ad4703ac84e34c84d5e1', -- See https://github.com/Julian/lean.nvim/issues/353
+  commit = "fd7262270c68667fae85ad4703ac84e34c84d5e1", -- See https://github.com/Julian/lean.nvim/issues/353
   event = { "BufReadPre *.lean", "BufNewFile *.lean" },
   dependencies = {
     "nvim-lua/plenary.nvim",


### PR DESCRIPTION
## Description

Basically the maintainer is experimenting with some stuff relating to handling when to run the config. The issue is that it is on the main branch, so the current state of the repo is not functional with our current config.

I created an issue on the lean.nvim repo about this, so hopefully it is resolved soon.
https://github.com/Julian/lean.nvim/issues/353

This PR pins lean.nvim to the last functional commit.

I will make a new PR for when the repo is functional again.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.