### PR TITLE
fix(java): make `Run with Args` work for Java in Dap

### DIFF
--- a/lua/lazyvim/plugins/extras/dap/core.lua
+++ b/lua/lazyvim/plugins/extras/dap/core.lua
@@ -1,5 +1,20 @@
+---@param config {args?:string|fun():string?}
+local function get_args_as_string(config)
+  local args = type(config.args) == "function" and (config.args() or "") or config.args or ""
+  ---@cast args string
+  if string.len(args) > 0 then
+    args = args .. " "
+  end
+  config = vim.deepcopy(config)
+  config.args = function()
+    local new_args = vim.fn.input("Run with args: ", args) --[[@as string]]
+    return new_args --[[@as string]]
+  end
+  return config
+end
+
 ---@param config {args?:string[]|fun():string[]?}
-local function get_args(config)
+local function get_args_as_table(config)
   local args = type(config.args) == "function" and (config.args() or {}) or config.args or {}
   config = vim.deepcopy(config)
   ---@cast args string[]
@@ -8,6 +23,18 @@ local function get_args(config)
     return vim.split(vim.fn.expand(new_args) --[[@as string]], " ")
   end
   return config
+end
+
+---@param config {type?:string}
+local function get_args(config)
+  --- Java Dap expects "args" to be a string, not a table
+  if config.type and config.type == "java" then
+    ---@cast config {type?:string, args?:string|fun():string?}
+    return get_args_as_string(config)
+  else
+    ---@cast config {type?:string, args?:string[]|fun():string[]?}
+    return get_args_as_table(config)
+  end
 end
 
 return {


### PR DESCRIPTION
## Description

When Java and Dap extras are installed, the command "Run with Args" does not work as expected: after inserting the arguments to pass to the Java program, you get

```
Debug adapter didn't respond. Either the adapter is slow (then wait and ignore this) or there is a problem with your adapter or `java` configuration. Check the logs for errors (:help dap.set_log_level)
```

As discussed here https://github.com/LazyVim/LazyVim/discussions/4604, this happens because the Java Dap adapter expects the `config.args' to be a string, while the default implementation in dap core, (see https://github.com/LazyVim/LazyVim/blob/v12.43.0/lua/lazyvim/plugins/extras/dap/core.lua#L34 and https://github.com/LazyVim/LazyVim/blob/v12.43.0/lua/lazyvim/plugins/extras/dap/core.lua#L2) passes the `config.args` as a table.

Alternative to https://github.com/LazyVim/LazyVim/pull/4673
as suggested in https://github.com/LazyVim/LazyVim/pull/4673#issuecomment-2452925460

## Related Issue(s)

Fixes #4672

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
