### PR TITLE
fix(lazygit): only add lazygit keymaps when lazygit is in path

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -130,22 +130,24 @@ if vim.lsp.inlay_hint then
 end
 
 -- lazygit
-map("n", "<leader>gg", function() LazyVim.lazygit( { cwd = LazyVim.root.git() }) end, { desc = "Lazygit (Root Dir)" })
-map("n", "<leader>gG", function() LazyVim.lazygit() end, { desc = "Lazygit (cwd)" })
-map("n", "<leader>gb", LazyVim.lazygit.blame_line, { desc = "Git Blame Line" })
-map("n", "<leader>gB", LazyVim.lazygit.browse, { desc = "Git Browse" })
+if vim.fn.executable('lazygit') == 1 then
+  map("n", "<leader>gg", function() LazyVim.lazygit( { cwd = LazyVim.root.git() }) end, { desc = "Lazygit (Root Dir)" })
+  map("n", "<leader>gG", function() LazyVim.lazygit() end, { desc = "Lazygit (cwd)" })
+  map("n", "<leader>gb", LazyVim.lazygit.blame_line, { desc = "Git Blame Line" })
+  map("n", "<leader>gB", LazyVim.lazygit.browse, { desc = "Git Browse" })
 
-map("n", "<leader>gf", function()
-  local git_path = vim.api.nvim_buf_get_name(0)
-  LazyVim.lazygit({args = { "-f", vim.trim(git_path) }})
-end, { desc = "Lazygit Current File History" })
+  map("n", "<leader>gf", function()
+    local git_path = vim.api.nvim_buf_get_name(0)
+    LazyVim.lazygit({args = { "-f", vim.trim(git_path) }})
+  end, { desc = "Lazygit Current File History" })
 
-map("n", "<leader>gl", function()
-  LazyVim.lazygit({ args = { "log" }, cwd = LazyVim.root.git() })
-end, { desc = "Lazygit Log" })
-map("n", "<leader>gL", function()
-  LazyVim.lazygit({ args = { "log" } })
-end, { desc = "Lazygit Log (cwd)" })
+  map("n", "<leader>gl", function()
+    LazyVim.lazygit({ args = { "log" }, cwd = LazyVim.root.git() })
+  end, { desc = "Lazygit Log" })
+  map("n", "<leader>gL", function()
+    LazyVim.lazygit({ args = { "log" } })
+  end, { desc = "Lazygit Log (cwd)" })
+end
 
 -- quit
 map("n", "<leader>qq", "<cmd>qa<cr>", { desc = "Quit All" })


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Keymaps for LazyGit should only be added when lazygit is in path.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
