### PR TITLE
fix(eslint): check if disabled before register

### DIFF
--- a/lua/lazyvim/plugins/extras/linting/eslint.lua
+++ b/lua/lazyvim/plugins/extras/linting/eslint.lua
@@ -14,6 +14,11 @@ return {
       },
       setup = {
         eslint = function()
+          -- verify if vim.g.root_lsp_ignore table contains `eslint`
+          if vim.tbl_contains(vim.g.root_lsp_ignore or {}, "eslint") then
+            return true
+          end
+
           local function get_client(buf)
             return LazyVim.lsp.get_clients({ name = "eslint", bufnr = buf })[1]
           end


### PR DESCRIPTION
## Description

This PR checks if eslint has been disabled by `vim.g.root_lsp_ignore`

## Related Issue(s)

<https://github.com/LazyVim/LazyVim/issues/4704>

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
