### PR TITLE
feat(ai): better completion/suggestions of AI engines

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -181,7 +181,7 @@ map("n", "<leader><tab>]", "<cmd>tabnext<cr>", { desc = "Next Tab" })
 map("n", "<leader><tab>d", "<cmd>tabclose<cr>", { desc = "Close Tab" })
 map("n", "<leader><tab>[", "<cmd>tabprevious<cr>", { desc = "Previous Tab" })
 
--- native snippets
+-- native snippets. only needed on < 0.11, as 0.11 creates these by default
 if vim.fn.has("nvim-0.11") == 0 then
   map("s", "<Tab>", function()
     return vim.snippet.active({ direction = 1 }) and "<cmd>lua vim.snippet.jump(1)<cr>" or "<Tab>"

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -180,3 +180,13 @@ map("n", "<leader><tab><tab>", "<cmd>tabnew<cr>", { desc = "New Tab" })
 map("n", "<leader><tab>]", "<cmd>tabnext<cr>", { desc = "Next Tab" })
 map("n", "<leader><tab>d", "<cmd>tabclose<cr>", { desc = "Close Tab" })
 map("n", "<leader><tab>[", "<cmd>tabprevious<cr>", { desc = "Previous Tab" })
+
+-- native snippets
+if vim.fn.has("nvim-0.11") == 0 then
+  map("s", "<Tab>", function()
+    return vim.snippet.active({ direction = 1 }) and "<cmd>lua vim.snippet.jump(1)<cr>" or "<Tab>"
+  end, { expr = true, desc = "Jump Next" })
+  map({ "i", "s" }, "<S-Tab>", function()
+    return vim.snippet.active({ direction = -1 }) and "<cmd>lua vim.snippet.jump(-1)<cr>" or "<S-Tab>"
+  end, { expr = true, desc = "Jump Previous" })
+end

--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -15,16 +15,6 @@ vim.g.lazyvim_picker = "auto"
 -- use that instead of inline suggestions
 vim.g.ai_cmp = true
 
--- if `vim.g.ai_cmp` is false, or the completion engine does
--- not support the AI source, use inline suggestions
--- with the keymaps below
-vim.g.ai_suggest_accept = "<tab>"
-vim.g.ai_suggest_accept_word = false
-vim.g.ai_suggest_accept_line = false
-vim.g.ai_suggest_next = "<M-]>"
-vim.g.ai_suggest_prev = "<M-[>"
-vim.g.ai_suggest_clear = "<C-]>"
-
 -- LazyVim root dir detection
 -- Each entry can be:
 -- * the name of a detector function like `lsp` or `cwd`

--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -11,6 +11,20 @@ vim.g.autoformat = true
 -- enabled with `:LazyExtras`
 vim.g.lazyvim_picker = "auto"
 
+-- if the completion engine supports the AI source,
+-- use that instead of inline suggestions
+vim.g.ai_cmp = true
+
+-- if `vim.g.ai_cmp` is false, or the completion engine does
+-- not support the AI source, use inline suggestions
+-- with the keymaps below
+vim.g.ai_suggest_accept = "<tab>"
+vim.g.ai_suggest_accept_word = false
+vim.g.ai_suggest_accept_line = false
+vim.g.ai_suggest_next = "<M-]>"
+vim.g.ai_suggest_prev = "<M-[>"
+vim.g.ai_suggest_clear = "<C-]>"
+
 -- LazyVim root dir detection
 -- Each entry can be:
 -- * the name of a detector function like `lsp` or `cwd`

--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -72,9 +72,10 @@ return {
           end,
         },
         experimental = {
-          ghost_text = {
+          -- only show ghost text when we show ai completions
+          ghost_text = vim.g.ai_cmp and {
             hl_group = "CmpGhostText",
-          },
+          } or false,
         },
         sorting = defaults.sorting,
       }

