### PR TITLE
feat(vscode): add keybindings for diagnostics

### DIFF
--- a/lua/lazyvim/plugins/extras/vscode.lua
+++ b/lua/lazyvim/plugins/extras/vscode.lua
@@ -35,6 +35,8 @@ vim.api.nvim_create_autocmd("User", {
     vim.keymap.set("n", "<leader><space>", "<cmd>Find<cr>")
     vim.keymap.set("n", "<leader>/", [[<cmd>lua require('vscode').action('workbench.action.findInFiles')<cr>]])
     vim.keymap.set("n", "<leader>ss", [[<cmd>lua require('vscode').action('workbench.action.gotoSymbol')<cr>]])
+    vim.keymap.set("n", "]d", [[<cmd>lua require('vscode').call('editor.action.marker.next')<cr>]], { desc = "Next Diagnostic" })
+    vim.keymap.set("n", "[d", [[<cmd>lua require('vscode').call('editor.action.marker.previous')<cr>]], { desc = "Previous Diagnostic" })
   end,
 })
 

--- a/lua/lazyvim/plugins/extras/vscode.lua
+++ b/lua/lazyvim/plugins/extras/vscode.lua
@@ -36,7 +36,7 @@ vim.api.nvim_create_autocmd("User", {
     vim.keymap.set("n", "<leader>/", [[<cmd>lua require('vscode').action('workbench.action.findInFiles')<cr>]])
     vim.keymap.set("n", "<leader>ss", [[<cmd>lua require('vscode').action('workbench.action.gotoSymbol')<cr>]])
     vim.keymap.set("n", "]d", [[<cmd>lua require('vscode').call('editor.action.marker.next')<cr>]], { desc = "Next Diagnostic" })
-    vim.keymap.set("n", "[d", [[<cmd>lua require('vscode').call('editor.action.marker.previous')<cr>]], { desc = "Previous Diagnostic" })
+    vim.keymap.set("n", "[d", [[<cmd>lua require('vscode').call('editor.action.marker.previous')<cr>]], { desc = "Prev Diagnostic" })
   end,
 })
 

--- a/lua/lazyvim/plugins/extras/vscode.lua
+++ b/lua/lazyvim/plugins/extras/vscode.lua
@@ -35,8 +35,18 @@ vim.api.nvim_create_autocmd("User", {
     vim.keymap.set("n", "<leader><space>", "<cmd>Find<cr>")
     vim.keymap.set("n", "<leader>/", [[<cmd>lua require('vscode').action('workbench.action.findInFiles')<cr>]])
     vim.keymap.set("n", "<leader>ss", [[<cmd>lua require('vscode').action('workbench.action.gotoSymbol')<cr>]])
-    vim.keymap.set("n", "]d", [[<cmd>lua require('vscode').call('editor.action.marker.next')<cr>]], { desc = "Next Diagnostic" })
-    vim.keymap.set("n", "[d", [[<cmd>lua require('vscode').call('editor.action.marker.previous')<cr>]], { desc = "Prev Diagnostic" })
+    vim.keymap.set(
+      "n",
+      "]d",
+      [[<cmd>lua require('vscode').call('editor.action.marker.next')<cr>]],
+      { desc = "Next Diagnostic" }
+    )
+    vim.keymap.set(
+      "n",
+      "[d",
+      [[<cmd>lua require('vscode').call('editor.action.marker.previous')<cr>]],
+      { desc = "Prev Diagnostic" }
+    )
   end,
 })
 


### PR DESCRIPTION
## Description

`[d` and `]d` (next/previous diagnostic) doesn't behave as expected when using [vscode-neovim](https://github.com/vscode-neovim/vscode-neovim). This should fix it.


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
