### PR TITLE
fix(extras): fix alpha-nvim non-string keycodes

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/alpha.lua
+++ b/lua/lazyvim/plugins/extras/ui/alpha.lua
@@ -23,11 +23,11 @@ return {
       dashboard.section.header.val = vim.split(logo, "\n")
       -- stylua: ignore
       dashboard.section.buttons.val = {
-        dashboard.button("f", " " .. " Find file",       LazyVim.pick()),
+        dashboard.button("f", " " .. " Find file",       "<cmd> lua LazyVim.pick()() <cr>"),
         dashboard.button("n", " " .. " New file",        [[<cmd> ene <BAR> startinsert <cr>]]),
-        dashboard.button("r", " " .. " Recent files",    LazyVim.pick("oldfiles")),
-        dashboard.button("g", " " .. " Find text",       LazyVim.pick("live_grep")),
-        dashboard.button("c", " " .. " Config",          LazyVim.pick.config_files()),
+        dashboard.button("r", " " .. " Recent files",    [[<cmd> lua LazyVim.pick("oldfiles")() <cr>]]),
+        dashboard.button("g", " " .. " Find text",       [[<cmd> lua LazyVim.pick("live_grep")() <cr>]]),
+        dashboard.button("c", " " .. " Config",          "<cmd> lua LazyVim.pick.config_files()() <cr>"),
         dashboard.button("s", " " .. " Restore Session", [[<cmd> lua require("persistence").load() <cr>]]),
         dashboard.button("x", " " .. " Lazy Extras",     "<cmd> LazyExtras <cr>"),
         dashboard.button("l", "󰒲 " .. " Lazy",            "<cmd> Lazy <cr>"),


### PR DESCRIPTION
## Description

The `dashboard.button` function provided by alpha-nvim expects a string keybind, not a function:

https://github.com/goolord/alpha-nvim/blob/main/lua/alpha/themes/dashboard.lua#L63

## Related Issue(s)

Fixes https://github.com/LazyVim/LazyVim/issues/3728.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
