### PR TITLE
fix(lsp): don't leak keymaps from LSP server configs

### DIFF
--- a/lua/lazyvim/plugins/lsp/keymaps.lua
+++ b/lua/lazyvim/plugins/lsp/keymaps.lua
@@ -67,7 +67,7 @@ function M.resolve(buffer)
   if not Keys.resolve then
     return {}
   end
-  local spec = M.get()
+  local spec = vim.tbl_extend("force", {}, M.get())
   local opts = LazyVim.opts("nvim-lspconfig")
   local clients = LazyVim.lsp.get_clients({ bufnr = buffer })
   for _, client in ipairs(clients) do


### PR DESCRIPTION
## Description

I found an issue where if I'm editing files of different types, say for example `.cs` and `.py` files, they will naturally load the corresponding LSPs for each language. However, if one of those LSPs has keys defined in their `server` config section, then those key maps will leak into the other, so in this case, the `gd` (go to definition) mapping intended for `.cs` buffers is now present in `.py` buffers, causing it not to work. This is currently the case with the `omnisharp` LSP, as it defines a `gd` key map, see: https://github.com/LazyVim/LazyVim/blob/63150fa4c5ec8a6f5c56e9035599a8c8e32dc8ed/lua/lazyvim/plugins/extras/lang/omnisharp.lua#L53-L61

The fix here is to shallow clone the "global" LSP keymaps before adding the LSP server-specific keymaps so the LSP keymaps aren't added to the global ones.

## Related Issue(s)

## Screenshots

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
