### PR TITLE
feat(copilot-chat): remove call to nvim-cmp integration

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/copilot-chat.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot-chat.lua
@@ -66,9 +66,6 @@ return {
     },
     config = function(_, opts)
       local chat = require("CopilotChat")
-      if pcall(require, "cmp") then
-        require("CopilotChat.integrations.cmp").setup()
-      end
 
       vim.api.nvim_create_autocmd("BufEnter", {
         pattern = "copilot-chat",


### PR DESCRIPTION
nvim-cmp integration was removed in favour of custom autocomplete (it was pointless trying to support all the new completion plugins when its 15 lines to implement something plugin specific)