### PR TITLE
fix(dap): remove explicit `load_launchjs` call

### DIFF
--- a/lua/lazyvim/plugins/extras/dap/core.lua
+++ b/lua/lazyvim/plugins/extras/dap/core.lua
@@ -69,11 +69,6 @@ return {
       vscode.json_decode = function(str)
         return vim.json.decode(json.json_strip_comments(str))
       end
-
-      -- Extends dap.configurations with entries read from .vscode/launch.json
-      if vim.fn.filereadable(".vscode/launch.json") then
-        vscode.load_launchjs()
-      end
     end,
   },
 


### PR DESCRIPTION
## Description

The explicit call to `load_launchjs` is unnecessary, since after https://github.com/mfussenegger/nvim-dap/pull/1237 `.vscode/launch.json` files are loaded automatically.

## Related Issue(s)
Fixes #4432


## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
