### PR TITLE
fix(lang/ruby): do not enable Rubocop as LSP if Solargraph is used

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/ruby.lua
+++ b/lua/lazyvim/plugins/extras/lang/ruby.lua
@@ -36,7 +36,10 @@ return {
           enabled = lsp == "solargraph",
         },
         rubocop = {
-          enabled = formatter == "rubocop",
+          -- If Solargraph and Rubocop are both enabled as an LSP,
+          -- diagnostics will be duplicated because Solargraph
+          -- already calls Rubocop if it is installed
+          enabled = formatter == "rubocop" and lsp ~= "solargraph",
         },
         standardrb = {
           enabled = formatter == "standardrb",


### PR DESCRIPTION
## Description

Solargraph already delegates some diagnostics to Rubocop by itself if it is installed on your system. However, if Rubocop is also enabled as an LSP while you're using Solargraph, then all Rubocop diagnostics are going to be duplicated and shown twice. Once from Solargraph after it calls Rubocop, and again by Rubocop separately running as an LSP.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
