### PR TITLE
feat(terraform): add formatter for packer files

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/terraform.lua
+++ b/lua/lazyvim/plugins/extras/lang/terraform.lua
@@ -29,6 +29,7 @@ return {
     opts = function(_, opts)
       local null_ls = require("null-ls")
       opts.sources = vim.list_extend(opts.sources or {}, {
+        null_ls.builtins.formatting.packer,
         null_ls.builtins.formatting.terraform_fmt,
         null_ls.builtins.diagnostics.terraform_validate,
       })
@@ -49,6 +50,7 @@ return {
     optional = true,
     opts = {
       formatters_by_ft = {
+        hcl = { "packer_fmt" },
         terraform = { "terraform_fmt" },
         tf = { "terraform_fmt" },
         ["terraform-vars"] = { "terraform_fmt" },


### PR DESCRIPTION
## Description

Adds a formatter for Packer configuration files (`ft=hcl`), a file type already partially supported by the `lang.terraform` extra.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
