### PR TITLE
refactor(cmp): add `optional` where necessary

### DIFF
--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -85,6 +85,7 @@ return {
   -- snippets
   {
     "nvim-cmp",
+    optional = true,
     dependencies = {
       {
         "garymjr/nvim-snippets",
@@ -209,6 +210,7 @@ return {
   -- Add lazydev source to cmp
   {
     "hrsh7th/nvim-cmp",
+    optional = true,
     opts = function(_, opts)
       table.insert(opts.sources, { name = "lazydev", group_index = 0 })
     end,

--- a/lua/lazyvim/plugins/extras/coding/tabnine.lua
+++ b/lua/lazyvim/plugins/extras/coding/tabnine.lua
@@ -2,6 +2,7 @@ return {
   -- Tabnine cmp source
   {
     "nvim-cmp",
+    optional = true,
     dependencies = {
       {
         "tzachar/cmp-tabnine",

--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -133,6 +133,7 @@ return {
 
   {
     "hrsh7th/nvim-cmp",
+    optional = true,
     opts = function(_, opts)
       opts.auto_brackets = opts.auto_brackets or {}
       table.insert(opts.auto_brackets, "python")

--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -9,6 +9,7 @@ return {
   -- Extend auto completion
   {
     "hrsh7th/nvim-cmp",
+    optional = true,
     dependencies = {
       {
         "Saecki/crates.nvim",

--- a/lua/lazyvim/plugins/extras/lang/tailwind.lua
+++ b/lua/lazyvim/plugins/extras/lang/tailwind.lua
@@ -59,6 +59,7 @@ return {
   },
   {
     "hrsh7th/nvim-cmp",
+    optional = true,
     dependencies = {
       { "roobert/tailwindcss-colorizer-cmp.nvim", opts = {} },
     },


### PR DESCRIPTION
## Description
Makes it easier to disable it for users who want to try other completion engines, without it being pulled back by some Extra.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
