### PR TITLE
fix(tex): specify filetype for <localleader>l

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -30,7 +30,7 @@ return {
       vim.g.vimtex_quickfix_method = vim.fn.executable("pplatex") == 1 and "pplatex" or "latexlog"
     end,
     keys = {
-      { "<localLeader>l", "", desc = "+vimtex" },
+      { "<localLeader>l", "", desc = "+vimtex", ft = "tex" },
     },
   },
 


### PR DESCRIPTION
## Description

Specify the filetype for the keymap  `<localleader>l`  to ensure that this keybinding group only appears when editing TeX files.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
