### PR TITLE
fix(sql): fix autocomplete, it was using the wrong plugin name on the `LazyVim.has` check

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/sql.lua
+++ b/lua/lazyvim/plugins/extras/lang/sql.lua
@@ -48,7 +48,7 @@ return {
       vim.api.nvim_create_autocmd("FileType", {
         pattern = sql_ft,
         callback = function()
-          if LazyVim.has("cmp") then
+          if LazyVim.has("nvim-cmp") then
             local cmp = require("cmp")
 
             -- global sources


### PR DESCRIPTION
## Description

`LazyVim.has` was called with the wrong plugin name.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
