### PR TITLE
feat(extras): expose `prios` to user

### DIFF
--- a/lua/lazyvim/plugins/xtras.lua
+++ b/lua/lazyvim/plugins/xtras.lua
@@ -1,4 +1,6 @@
 -- Some extras need to be loaded before others
+
+---@class LazyVimExtrasPrios: table<string, integer>
 local prios = {
   ["lazyvim.plugins.extras.test.core"] = 1,
   ["lazyvim.plugins.extras.dap.core"] = 1,
@@ -6,9 +8,12 @@ local prios = {
   ["lazyvim.plugins.extras.lang.typescript"] = 5,
   ["lazyvim.plugins.extras.formatting.prettier"] = 10,
   -- default priority is 50
+
   ["lazyvim.plugins.extras.editor.aerial"] = 100,
   ["lazyvim.plugins.extras.editor.outline"] = 100,
 }
+
+LazyVim.xtras_prios = prios
 
 ---@type string[]
 local extras = LazyVim.dedup(LazyVim.config.json.data.extras)

--- a/lua/lazyvim/util/init.lua
+++ b/lua/lazyvim/util/init.lua
@@ -2,6 +2,7 @@ local LazyUtil = require("lazy.core.util")
 
 ---@class lazyvim.util: LazyUtilCore
 ---@field config LazyVimConfig
+---@field xtras_prios LazyVimExtrasPrios
 ---@field ui lazyvim.util.ui
 ---@field lsp lazyvim.util.lsp
 ---@field root lazyvim.util.root


### PR DESCRIPTION
## Description
This exposes the `local prios` table in `plugins.xtras` to the `LazyVim` global, so that users can have access to it and customize the priorities.
The extra empty lines are so that the comments are not taken into account from `lua_ls` for the field right after them.

If you feel that such a feature should not be available to the users, please feel free to close this. 
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Closes #4584
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
