### PR TITLE
feat(extras.nushell): update to upstream treesitter

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/nushell.lua
+++ b/lua/lazyvim/plugins/extras/lang/nushell.lua
@@ -12,23 +12,6 @@ return {
   },
   {
     "nvim-treesitter/nvim-treesitter",
-    dependencies = {
-      { "nushell/tree-sitter-nu" },
-    },
-    opts = function(_, opts)
-      ---@diagnostic disable-next-line: inject-field
-      require("nvim-treesitter.parsers").get_parser_configs().nu = {
-        install_info = {
-          url = "https://github.com/nushell/tree-sitter-nu",
-          files = { "src/parser.c" },
-          branch = "main",
-        },
-        filetype = "nu",
-      }
-
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "nu" })
-      end
-    end,
+    opts = { ensure_installed = { "nu" } },
   },
 }


### PR DESCRIPTION
## Description

Since the nushell treesitter parser is now upstream, as seen in [this pr](https://github.com/nvim-treesitter/nvim-treesitter/pull/7267), it updates the treesitter config of this extra

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
