### PR TITLE
fix(ui): disable indent-blankline on `ft=snacks_dashboard`

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -216,6 +216,7 @@ return {
             "mason",
             "neo-tree",
             "notify",
+            "snacks_dashboard",
             "snacks_notif",
             "snacks_terminal",
             "snacks_win",


### PR DESCRIPTION
## Description

`indent-blankline.nvim` would act on the snacks dashboard if it was somehow loaded while the dashboard is still open.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

Fixes this:
![image](https://github.com/user-attachments/assets/1f77cf1d-c9c1-48d1-9bf3-8508782e8dd1)

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
