### PR TITLE
feat(bufferline): integration for catppuccin highlights

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -81,6 +81,10 @@ return {
       },
     },
     config = function(_, opts)
+      ---@diagnostic disable-next-line: param-type-mismatch
+      if type(LazyVim.config.colorscheme) == "string" and vim.startswith(LazyVim.config.colorscheme, "catppuccin") then
+        opts.highlights = require("catppuccin.groups.integrations.bufferline").get()
+      end
       require("bufferline").setup(opts)
       -- Fix bufferline when restoring a session
       vim.api.nvim_create_autocmd({ "BufAdd", "BufDelete" }, {


### PR DESCRIPTION
## Description
I'm not sure how to do this if `LazyVim.config.colorscheme` is a function, because it doesn't return a string to compare to. I also tried `vim.cmd("colorscheme")`, but it executes too late. If you know of a way to also include the function please feel free to make any changes necessary.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Closes #4581
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
