### PR TITLE
fix(lazygit): file history when cwd is outside the repo

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -137,7 +137,7 @@ map("n", "<leader>gB", LazyVim.lazygit.browse, { desc = "Git Browse" })
 
 map("n", "<leader>gf", function()
   local git_path = vim.api.nvim_buf_get_name(0)
-  LazyVim.lazygit({args = { "-f", vim.trim(git_path) }})
+  LazyVim.lazygit({args = { "-f", vim.trim(git_path) }, cwd = LazyVim.root.git()})
 end, { desc = "Lazygit Current File History" })
 
 map("n", "<leader>gl", function()


### PR DESCRIPTION
## Description

When using `<leader>gf` Lazygit is launched in the current directory rather than the root directory.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
