### PR TITLE
fix(eslint): use correct option name to select workingDirectory

### DIFF
--- a/lua/lazyvim/plugins/extras/linting/eslint.lua
+++ b/lua/lazyvim/plugins/extras/linting/eslint.lua
@@ -8,7 +8,7 @@ return {
         eslint = {
           settings = {
             -- helps eslint find the eslintrc when it's placed in a subfolder instead of the cwd root
-            workingDirectories = { mode = "auto" },
+            workingDirectory = { mode = "auto" },
           },
         },
       },


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

The eslint default config used a wrong option name. It has to be `workingDirectory` instead of the plural that was currently used. Reference here: https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#eslint

There might be some implications of fixing this, as it changes the default option (which is `location` instead of `auto`), that has been implicitly used until now.

Documentation of that option here: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint#settings-options

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
fixes #4663

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
