### PR TITLE
fix(extras): use the correct naming when setting up eruby formatter

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/ruby.lua
+++ b/lua/lazyvim/plugins/extras/lang/ruby.lua
@@ -64,7 +64,7 @@ return {
     opts = {
       formatters_by_ft = {
         ruby = { formatter },
-        eruby = { "erb-format" },
+        eruby = { "erb_format" },
       },
     },
   },


### PR DESCRIPTION
## Description

Eruby files (.*.erb) are not formatted because the formatter name is incorrect. This PR fixes it.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.