### PR TITLE
Migrate away from deprecated `get_target_window()` in mini-files

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/mini-files.lua
+++ b/lua/lazyvim/plugins/extras/editor/mini-files.lua
@@ -48,7 +48,7 @@ return {
     local map_split = function(buf_id, lhs, direction, close_on_file)
       local rhs = function()
         local new_target_window
-        local cur_target_window = require("mini.files").get_target_window()
+        local cur_target_window = require("mini.files").get_explorer_state().target_window
         if cur_target_window ~= nil then
           vim.api.nvim_win_call(cur_target_window, function()
             vim.cmd("belowright " .. direction .. " split")


### PR DESCRIPTION
## Description

This method is deprecated in the most recent version of mini-files: https://github.com/echasnovski/mini.files/blob/a3a9cce82115a69dba161ac45bda16f4e606f73b/lua/mini/files.lua#L1060-L1068, which causes a warning message to be displayed every time the `<leader>wv` and similar commands are used from the mini file browser.

I've tested this change locally and it gets rid of the warning message.

## Screenshots
Warning message without this fix:
<img width="1355" alt="image" src="https://github.com/user-attachments/assets/cf5dc674-6054-4cb2-9e9b-3b0bb03dd5ca">

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
