### PR TITLE
feat(keymaps): enhance pasting and deleting text from buffer

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -75,6 +75,10 @@ map("n", "<leader>K", "<cmd>norm! K<cr>", { desc = "Keywordprg" })
 map("v", "<", "<gv")
 map("v", ">", ">gv")
 
+-- Keep last yanked when pasting or deleting
+map("v", "p", '"_dP')
+map("n", "x", '"_x')
+
 -- commenting
 map("n", "gco", "o<esc>Vcx<esc><cmd>normal gcc<cr>fxa<bs>", { desc = "Add Comment Below" })
 map("n", "gcO", "O<esc>Vcx<esc><cmd>normal gcc<cr>fxa<bs>", { desc = "Add Comment Above" })


### PR DESCRIPTION
## Description

by nature if yanked text and selected other  text and pasted it over it   neovim will  automatically replace the yanked  text with the selected text.
This mapping will disable this behavior 

## Checklist

- [ x ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
