### PR TITLE
fix(options): disable default ruler

### DIFF
--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -70,6 +70,7 @@ opt.number = true -- Print line number
 opt.pumblend = 10 -- Popup blend
 opt.pumheight = 10 -- Maximum number of entries in a popup
 opt.relativenumber = true -- Relative line numbers
+opt.ruler = false -- Disable the default ruler
 opt.scrolloff = 4 -- Lines of context
 opt.sessionoptions = { "buffers", "curdir", "tabpages", "winsize", "help", "globals", "skiprtp", "folds" }
 opt.shiftround = true -- Round indent


### PR DESCRIPTION
## Description

The ruler option causes numbers to be briefly shown on the dashboard while LazyVim is loading. This MR disables the ruler.


## Screenshots
<img width="1086" alt="image" src="https://github.com/user-attachments/assets/debd9e9b-bfd2-485e-be51-d1b7a59c3729">


<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
