### PR TITLE
fix(lang/r): make keymaps in which-key menu available in visual mode

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/r.lua
+++ b/lua/lazyvim/plugins/extras/lang/r.lua
@@ -22,6 +22,7 @@ return {
           local wk = require("which-key")
           wk.add({
             buffer = true,
+            mode = { "n", "v" },
             { "<localleader>a", group = "all" },
             { "<localleader>b", group = "between marks" },
             { "<localleader>c", group = "chunks" },


### PR DESCRIPTION
## Description
`r.nvim` keymaps don't show group names in visual mode.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
No, rather discussion #4564
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
