### PR TITLE
feat(catppuccin): enable bufferline integration

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -81,6 +81,9 @@ return {
       },
     },
     config = function(_, opts)
+      if LazyVim.is_loaded("catppuccin") then
+        opts.highlights = require("catppuccin.groups.integrations.bufferline").get()
+      end
       require("bufferline").setup(opts)
       -- Fix bufferline when restoring a session
       vim.api.nvim_create_autocmd({ "BufAdd", "BufDelete" }, {


### PR DESCRIPTION
## Description

Similar implementation to https://github.com/LazyVim/LazyVim/pull/4582, but looks a bit cleaner. I know `is_loaded` is not exactly meant to be used this way, but it is the most fitting loading method I could find.

Bufferline integration must be run after catppuccin is loaded, and since LazyVim loads the colorscheme first, this should work as expected.

## Related Issue(s)

Closes #4581 

## Screenshots

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
