### PR TITLE
fix(extras): lazy-load telescope-terraform plugins

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/terraform.lua
+++ b/lua/lazyvim/plugins/extras/lang/terraform.lua
@@ -58,9 +58,10 @@ return {
   {
     "nvim-telescope/telescope.nvim",
     optional = true,
-    dependencies = {
+    specs = {
       {
         "ANGkeith/telescope-terraform-doc.nvim",
+        ft = { "terraform", "hcl" },
         config = function()
           LazyVim.on_load("telescope.nvim", function()
             require("telescope").load_extension("terraform_doc")
@@ -69,6 +70,7 @@ return {
       },
       {
         "cappyzawa/telescope-terraform.nvim",
+        ft = { "terraform", "hcl" },
         config = function()
           LazyVim.on_load("telescope.nvim", function()
             require("telescope").load_extension("terraform")


### PR DESCRIPTION
## Description

In the current terraform extra, both `cappyzawa/telescope-terraform.nvim` and
`ANGkeith/telescope-terraform-doc.nvim` are dependencies of `telescope.nvim`.
This should be reversed so that the telescope extensions only load when needed
(I added a `ft` trigger which I think makes the most sense), and not as a
dependency of `telescope.nvim`.

## Related Issue(s)

No related issues, just fixed this when the loading time of
`telescope-terraform-doc.nvim` in-particular was annoying (+~30ms startup).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
