### PR TITLE
fix(sql): only use cmp if it is available

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/sql.lua
+++ b/lua/lazyvim/plugins/extras/lang/sql.lua
@@ -48,19 +48,21 @@ return {
       vim.api.nvim_create_autocmd("FileType", {
         pattern = sql_ft,
         callback = function()
-          local cmp = require("cmp")
+          if LazyVim.has("cmp") then
+            local cmp = require("cmp")
 
-          -- global sources
-          ---@param source cmp.SourceConfig
-          local sources = vim.tbl_map(function(source)
-            return { name = source.name }
-          end, cmp.get_config().sources)
+            -- global sources
+            ---@param source cmp.SourceConfig
+            local sources = vim.tbl_map(function(source)
+              return { name = source.name }
+            end, cmp.get_config().sources)
 
-          -- add vim-dadbod-completion source
-          table.insert(sources, { name = "vim-dadbod-completion" })
+            -- add vim-dadbod-completion source
+            table.insert(sources, { name = "vim-dadbod-completion" })
 
-          -- update sources for the current buffer
-          cmp.setup.buffer({ sources = sources })
+            -- update sources for the current buffer
+            cmp.setup.buffer({ sources = sources })
+          end
         end,
       })
     end,


### PR DESCRIPTION
## Description

The blink and sql extras are currently conflicting because the sql extra has a hard dependency on nvim-cmp, which is disabled by the blink extra. Introducing a check for cmp in the sql extra resolves this.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
