### PR TITLE
fix(extras): add blink.cmp integration for SQL extra

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/sql.lua
+++ b/lua/lazyvim/plugins/extras/lang/sql.lua
@@ -122,6 +122,25 @@ return {
     end,
   },
 
+  -- blink.cmp integration
+  {
+    "saghen/blink.cmp",
+    optional = true,
+    opts = {
+      sources = {
+        completion = {
+          enabled_providers = { "dadbod" },
+        },
+        providers = {
+          dadbod = { name = "Dadbod", module = "vim_dadbod_completion.blink" },
+        },
+      },
+    },
+    dependencies = {
+      "kristijanhusak/vim-dadbod-completion",
+    },
+  },
+
   -- Linters & formatters
   {
     "williamboman/mason.nvim",


### PR DESCRIPTION
## Description

This PR adds blink.cmp integration with `vim-dadbod-completion` in the SQL extras module. It allows blink.cmp to use the dadbod provider for SQL autocompletion in Neovim.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
