### PR TITLE
fix(lazyfile): account for treesitter disable highlights

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -9,6 +9,13 @@ return {
   -- Add BibTeX/LaTeX to treesitter
   {
     "nvim-treesitter/nvim-treesitter",
+    init = function()
+      if
+        vim.fn.argc() > 0 and vim.fn.isdirectory(vim.fn.argv(0) --[[@as string]]) ~= 1
+      then
+        vim.g.treesitter_disable_highlight = { "latex" }
+      end
+    end,
     opts = function(_, opts)
       opts.highlight = opts.highlight or {}
       if type(opts.ensure_installed) == "table" then

--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -13,7 +13,7 @@ return {
       if
         vim.fn.argc() > 0 and vim.fn.isdirectory(vim.fn.argv(0) --[[@as string]]) ~= 1
       then
-        vim.g.treesitter_disable_highlight = { "latex" }
+        vim.g.treesitter_syntax_legacy = { "latex" }
       end
     end,
     opts = function(_, opts)

--- a/lua/lazyvim/util/plugin.lua
+++ b/lua/lazyvim/util/plugin.lua
@@ -86,10 +86,10 @@ function M.lazy_file()
       if ft then
         -- Add treesitter highlights and fallback to syntax
         local lang = vim.treesitter.language.get_lang(ft)
-        if vim.tbl_contains(vim.g.treesitter_disable_highlight or {}, lang) then
-          lang = nil
-        end
         if not (lang and pcall(vim.treesitter.start, event.buf, lang)) then
+          vim.bo[event.buf].syntax = ft
+        end
+        if vim.tbl_contains(vim.g.treesitter_syntax_legacy or {}, lang) then
           vim.bo[event.buf].syntax = ft
         end
 

--- a/lua/lazyvim/util/plugin.lua
+++ b/lua/lazyvim/util/plugin.lua
@@ -86,6 +86,9 @@ function M.lazy_file()
       if ft then
         -- Add treesitter highlights and fallback to syntax
         local lang = vim.treesitter.language.get_lang(ft)
+        if vim.tbl_contains(vim.g.treesitter_disable_highlight or {}, lang) then
+          lang = nil
+        end
         if not (lang and pcall(vim.treesitter.start, event.buf, lang)) then
           vim.bo[event.buf].syntax = ft
         end


### PR DESCRIPTION
## Description
In `util.plugin.lazyfile` the function always starts `vim.treesitter.start()` for treesitter highlighting, but this causes problems with the `tex` Extra which expects the highlighting for `latex` to be disabled.

Solution: In `tex` Extra define a global `vim.g.treesitter_disable_highlight` table that will include `latex` and then in `lazyfile` check if `lang` exists in the aforementioned table, so that the protected call to `vim.treesitter.start` won't execute and instead we get legacy syntax.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #4687.
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
