### PR TITLE
feat(extras): add Dart language

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/dart.lua
+++ b/lua/lazyvim/plugins/extras/lang/dart.lua
@@ -1,0 +1,45 @@
+return {
+  recommended = function()
+    return LazyVim.extras.wants({
+      ft = "dart",
+      root = { "pubspec.yaml" },
+    })
+  end,
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        dartls = {},
+      },
+    },
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = { ensure_installed = { "dart" } },
+  },
+  {
+    "stevearc/conform.nvim",
+    opts = {
+      formatters = {
+        dart_format = {
+          args = { "format", "--line-length", "120" },
+        },
+      },
+      formatters_by_ft = {
+        dart = { "dart_format" },
+      },
+    },
+  },
+  {
+    "nvim-neotest/neotest",
+    optional = true,
+    dependencies = {
+      "sidlatau/neotest-dart",
+    },
+    opts = {
+      adapters = {
+        ["neotest-dart"] = {},
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Description

This PR add Dart language support to **extras** section.

## Testing

I checked that:
- the LSP correctly loads on Dart files and provides suggestions and highlights errors
- `treesitter` parses the Dart language tree and highlights the code
- `conform` correctly formats Dart files using the built-in formatter
- `neotest` is capable of running Dart tests

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