--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -106,10 +106,22 @@ return {
         table.insert(opts.sources, { name = "snippets" })
       end
     end,
+    -- stylua: ignore
+    keys = {
+      {
+        "<tab>",
+        function()
+          return vim.snippet.active({ direction = 1 }) and "<cmd>lua vim.snippet.jump(1)<cr>"
+            or LazyVim.cmp.ai_accept()
+            or "<Tab>"
+        end,
+        expr = true, silent = true, mode = "i",
+      },
+    },
     init = function()
       -- Neovim enabled snippet navigation mappings by default in v0.11
       if vim.fn.has("nvim-0.11") == 0 then
-        vim.keymap.set({ "i", "s" }, "<Tab>", function()
+        vim.keymap.set({ "s" }, "<Tab>", function()
           return vim.snippet.active({ direction = 1 }) and "<cmd>lua vim.snippet.jump(1)<cr>" or "<Tab>"
         end, { expr = true, silent = true })
         vim.keymap.set({ "i", "s" }, "<S-Tab>", function()

--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -43,6 +43,9 @@ return {
             cmp.abort()
             fallback()
           end,
+          ["<tab>"] = function(fallback)
+            return LazyVim.cmp.map({ "snippet_forward", "ai_accept" }, fallback)()
+          end,
         }),
         sources = cmp.config.sources({
           { name = "nvim_lsp" },
@@ -104,29 +107,6 @@ return {
       }
       if LazyVim.has("nvim-snippets") then
         table.insert(opts.sources, { name = "snippets" })
-      end
-    end,
-    -- stylua: ignore
-    keys = {
-      {
-        "<tab>",
-        function()
-          return vim.snippet.active({ direction = 1 }) and "<cmd>lua vim.snippet.jump(1)<cr>"
-            or LazyVim.cmp.ai_accept()
-            or "<Tab>"
-        end,
-        expr = true, silent = true, mode = "i",
-      },
-    },
-    init = function()
-      -- Neovim enabled snippet navigation mappings by default in v0.11
-      if vim.fn.has("nvim-0.11") == 0 then
-        vim.keymap.set({ "s" }, "<Tab>", function()
-          return vim.snippet.active({ direction = 1 }) and "<cmd>lua vim.snippet.jump(1)<cr>" or "<Tab>"
-        end, { expr = true, silent = true })
-        vim.keymap.set({ "i", "s" }, "<S-Tab>", function()
-          return vim.snippet.active({ direction = -1 }) and "<cmd>lua vim.snippet.jump(-1)<cr>" or "<S-Tab>"
-        end, { expr = true, silent = true })
       end
     end,
   },

--- a/lua/lazyvim/plugins/extras/ai/codeium.lua
+++ b/lua/lazyvim/plugins/extras/ai/codeium.lua
@@ -1,17 +1,31 @@
 return {
 
+  -- codeium
+  {
+    "Exafunction/codeium.nvim",
+    cmd = "Codeium",
+    build = ":Codeium Auth",
+    opts = {
+      enable_cmp_source = vim.g.ai_cmp,
+      virtual_text = {
+        enabled = not vim.g.ai_cmp,
+        accept_fallback = vim.g.ai_suggest_accept,
+        key_bindings = {
+          accept = vim.g.ai_suggest_accept,
+          accept_word = vim.g.ai_suggest_accept_word,
+          accept_line = vim.g.ai_suggest_accept_line,
+          next = vim.g.ai_suggest_next,
+          prev = vim.g.ai_suggest_prev,
+          clear = vim.g.ai_suggest_clear,
+        },
+      },
+    },
+  },
   -- codeium cmp source
   {
     "nvim-cmp",
-    dependencies = {
-      -- codeium
-      {
-        "Exafunction/codeium.nvim",
-        cmd = "Codeium",
-        build = ":Codeium Auth",
-        opts = {},
-      },
-    },
+    optional = true,
+    dependencies = { "codeium.nvim" },
     ---@param opts cmp.ConfigSchema
     opts = function(_, opts)
       table.insert(opts.sources, 1, {
@@ -29,5 +43,19 @@ return {
     opts = function(_, opts)
       table.insert(opts.sections.lualine_x, 2, LazyVim.lualine.cmp_source("codeium"))
     end,
+  },
+
+  {
+    "saghen/blink.cmp",
+    optional = true,
+    opts = {
+      sources = {
+        compat = vim.g.ai_cmp and { "codeium" } or nil,
+      },
+    },
+    dependencies = {
+      "codeium.nvim",
+      vim.g.ai_cmp and { "saghen/blink.compat" } or {},
+    },
   },
 }

--- a/lua/lazyvim/plugins/extras/ai/codeium.lua
+++ b/lua/lazyvim/plugins/extras/ai/codeium.lua
@@ -9,24 +9,34 @@ return {
       enable_cmp_source = vim.g.ai_cmp,
       virtual_text = {
         enabled = not vim.g.ai_cmp,
-        accept_fallback = vim.g.ai_suggest_accept,
+        accept_fallback = "<tab>",
         key_bindings = {
-          accept = vim.g.ai_suggest_accept,
-          accept_word = vim.g.ai_suggest_accept_word,
-          accept_line = vim.g.ai_suggest_accept_line,
-          next = vim.g.ai_suggest_next,
-          prev = vim.g.ai_suggest_prev,
-          clear = vim.g.ai_suggest_clear,
+          accept = "<tab>",
+          next = "<M-]>",
+          prev = "<M-[>",
         },
       },
     },
+    config = function(_, opts)
+      LazyVim.cmp.ai_accept = function()
+        if require("codeium.virtual_text").get_current_completion_item() then
+          LazyVim.create_undo()
+          vim.api.nvim_input(require("codeium.virtual_text").accept())
+          return true
+        end
+      end
+      if opts.virtual_text.key_bindings.accept == "<tab>" then
+        opts.virtual_text.key_bindings.accept = false
+      end
+      require("codeium").setup(opts)
+    end,
   },
+
   -- codeium cmp source
   {
     "nvim-cmp",
     optional = true,
     dependencies = { "codeium.nvim" },
-    ---@param opts cmp.ConfigSchema
     opts = function(_, opts)
       table.insert(opts.sources, 1, {
         name = "codeium",

--- a/lua/lazyvim/plugins/extras/ai/codeium.lua
+++ b/lua/lazyvim/plugins/extras/ai/codeium.lua
@@ -9,26 +9,26 @@ return {
       enable_cmp_source = vim.g.ai_cmp,
       virtual_text = {
         enabled = not vim.g.ai_cmp,
-        accept_fallback = "<tab>",
         key_bindings = {
-          accept = "<tab>",
+          accept = false, -- handled by nvim-cmp / blink.cmp
           next = "<M-]>",
           prev = "<M-[>",
         },
       },
     },
-    config = function(_, opts)
-      LazyVim.cmp.ai_accept = function()
+  },
+
+  -- add ai_accept action
+  {
+    "Exafunction/codeium.nvim",
+    opts = function()
+      LazyVim.cmp.actions.ai_accept = function()
         if require("codeium.virtual_text").get_current_completion_item() then
           LazyVim.create_undo()
           vim.api.nvim_input(require("codeium.virtual_text").accept())
           return true
         end
       end
-      if opts.virtual_text.key_bindings.accept == "<tab>" then
-        opts.virtual_text.key_bindings.accept = false
-      end
-      require("codeium").setup(opts)
     end,
   },
 
@@ -65,7 +65,7 @@ return {
     },
     dependencies = {
       "codeium.nvim",
-      vim.g.ai_cmp and { "saghen/blink.compat" } or {},
+      vim.g.ai_cmp and "saghen/blink.compat" or nil,
     },
   },
 }

--- a/lua/lazyvim/plugins/extras/ai/copilot.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot.lua
@@ -5,8 +5,20 @@ return {
     "zbirenbaum/copilot.lua",
     cmd = "Copilot",
     build = ":Copilot auth",
+    event = "InsertEnter",
     opts = {
-      suggestion = { enabled = false },
+      suggestion = {
+        enabled = true,
+        auto_trigger = true,
+        keymap = {
+          accept = vim.g.ai_suggest_accept,
+          accept_word = vim.g.ai_suggest_accept_word,
+          accept_line = vim.g.ai_suggest_accept_line,
+          next = vim.g.ai_suggest_next,
+          prev = vim.g.ai_suggest_prev,
+          dismiss = vim.g.ai_suggest_clear,
+        },
+      },
       panel = { enabled = false },
       filetypes = {
         markdown = true,
@@ -55,9 +67,11 @@ return {
   -- copilot cmp source
   {
     "nvim-cmp",
-    dependencies = {
+    optional = true,
+    dependencies = { -- this will only be evaluated if nvim-cmp is enabled
       {
         "zbirenbaum/copilot-cmp",
+        enabled = vim.g.ai_cmp, -- only enable if wanted
         dependencies = "copilot.lua",
         opts = {},
         config = function(_, opts)
@@ -69,34 +83,30 @@ return {
             copilot_cmp._on_insert_enter({})
           end, "copilot")
         end,
+        specs = {
+          {
+            "zbirenbaum/copilot.lua",
+            opts = { suggestion = { enabled = false } },
+          },
+          {
+            "nvim-cmp",
+            ---@param opts cmp.ConfigSchema
+            opts = function(_, opts)
+              table.insert(opts.sources, 1, {
+                name = "copilot",
+                group_index = 1,
+                priority = 100,
+              })
+            end,
+          },
+        },
       },
     },
-    ---@param opts cmp.ConfigSchema
-    opts = function(_, opts)
-      table.insert(opts.sources, 1, {
-        name = "copilot",
-        group_index = 1,
-        priority = 100,
-      })
-    end,
   },
 
   {
     "saghen/blink.cmp",
     optional = true,
-    specs = {
-      {
-        "zbirenbaum/copilot.lua",
-        event = "InsertEnter",
-        opts = {
-          suggestion = {
-            enabled = true,
-            auto_trigger = true,
-            keymap = { accept = false },
-          },
-        },
-      },
-    },
     opts = {
       windows = {
         ghost_text = {
@@ -104,7 +114,7 @@ return {
         },
       },
       keymap = {
-        ["<Tab>"] = {
+        [vim.g.ai_suggest_accept] = {
           function(cmp)
             if cmp.is_in_snippet() then
               return cmp.accept()

--- a/lua/lazyvim/plugins/extras/ai/copilot.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot.lua
@@ -11,7 +11,7 @@ return {
         enabled = not vim.g.ai_cmp,
         auto_trigger = true,
         keymap = {
-          accept = "<tab>",
+          accept = false, -- handled by nvim-cmp / blink.cmp
           next = "<M-]>",
           prev = "<M-[>",
         },
@@ -22,20 +22,19 @@ return {
         help = true,
       },
     },
-    config = function(_, opts)
-      LazyVim.cmp.ai_accept = function()
+  },
+
+  -- add ai_accept action
+  {
+    "zbirenbaum/copilot.lua",
+    opts = function()
+      LazyVim.cmp.actions.ai_accept = function()
         if require("copilot.suggestion").is_visible() then
           LazyVim.create_undo()
           require("copilot.suggestion").accept()
-          return ""
+          return true
         end
       end
-      -- tab is handled by nvim-cmp / blink.cmp
-      local key = opts.suggestion.keymap.accept
-      if key == "<tab>" then
-        opts.suggestion.keymap.accept = false
-      end
-      require("copilot").setup(opts)
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -38,7 +38,7 @@ return {
           auto_show = true,
         },
         ghost_text = {
-          enabled = true,
+          enabled = vim.g.ai_cmp,
         },
       },
 
@@ -59,6 +59,13 @@ return {
 
       keymap = {
         preset = "enter",
+        ["<tab>"] = {
+          "snippet_forward",
+          function()
+            return LazyVim.cmp.ai_accept()
+          end,
+          "fallback",
+        },
       },
     },
     ---@param opts blink.cmp.Config

--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -73,16 +73,18 @@ return {
         },
       },
     },
-    ---@param opts blink.cmp.Config
+    ---@param opts blink.cmp.Config | { sources: { compat: string[] } }
     config = function(_, opts)
+      -- setup compat sources
+      local enabled = opts.sources.completion.enabled_providers
       for _, source in ipairs(opts.sources.compat or {}) do
-        opts.sources.providers[source] = opts.sources.providers[source]
-          or {
-            name = source,
-            module = "blink.compat.source",
-          }
-        if not vim.tbl_contains(opts.sources.completion.enabled_providers, source) then
-          table.insert(opts.sources.completion.enabled_providers, source)
+        opts.sources.providers[source] = vim.tbl_deep_extend(
+          "force",
+          { name = source, module = "blink.compat.source" },
+          opts.sources.providers[source] or {}
+        )
+        if type(enabled) == "table" and not vim.tbl_contains(enabled, source) then
+          table.insert(enabled, source)
         end
       end
       require("blink.cmp").setup(opts)

--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -6,7 +6,10 @@ return {
   {
     "saghen/blink.cmp",
     version = "*",
-    opts_extend = { "sources.completion.enabled_providers" },
+    opts_extend = {
+      "sources.completion.enabled_providers",
+      "sources.compat",
+    },
     dependencies = {
       "rafamadriz/friendly-snippets",
       -- add blink.compat to dependencies
@@ -45,6 +48,9 @@ return {
       -- experimental signature help support
       -- trigger = { signature_help = { enabled = true } }
       sources = {
+        -- adding any nvim-cmp sources here will enable them
+        -- with blink.compat
+        compat = {},
         completion = {
           -- remember to enable your providers here
           enabled_providers = { "lsp", "path", "snippets", "buffer" },
@@ -55,6 +61,20 @@ return {
         preset = "enter",
       },
     },
+    ---@param opts blink.cmp.Config
+    config = function(_, opts)
+      for _, source in ipairs(opts.sources.compat or {}) do
+        opts.sources.providers[source] = opts.sources.providers[source]
+          or {
+            name = source,
+            module = "blink.compat.source",
+          }
+        if not vim.tbl_contains(opts.sources.completion.enabled_providers, source) then
+          table.insert(opts.sources.completion.enabled_providers, source)
+        end
+      end
+      require("blink.cmp").setup(opts)
+    end,
   },
 
   -- add icons

--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -1,3 +1,10 @@
+if lazyvim_docs then
+  -- set to `true` to follow the main branch
+  -- you need to have a working rust toolchain to build the plugin
+  -- in this case.
+  vim.g.lazyvim_blink_main = false
+end
+
 return {
   {
     "hrsh7th/nvim-cmp",
@@ -5,7 +12,8 @@ return {
   },
   {
     "saghen/blink.cmp",
-    version = "*",
+    version = not vim.g.lazyvim_blink_main and "*",
+    build = vim.g.lazyvim_blink_main and "cargo build --release",
     opts_extend = {
       "sources.completion.enabled_providers",
       "sources.compat",
@@ -59,11 +67,8 @@ return {
 
       keymap = {
         preset = "enter",
-        ["<tab>"] = {
-          "snippet_forward",
-          function()
-            return LazyVim.cmp.ai_accept()
-          end,
+        ["<Tab>"] = {
+          LazyVim.cmp.map({ "snippet_forward", "ai_accept" }),
           "fallback",
         },
       },

--- a/lua/lazyvim/plugins/extras/coding/luasnip.lua
+++ b/lua/lazyvim/plugins/extras/coding/luasnip.lua
@@ -1,4 +1,8 @@
 return {
+  -- disable builtin snippet support
+  { "garymjr/nvim-snippets", enabled = false },
+
+  -- add luasnip
   {
     "L3MON4D3/LuaSnip",
     lazy = true,
@@ -19,6 +23,19 @@ return {
     },
   },
 
+  -- add snippet_forward action
+  {
+    "L3MON4D3/LuaSnip",
+    opts = function()
+      LazyVim.cmp.actions.snippet_forward = function()
+        if require("luasnip").jumpable(1) then
+          require("luasnip").jump(1)
+          return true
+        end
+      end
+    end,
+  },
+
   -- nvim-cmp integration
   {
     "nvim-cmp",
@@ -34,23 +51,21 @@ return {
     end,
     -- stylua: ignore
     keys = {
-      {
-        "<tab>",
-        function()
-          return require("luasnip").jumpable(1) and "<Plug>luasnip-jump-next"
-            or LazyVim.cmp.ai_accept()
-            or "<tab>"
-        end,
-        expr = true, silent = true, mode = "i",
-      },
       { "<tab>", function() require("luasnip").jump(1) end, mode = "s" },
       { "<s-tab>", function() require("luasnip").jump(-1) end, mode = { "i", "s" } },
     },
   },
-  {
-    "garymjr/nvim-snippets",
-    enabled = false,
-  },
 
-  -- TODO: blink.cmp integration
+  -- blink.cmp integration
+  {
+    "saghen/blink.cmp",
+    optional = true,
+    opts = {
+      accept = {
+        expand_snippet = function(...)
+          return require("luasnip").lsp_expand(...)
+        end,
+      },
+    },
+  },
 }

--- a/lua/lazyvim/plugins/extras/coding/luasnip.lua
+++ b/lua/lazyvim/plugins/extras/coding/luasnip.lua
@@ -12,34 +12,34 @@ return {
           require("luasnip.loaders.from_vscode").lazy_load()
         end,
       },
-      {
-        "nvim-cmp",
-        dependencies = {
-          "saadparwaiz1/cmp_luasnip",
-        },
-        opts = function(_, opts)
-          opts.snippet = {
-            expand = function(args)
-              require("luasnip").lsp_expand(args.body)
-            end,
-          }
-          table.insert(opts.sources, { name = "luasnip" })
-        end,
-      },
     },
     opts = {
       history = true,
       delete_check_events = "TextChanged",
     },
   },
+
+  -- nvim-cmp integration
   {
     "nvim-cmp",
+    optional = true,
+    dependencies = { "saadparwaiz1/cmp_luasnip" },
+    opts = function(_, opts)
+      opts.snippet = {
+        expand = function(args)
+          require("luasnip").lsp_expand(args.body)
+        end,
+      }
+      table.insert(opts.sources, { name = "luasnip" })
+    end,
     -- stylua: ignore
     keys = {
       {
         "<tab>",
         function()
-          return require("luasnip").jumpable(1) and "<Plug>luasnip-jump-next" or "<tab>"
+          return require("luasnip").jumpable(1) and "<Plug>luasnip-jump-next"
+            or LazyVim.cmp.ai_accept()
+            or "<tab>"
         end,
         expr = true, silent = true, mode = "i",
       },
@@ -51,4 +51,6 @@ return {
     "garymjr/nvim-snippets",
     enabled = false,
   },
+
+  -- TODO: blink.cmp integration
 }

--- a/lua/lazyvim/util/cmp.lua
+++ b/lua/lazyvim/util/cmp.lua
@@ -1,8 +1,35 @@
 ---@class lazyvim.util.cmp
 local M = {}
 
----@return string?
-function M.ai_accept() end
+---@alias lazyvim.util.cmp.Action fun():boolean?
+---@type table<string, lazyvim.util.cmp.Action>
+M.actions = {
+  -- Native Snippets
+  snippet_forward = function()
+    if vim.snippet.active({ direction = 1 }) then
+      vim.schedule(function()
+        vim.snippet.jump(1)
+      end)
+      return true
+    end
+  end,
+}
+
+---@param actions string[]
+---@param fallback? string|fun()
+function M.map(actions, fallback)
+  return function()
+    for _, name in ipairs(actions) do
+      if M.actions[name] then
+        local ret = M.actions[name]()
+        if ret then
+          return true
+        end
+      end
+    end
+    return type(fallback) == "function" and fallback() or fallback
+  end
+end
 
 ---@alias Placeholder {n:number, text:string}
 

--- a/lua/lazyvim/util/cmp.lua
+++ b/lua/lazyvim/util/cmp.lua
@@ -1,6 +1,9 @@
 ---@class lazyvim.util.cmp
 local M = {}
 
+---@return string?
+function M.ai_accept() end
+
 ---@alias Placeholder {n:number, text:string}
 
 ---@param snippet string

--- a/lua/lazyvim/util/lualine.lua
+++ b/lua/lazyvim/util/lualine.lua
@@ -7,7 +7,7 @@ function M.cmp_source(name, icon)
     if not package.loaded["cmp"] then
       return
     end
-    for _, s in ipairs(require("cmp").core.sources) do
+    for _, s in ipairs(require("cmp").core.sources or {}) do
       if s.name == name then
         if s.source:is_available() then
           started = true


### PR DESCRIPTION
## Description

The whole completion / snippets / AI is very tricky:
- multiple snippet engines
- native snippets on > 0.11 set their own keymaps, but not on 0.10
- multiple completion engines, like `nvim-cmp` and `blink.cmp`
- multiple ai completion engines that have a different API
- user's preference of showing ai suggestions as completion or not
- none of the ai completion engines currently set undo points, which is bad

Solution:
- [x] added `LazyVim.cmp.actions`, where snippet engines and ai engines can register their action.
- [x] an action returns `true` if it succeeded, or `false|nil` otherwise
- [x] in a completion engine, we then try running multiple actions and use the fallback if needed
- [x] so `<tab>` runs `{"snippet_forward", "ai_accept", "fallback"}`
- [x] added `vim.g.ai_cmp`. When `true` we try to integrate the AI source in the completion engine.
- [x] when `false`, `<tab>` should be used to insert the AI suggestion
- [x] when `false`, the completion engine's ghost text is disabled
- [x] luasnip support for blink (only works with blink `main`)
- [x] create undo points when accepting AI suggestions 

## Test Matrix

| completion   | snippets     | ai          | ai_cmp | tested? |
|--------------|--------------|-------------|--------|---------|
| nvim-cmp     | native       | copilot     | true   | ✅      |
| nvim-cmp     | native       | copilot     | false  | ✅      |
| nvim-cmp     | native       | codeium     | true   | ✅      |
| nvim-cmp     | native       | codeium     | false  | ✅      |
| nvim-cmp     | luasnip      | copilot     | true   | ✅      |
| nvim-cmp     | luasnip      | copilot     | false  | ✅      |
| nvim-cmp     | luasnip      | codeium     | true   | ✅      |
| nvim-cmp     | luasnip      | codeium     | false  | ✅      |
| blink.cmp    | native       | copilot     | true   | ✅      |
| blink.cmp    | native       | copilot     | false  | ✅      |
| blink.cmp    | native       | codeium     | true   | ✅      |
| blink.cmp    | native       | codeium     | false  | ✅      |
| blink.cmp    | luasnip      | copilot     | true   | ✅      |
| blink.cmp    | luasnip      | copilot     | false  | ✅      |
| blink.cmp    | luasnip      | codeium     | true   | ✅      |
| blink.cmp    | luasnip      | codeium     | false  | ✅      |


## Related Issue(s)

- [ ] Closes #4702

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
