### PR TITLE
fix(toggle): `M.wk` should not add description if there's a LazyKeysHandler present

### DIFF
--- a/lua/lazyvim/util/toggle.lua
+++ b/lua/lazyvim/util/toggle.lua
@@ -39,7 +39,13 @@ function M.map(lhs, toggle)
 end
 
 function M.wk(lhs, toggle)
+  local keys = require("lazy.core.handler").handlers.keys
+  ---@cast keys LazyKeysHandler
+
   if not LazyVim.has("which-key.nvim") then
+    return
+  end
+  if keys.have and keys:have(lhs, "n") then
     return
   end
   local function safe_get()


### PR DESCRIPTION
## Description
Currently there's no check in `LazyVim.toggle.wk` function if a `LazyKeysHandler` is present in some spec. This fixes that.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #4502
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
