### PR TITLE
chore(extras/fzf-lua): specify mini.icons dependency

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/fzf.lua
+++ b/lua/lazyvim/plugins/extras/editor/fzf.lua
@@ -44,6 +44,7 @@ return {
   {
     "ibhagwan/fzf-lua",
     cmd = "FzfLua",
+    dependencies = { "echasnovski/mini.icons" },
     opts = function(_, opts)
       local config = require("fzf-lua.config")
       local actions = require("fzf-lua.actions")


### PR DESCRIPTION
Despite LazyVim using mini.icons by default, `fzf-lua` requires you to specify the icons dependency to use them.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
