### PR TITLE
docs(dap): document `continue` to be used also for `run`

### DIFF
--- a/lua/lazyvim/plugins/extras/dap/core.lua
+++ b/lua/lazyvim/plugins/extras/dap/core.lua
@@ -30,7 +30,7 @@ return {
       { "<leader>d", "", desc = "+debug", mode = {"n", "v"} },
       { "<leader>dB", function() require("dap").set_breakpoint(vim.fn.input('Breakpoint condition: ')) end, desc = "Breakpoint Condition" },
       { "<leader>db", function() require("dap").toggle_breakpoint() end, desc = "Toggle Breakpoint" },
-      { "<leader>dc", function() require("dap").continue() end, desc = "Continue" },
+      { "<leader>dc", function() require("dap").continue() end, desc = "Run/Continue" },
       { "<leader>da", function() require("dap").continue({ before = get_args }) end, desc = "Run with Args" },
       { "<leader>dC", function() require("dap").run_to_cursor() end, desc = "Run to Cursor" },
       { "<leader>dg", function() require("dap").goto_() end, desc = "Go to Line (No Execute)" },


### PR DESCRIPTION
The `dap.continue` is meant to be used also to start the program if no debugging session is active.

The documentation states:

> `continue()` is the main entry-point for users to start debugging an application.

With this change, it should be clearer to the user that `continue` is the way to start a program. Otherwise, one could think to use `Run with args` (which is misleading). At least for me, it was, until I read the dap documentation.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
