### PR TITLE
fix(lualine): dynamically fetch the color used in lualine

### DIFF
--- a/lua/lazyvim/util/lualine.lua
+++ b/lua/lazyvim/util/lualine.lua
@@ -5,9 +5,9 @@ local M = {}
 ---@param status fun(): nil|"ok"|"error"|"pending"
 function M.status(icon, status)
   local colors = {
-    ok = LazyVim.ui.fg("Special"),
-    error = LazyVim.ui.fg("DiagnosticError"),
-    pending = LazyVim.ui.fg("DiagnosticWarn"),
+    ok = "Special",
+    error = "DiagnosticError",
+    pending = "DiagnosticWarn",
   }
   return {
     function()
@@ -17,7 +17,7 @@ function M.status(icon, status)
       return status() ~= nil
     end,
     color = function()
-      return colors[status()] or colors.ok
+      return LazyVim.ui.fg(colors[status()] or colors.ok)
     end,
   }
 end
@@ -145,7 +145,9 @@ function M.root_dir(opts)
     parent = true,
     other = true,
     icon = "󱉭 ",
-    color = LazyVim.ui.fg("Special"),
+    color = function()
+      return LazyVim.ui.fg("Special")
+    end,
   }, opts or {})
 
   local function get()


### PR DESCRIPTION
## Description

The color used in lualine was previously static and did not update dynamically when a new colorscheme was applied. This resulted in inconsistencies between the theme and the lualine colors, as the 'local' color table returned the highlight color defined during initialization.

This pull request resolves the issue by ensuring that the lualine colors are always in sync with the current colorscheme. It achieves this by using `LazyVim.ui.fg(HIGHLIGHT)` to dynamically fetch the appropriate highlight colors, making the lualine colors responsive to colorscheme changes.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

**Before**

![image](https://github.com/user-attachments/assets/6b78483b-4a64-4ec3-a902-a0d1ed10a992)

**After**

![image](https://github.com/user-attachments/assets/3f73ec26-cbf1-4ff7-873f-6c7b2c13c481)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
