### PR TITLE
fix(copilot-chat): setup cmp conditionally

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/copilot-chat.lua
+++ b/lua/lazyvim/plugins/extras/coding/copilot-chat.lua
@@ -73,7 +73,10 @@ return {
     },
     config = function(_, opts)
       local chat = require("CopilotChat")
-      require("CopilotChat.integrations.cmp").setup()
+      local cmp_status_ok = pcall(require, "cmp")
+      if cmp_status_ok then
+        require("CopilotChat.integrations.cmp").setup()
+      end
 
       vim.api.nvim_create_autocmd("BufEnter", {
         pattern = "copilot-chat",

--- a/lua/lazyvim/plugins/extras/coding/copilot-chat.lua
+++ b/lua/lazyvim/plugins/extras/coding/copilot-chat.lua
@@ -73,8 +73,7 @@ return {
     },
     config = function(_, opts)
       local chat = require("CopilotChat")
-      local cmp_status_ok = pcall(require, "cmp")
-      if cmp_status_ok then
+      if pcall(require, "cmp") then
         require("CopilotChat.integrations.cmp").setup()
       end
 


### PR DESCRIPTION
## Description

Check for cmp before setting up copilot chat.

## Related Issue(s)

For https://github.com/LazyVim/LazyVim/issues/4702

I would like to set up the cmp compatability later if possible, but this is a quick patch to allow copilot chat to work without cmp (for now).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
