### PR TITLE
fix(prettier): keep existing formatters_by_ft

### DIFF
--- a/lua/lazyvim/plugins/extras/formatting/prettier.lua
+++ b/lua/lazyvim/plugins/extras/formatting/prettier.lua
@@ -70,7 +70,8 @@ return {
     opts = function(_, opts)
       opts.formatters_by_ft = opts.formatters_by_ft or {}
       for _, ft in ipairs(supported) do
-        opts.formatters_by_ft[ft] = { "prettier" }
+        opts.formatters_by_ft[ft] = opts.formatters_by_ft[ft] or {}
+        table.insert(opts.formatters_by_ft[ft], "prettier")
       end
 
       opts.formatters = opts.formatters or {}


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

This change makes it possible to configure other formatters for filetypes supported by the prettier extra, for instance

```js
return {
  {
    "stevearc/conform.nvim",
    opts = {
      formatters_by_ft = {
        css = { "stylelint" },
      },
    },
  },
}
```

Currently the prettier extra overwrites any existing `formatters_by_ft` for the filetypes it supports. I've changed it to use `table.insert` [like the sql extra does](https://github.com/LazyVim/LazyVim/blob/75750be1c0493659c9fbc60ff5e06dba053ef528/lua/lazyvim/plugins/extras/lang/sql.lua#L148-L149).

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

None that I know of

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
