### PR TITLE
feat(lang): add maxInlayHintLength for vtsls to resolve inlay hint to…

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -44,6 +44,7 @@ return {
               enableMoveToFileCodeAction = true,
               autoUseWorkspaceTsdk = true,
               experimental = {
+                maxInlayHintLength = 30,
                 completion = {
                   enableServerSideFuzzyMatch = true,
                 },


### PR DESCRIPTION
## Description

feat(lang): add maxInlayHintLength for vtsls to resolve inlay hint too long

## Related Issue(s)
* https://github.com/neovim/neovim/issues/27240
* https://github.com/yioneko/vtsls/pull/173


## Screenshots
before
![image](https://github.com/user-attachments/assets/5bc53695-7457-4f8f-bd03-b4de29f6f80d)


after
![image](https://github.com/user-attachments/assets/c9281173-4198-4bf2-84cf-33c5d1984550)



## Checklist

- [ x ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
