### PR TITLE
fix(dial): follow comment explanation for integers

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/dial.lua
+++ b/lua/lazyvim/plugins/extras/editor/dial.lua
@@ -120,7 +120,7 @@ return {
           months,
         },
         typescript = {
-          augend.integer.alias.decimal, -- nonnegative and negative decimal number
+          augend.integer.alias.decimal_int, -- nonnegative and negative decimal number
           augend.constant.alias.bool, -- boolean value (true <-> false)
           logical_alias,
           augend.constant.new({ elements = { "let", "const" } }),

--- a/lua/lazyvim/plugins/extras/editor/dial.lua
+++ b/lua/lazyvim/plugins/extras/editor/dial.lua
@@ -126,11 +126,11 @@ return {
           augend.constant.new({ elements = { "let", "const" } }),
         },
         yaml = {
-          augend.integer.alias.decimal, -- nonnegative and negative decimal number
+          augend.integer.alias.decimal_int, -- nonnegative and negative decimal number
           augend.constant.alias.bool, -- boolean value (true <-> false)
         },
         css = {
-          augend.integer.alias.decimal, -- nonnegative and negative decimal number
+          augend.integer.alias.decimal_int, -- nonnegative and negative decimal number
           augend.hexcolor.new({
             case = "lower",
           }),
@@ -142,11 +142,11 @@ return {
           augend.misc.alias.markdown_header,
         },
         json = {
-          augend.integer.alias.decimal, -- nonnegative and negative decimal number
+          augend.integer.alias.decimal_int, -- nonnegative and negative decimal number
           augend.semver.alias.semver, -- versioning (v1.1.2)
         },
         lua = {
-          augend.integer.alias.decimal, -- nonnegative and negative decimal number
+          augend.integer.alias.decimal_int, -- nonnegative and negative decimal number
           augend.constant.alias.bool, -- boolean value (true <-> false)
           augend.constant.new({
             elements = { "and", "or" },
@@ -155,7 +155,7 @@ return {
           }),
         },
         python = {
-          augend.integer.alias.decimal, -- nonnegative and negative decimal number
+          augend.integer.alias.decimal_int, -- nonnegative and negative decimal number
           capitalized_boolean,
           logical_alias,
         },


### PR DESCRIPTION
relevant doc page: https://github.com/monaqa/dial.nvim?tab=readme-ov-file#augend-alias

## Description

The specific augend for integers in several languages is a different one than what the comment explaining it suggests.

Changed the augend to the one that includes negative integers like the comment suggests.


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
