### PR TITLE
fix(autocmds): change mapping for `lazyvim_close_with_q`

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -72,11 +72,13 @@ vim.api.nvim_create_autocmd("FileType", {
   },
   callback = function(event)
     vim.bo[event.buf].buflisted = false
-    vim.keymap.set("n", "q", "<cmd>close<cr>", {
-      buffer = event.buf,
-      silent = true,
-      desc = "Quit buffer",
-    })
+    vim.schedule(function()
+      vim.keymap.set("n", "q", "<cmd>:bd<cr>", {
+        buffer = event.buf,
+        silent = true,
+        desc = "Quit buffer",
+      })
+    end)
   end,
 })
 


### PR DESCRIPTION
## Description
Currently `checkhealth` buffers stay visible on `bufferline` when you close them with `q`. Use `:bd` instead to delete the buffer from bufferlist. `vim.schedule` is needed because `LspInfo` adds its own mapping to close the window (see [here](https://github.com/neovim/nvim-lspconfig/blob/edd9591199d1c78c0cb20514231f7f936f9412a2/lua/lspconfig/health.lua#L328)), so we need to overwrite it.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
