### PR TITLE
fix(extras): fix git recommended ft

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/git.lua
+++ b/lua/lazyvim/plugins/extras/lang/git.lua
@@ -1,7 +1,9 @@
 return {
-  recommended = {
-    ft = { "gitcommit", "gitconfig", "gitrebase", "gitignore", "gitattributes" },
-  },
+  recommended = function()
+    return LazyVim.extras.wants({
+      ft = { "gitcommit", "gitconfig", "gitrebase", "gitignore", "gitattributes" },
+    })
+  end,
   -- Treesitter git support
   {
     "nvim-treesitter/nvim-treesitter",


### PR DESCRIPTION
Fix git extras recommended filetype to use `LazyVim.extras.wants`. This fixes an issue where the `ft` table does not get read correctly.