### PR TITLE
fix(keymaps): fix which-key description of `<c-_>`

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -159,11 +159,11 @@ map("n", "<leader>L", function() LazyVim.news.changelog() end, { desc = "LazyVim
 map("n", "<leader>fT", function() Snacks.terminal() end, { desc = "Terminal (cwd)" })
 map("n", "<leader>ft", function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "Terminal (Root Dir)" })
 map("n", "<c-/>",      function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "Terminal (Root Dir)" })
-map("n", "<c-_>",      function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "which_key_ignore" })
+map("n", "<c-_>",      function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "Terminal (Root Dir)" })
 
 -- Terminal Mappings
 map("t", "<C-/>", "<cmd>close<cr>", { desc = "Hide Terminal" })
-map("t", "<c-_>", "<cmd>close<cr>", { desc = "which_key_ignore" })
+map("t", "<c-_>", "<cmd>close<cr>", { desc = "Hide Terminal" })
 
 -- windows
 map("n", "<leader>w", "<c-w>", { desc = "Windows", remap = true })


### PR DESCRIPTION
## Description

Since `<C-/>` and `<C-_>` are mapped to the same command, I think it's better to use the same description.
Moreover, I don't see how `ignore_which_key` is appropriate here, since the description never shows up automatically (because it's a single character).
Putting the new description however improves the result shown in the keymaps with `<space>sk` and allows to discover it by searching for "terminal".

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
