### PR TITLE
feat(snacks): add keymap to copy url from gitbrowse

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -144,7 +144,10 @@ if vim.fn.executable("lazygit") == 1 then
 end
 
 map("n", "<leader>gb", function() Snacks.git.blame_line() end, { desc = "Git Blame Line" })
-map({ "n", "x" }, "<leader>gB", function() Snacks.gitbrowse() end, { desc = "Git Browse" })
+map({ "n", "x" }, "<leader>gB", function() Snacks.gitbrowse() end, { desc = "Git Browse (open)" })
+map({"n", "x" }, "<leader>gY", function()
+  Snacks.gitbrowse({ open = function(url) vim.fn.setreg("+", url) end })
+end, { desc = "Git Browse (copy)" })
 
 -- quit
 map("n", "<leader>qq", "<cmd>qa<cr>", { desc = "Quit All" })


### PR DESCRIPTION
## Description

Adds a `<leader>gY` keymap that copies the URL from `Snacks.gitbrowse()` to the clipboard. 

This is a feature in other git browse plugins like `vim-rhubarb`, so other people will probably be looking for this when migrating like I did.

Let me know if you'd prefer a different key combination, thanks!

## Related Issue(s)

N/A

## Screenshots

N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
