### PR TITLE
feat(lazygit): `util.lazygit.browse` can open current branch

### DIFF
--- a/lua/lazyvim/util/lazygit.lua
+++ b/lua/lazyvim/util/lazygit.lua
@@ -189,6 +189,7 @@ end
 function M.browse()
   local lines = require("lazy.manage.process").exec({ "git", "remote", "-v" })
   local remotes = {} ---@type {name:string, url:string}[]
+  local branch = require("lazy.manage.process").exec({ "git", "rev-parse", "--abbrev-ref", "HEAD" })[1]
 
   for _, line in ipairs(lines) do
     local name, remote = line:match("(%S+)%s+(%S+)%s+%(fetch%)")
@@ -197,7 +198,7 @@ function M.browse()
       if url then
         table.insert(remotes, {
           name = name,
-          url = url,
+          url = (branch ~= "main" and branch ~= "master") and url .. "/tree/" .. branch or url,
         })
       end
     end


### PR DESCRIPTION
## Description
This allows the function `util.lazygit.browse` to open the current branch a user is at a repo.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Closes #4491
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
