### PR TITLE
fix(render-markdown): remove redundant `opts.file_types`

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/markdown.lua
+++ b/lua/lazyvim/plugins/extras/lang/markdown.lua
@@ -95,7 +95,6 @@ return {
   {
     "MeanderingProgrammer/render-markdown.nvim",
     opts = {
-      file_types = { "markdown", "norg", "rmd", "org" },
       code = {
         sign = false,
         width = "block",


### PR DESCRIPTION
## Description
After https://github.com/MeanderingProgrammer/render-markdown.nvim/commit/cb9a5e2412d21c7a89627e0d6da5459acbc0eb9c there's no need for defining filetypes both in Lazy's `ft` and the plugin's `opts.file_types`.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
