### PR TITLE
feat(options): add `localoptions` to `opt.sessionoptions`

### DIFF
--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -89,7 +89,8 @@ opt.pumblend = 10 -- Popup blend
 opt.pumheight = 10 -- Maximum number of entries in a popup
 opt.relativenumber = true -- Relative line numbers
 opt.scrolloff = 4 -- Lines of context
-opt.sessionoptions = { "buffers", "curdir", "tabpages", "winsize", "help", "globals", "skiprtp", "folds" }
+opt.sessionoptions =
+  { "buffers", "curdir", "tabpages", "winsize", "help", "globals", "skiprtp", "folds", "localoptions" }
 opt.shiftround = true -- Round indent
 opt.shiftwidth = 2 -- Size of an indent
 opt.shortmess:append({ W = true, I = true, c = true, C = true })


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
  
  I take markdown notes in multiple languages (English and Spanish), but my langspell settings are not remembered if I switch to something other than the config in `opt.spelllang` in the `options.lua` file, which I have set to `English`
  
  By adding `localoptions` to  `opt.sessionoptions` these settings are persisted so that I can change the language to `english` , `spanish` or `en,es` on a buffer and when I re-open the buffer it will pick up that information so that I don't have to be setting the spellang again
  
  See [this video](https://youtu.be/uLFAMYFmpkE) for reference

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
