### PR TITLE
fix(extras): rename `lspconfig.server_configurations` to `lspconfig.configs`

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -1,4 +1,4 @@
--- This is the same as in lspconfig.server_configurations.jdtls, but avoids
+-- This is the same as in lspconfig.configs.jdtls, but avoids
 -- needing to require that when this module loads.
 local java_filetypes = { "java" }
 
@@ -76,7 +76,7 @@ return {
       return {
         -- How to find the root dir for a given filename. The default comes from
         -- lspconfig which provides a function specifically for java projects.
-        root_dir = require("lspconfig.server_configurations.jdtls").default_config.root_dir,
+        root_dir = require("lspconfig.configs.jdtls").default_config.root_dir,
 
         -- How to find the project name for a given root dir.
         project_name = function(root_dir)

--- a/lua/lazyvim/plugins/extras/lang/lean.lua
+++ b/lua/lazyvim/plugins/extras/lang/lean.lua
@@ -17,7 +17,7 @@ return {
     --
     -- false to disable, otherwise should be a table of options to pass to `leanls`
     --
-    -- See https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#leanls for details.
+    -- See https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#leanls for details.
     -- In particular ensure you have followed instructions setting up a callback
     -- for `LspAttach` which sets your key bindings!
     lsp = {

--- a/lua/lazyvim/plugins/extras/lang/tailwind.lua
+++ b/lua/lazyvim/plugins/extras/lang/tailwind.lua
@@ -28,7 +28,7 @@ return {
       },
       setup = {
         tailwindcss = function(_, opts)
-          local tw = require("lspconfig.server_configurations.tailwindcss")
+          local tw = require("lspconfig.configs.tailwindcss")
           opts.filetypes = opts.filetypes or {}
 
           -- Add default filetypes


### PR DESCRIPTION
## Description

https://github.com/neovim/nvim-lspconfig/commit/bedb2a0df105f68a624a49b867f269b6d55a2c89 introduces a change to the Lua module structure for `nvim-lspconfig` that broke `tailwindcss`.  Tried to also address all the other usages of `lspconfig.server_configurations` within the ecosystem.

## Screenshots

![mason-lspconfig nvim](https://github.com/user-attachments/assets/bc9f80f0-3386-436f-8f86-abfcb311cec2)


## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
