### PR TITLE
feat(blink): auto-enable catppuccin integration

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -121,4 +121,12 @@ return {
       },
     },
   },
+  -- catppuccin support
+  {
+    "catppuccin",
+    optional = true,
+    opts = {
+      integrations = { blink_cmp = true },
+    },
+  },
 }


### PR DESCRIPTION
## Description

Auto enable `blink_cmp` integration in catppuccin if the theme plugin is loaded.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

**Before**
![before](https://github.com/user-attachments/assets/918d5110-fd05-4468-9259-bf7164569521)

**After**
![after](https://github.com/user-attachments/assets/0d02d0c6-2b31-41cd-8b26-fbf74a86e498)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.