### PR TITLE
fix(dial): add and/or augend to python ft

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/dial.lua
+++ b/lua/lazyvim/plugins/extras/editor/dial.lua
@@ -108,6 +108,7 @@ return {
         markdown = "markdown",
         sass = "css",
         scss = "css",
+        python = "python",
       },
       groups = {
         default = {
@@ -149,6 +150,11 @@ return {
             elements = { "and", "or" },
             word = true, -- if false, "sand" is incremented into "sor", "doctor" into "doctand", etc.
             cyclic = true, -- "or" is incremented into "and".
+          }),
+        },
+        python = {
+          augend.constant.new({
+            elements = { "and", "or" },
           }),
         },
       },


### PR DESCRIPTION
## Description

The python language includes the keywords `and` or `or` for logical operations.
The current `dial.nvim` config does not include an augend for swapping these
keywords.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
