### PR TITLE
chore(telescope): Use gmake instead of make on non-linux system

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/telescope.lua
+++ b/lua/lazyvim/plugins/extras/editor/telescope.lua
@@ -4,7 +4,7 @@ if lazyvim_docs then
   vim.g.lazyvim_picker = "telescope"
 end
 
-local make_cmd = vim.loop.os_uname().sysname == "Linux" and "make" or "gmake"
+local make_cmd = vim.uv.os_uname().sysname == "Linux" and "make" or "gmake"
 local have_make = vim.fn.executable("make") == 1
 local have_cmake = vim.fn.executable("cmake") == 1
 

--- a/lua/lazyvim/plugins/extras/editor/telescope.lua
+++ b/lua/lazyvim/plugins/extras/editor/telescope.lua
@@ -4,6 +4,7 @@ if lazyvim_docs then
   vim.g.lazyvim_picker = "telescope"
 end
 
+local make_cmd = vim.loop.os_uname().sysname == "Linux" and "make" or "gmake"
 local have_make = vim.fn.executable("make") == 1
 local have_cmake = vim.fn.executable("cmake") == 1
 
@@ -63,7 +64,7 @@ return {
     dependencies = {
       {
         "nvim-telescope/telescope-fzf-native.nvim",
-        build = have_make and "make"
+        build = have_make and make_cmd
           or "cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release && cmake --install build --prefix build",
         enabled = have_make or have_cmake,
         config = function(plugin)


### PR DESCRIPTION
## Description

On non-Linux systems(eg freebsd/netbsd), make is not gmake. Therefore, gmake must be used on non-Linux systems.

## Related Issue(s)

none

## Screenshots

N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
