### PR TITLE
feat(toggle): add `silent` field to toggle to customize behavior of notifications

### DIFF
--- a/lua/lazyvim/util/toggle.lua
+++ b/lua/lazyvim/util/toggle.lua
@@ -8,6 +8,7 @@ local M = {}
 ---@field color_disabled? string
 ---@field get fun():boolean
 ---@field set fun(state:boolean)
+---@field silent? boolean
 
 ---@class lazyvim.Toggle.wrap: lazyvim.Toggle
 ---@operator call:boolean
@@ -18,9 +19,9 @@ function M.wrap(toggle)
     __call = function()
       toggle.set(not toggle.get())
       local state = toggle.get()
-      if state then
+      if state and not toggle.silent then
         LazyVim.info("Enabled " .. toggle.name, { title = toggle.name })
-      else
+      elseif not state and not toggle.silent then
         LazyVim.warn("Disabled " .. toggle.name, { title = toggle.name })
       end
       return state


### PR DESCRIPTION
## Description
Allow user to customize the behavior of notifications pop-ups to be able to hide them or not.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
A comment https://github.com/LazyVim/LazyVim/discussions/4232#discussioncomment-11061942
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
