### PR TITLE
fix(lualine): only trim root from path if present

### DIFF
--- a/lua/lazyvim/util/lualine.lua
+++ b/lua/lazyvim/util/lualine.lua
@@ -96,7 +96,7 @@ function M.pretty_path(opts)
 
     if opts.relative == "cwd" and path:find(cwd, 1, true) == 1 then
       path = path:sub(#cwd + 2)
-    else
+    elseif path:find(root, 1, true) == 1 then
       path = path:sub(#root + 2)
     end
 


### PR DESCRIPTION
Ensure that path actually begins with root before trimming it off the front. Otherwise, the path gets mangled.

## Description

`Util.lualine.pretty_path()`  checks if that path should be relative to `cwd` and trims the value of `cwd` off the front of path if present.  If not, then it just blindly trims the length of `root` off of the front of path, without checking to see if the path is prefixed with `root`. This results in paths getting mangled.

For example, if I run `cd /tmp && vi ~/.config/nvim/lua/plugins/init.lua` (so that I'm editing a file outside of cwd), then lualine.pretty_path() sets a path of `ns/init.lua`:

![2024-09-26T11:41:18,006345055-07:00](https://github.com/user-attachments/assets/9ab3b5b5-514e-41b9-8286-24f22a6845b0)

With this fix, it leaves the path alone, and collapses path elements to the configured length:

![2024-09-26T11:41:40,978182873-07:00](https://github.com/user-attachments/assets/7051cc87-176c-4961-ab21-983a95cd73bb)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
