### PR TITLE
feat(toggle): add more `M.wk` fields for better user customization

### DIFF
--- a/lua/lazyvim/util/toggle.lua
+++ b/lua/lazyvim/util/toggle.lua
@@ -3,6 +3,9 @@ local M = {}
 
 ---@class lazyvim.Toggle
 ---@field name string
+---@field icon? string
+---@field color_enabled? string
+---@field color_disabled? string
 ---@field get fun():boolean
 ---@field set fun(state:boolean)
 
@@ -50,7 +53,8 @@ function M.wk(lhs, toggle)
     {
       lhs,
       icon = function()
-        return safe_get() and { icon = " ", color = "green" } or { icon = " ", color = "yellow" }
+        return safe_get() and { icon = toggle.icon or " ", color = toggle.color_enabled or "green" }
+          or { icon = toggle.icon or " ", color = toggle.color_disabled or "yellow" }
       end,
       desc = function()
         return (safe_get() and "Disable " or "Enable ") .. toggle.name


### PR DESCRIPTION
## Description
Add to `M.wk` fields for `icon`, `color_enabled` and `color_disabled` for more granual user customization.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
No, rather a discussion #4512
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
