### PR TITLE
feat(copilot-chat): remove deprecated options

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/copilot-chat.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot-chat.lua
@@ -24,16 +24,11 @@ return {
       user = user:sub(1, 1):upper() .. user:sub(2)
       return {
         auto_insert_mode = true,
-        show_help = true,
         question_header = "  " .. user .. " ",
         answer_header = "  Copilot ",
         window = {
           width = 0.4,
         },
-        selection = function(source)
-          local select = require("CopilotChat.select")
-          return select.visual(source) or select.buffer(source)
-        end,
       }
     end,
     keys = {
@@ -66,8 +61,6 @@ return {
         desc = "Quick Chat (CopilotChat)",
         mode = { "n", "v" },
       },
-      -- Show help actions with telescope
-      { "<leader>ad", M.pick("help"), desc = "Diagnostic Help (CopilotChat)", mode = { "n", "v" } },
       -- Show prompts actions with telescope
       { "<leader>ap", M.pick("prompt"), desc = "Prompt Actions (CopilotChat)", mode = { "n", "v" } },
     },


### PR DESCRIPTION
- Diagnostic help was deprecated and now just proxies to prompt actions (by default diagnostics are auto included in all selections so this feature was no longer necessary)
- Selecton is now visual || buffer by default so the custom selection config is no longer needed too
