### PR TITLE
Mini.files windowpicker

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/mini-files.lua
+++ b/lua/lazyvim/plugins/extras/editor/mini-files.lua
@@ -108,41 +108,38 @@ return {
       end,
     })
 
-    local plugin = require("lazy.core.config").plugins["nvim-window-picker"]
-    if plugin then
-      --- Opens the file in a picked window.
-      --- @param close boolean Whether to close the mini.files window after opening the file.
-      local open_in_window = function(close)
-        close = close or false
-        local mini_files = require("mini.files")
-        local picked_window_id = require("window-picker").pick_window({
-          filter_rules = {
-            autoselect_one = true,
-            bo = {
-              filetype = { "notify", "minifiles" },
-              buftype = { "terminal", "quickfix", "nofile" },
-            },
+    --- Opens the file in a picked window.
+    --- @param close boolean Whether to close the mini.files window after opening the file.
+    local open_in_window = function(close)
+      close = close or false
+      local mini_files = require("mini.files")
+      local picked_window_id = require("window-picker").pick_window({
+        filter_rules = {
+          autoselect_one = true,
+          bo = {
+            filetype = { "notify", "minifiles" },
+            buftype = { "terminal", "quickfix", "nofile" },
           },
-        })
-        if picked_window_id then
-          mini_files.set_target_window(picked_window_id)
-          mini_files.go_in({ close_on_file = close })
-        else
-          vim.notify("Window selection canceled", vim.log.levels.INFO, { title = "mini.files" })
-        end
-      end
-
-      vim.api.nvim_create_autocmd("User", {
-        pattern = "MiniFilesBufferCreate",
-        callback = function(args)
-          local buf_id = args.data.buf_id
-
-          vim.keymap.set("n", "<M-l>", open_in_window, { buffer = buf_id, desc = "Open file in window" })
-          vim.keymap.set("n", "<M-L>", function()
-            open_in_window(true)
-          end, { buffer = buf_id, desc = "Open file in window and close" })
-        end,
+        },
       })
+      if picked_window_id then
+        mini_files.set_target_window(picked_window_id)
+        mini_files.go_in({ close_on_file = close })
+      else
+        vim.notify("Window selection canceled", vim.log.levels.INFO, { title = "mini.files" })
+      end
     end
+
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "MiniFilesBufferCreate",
+      callback = function(args)
+        local buf_id = args.data.buf_id
+
+        vim.keymap.set("n", "<M-l>", open_in_window, { buffer = buf_id, desc = "Open file in window" })
+        vim.keymap.set("n", "<M-L>", function()
+          open_in_window(true)
+        end, { buffer = buf_id, desc = "Open file in window and close" })
+      end,
+    })
   end,
 }

--- a/lua/lazyvim/plugins/extras/editor/mini-files.lua
+++ b/lua/lazyvim/plugins/extras/editor/mini-files.lua
@@ -107,5 +107,42 @@ return {
         Snacks.rename.on_rename_file(event.data.from, event.data.to)
       end,
     })
+
+    local plugin = require("lazy.core.config").plugins["nvim-window-picker"]
+    if plugin then
+      --- Opens the file in a picked window.
+      --- @param close boolean Whether to close the mini.files window after opening the file.
+      local open_in_window = function(close)
+        close = close or false
+        local mini_files = require("mini.files")
+        local picked_window_id = require("window-picker").pick_window({
+          filter_rules = {
+            autoselect_one = true,
+            bo = {
+              filetype = { "notify", "minifiles" },
+              buftype = { "terminal", "quickfix", "nofile" },
+            },
+          },
+        })
+        if picked_window_id then
+          mini_files.set_target_window(picked_window_id)
+          mini_files.go_in({ close_on_file = close })
+        else
+          vim.notify("Window selection canceled", vim.log.levels.INFO, { title = "mini.files" })
+        end
+      end
+
+      vim.api.nvim_create_autocmd("User", {
+        pattern = "MiniFilesBufferCreate",
+        callback = function(args)
+          local buf_id = args.data.buf_id
+
+          vim.keymap.set("n", "<M-l>", open_in_window, { buffer = buf_id, desc = "Open file in window" })
+          vim.keymap.set("n", "<M-L>", function()
+            open_in_window(true)
+          end, { buffer = buf_id, desc = "Open file in window and close" })
+        end,
+      })
+    end
   end,
 }


### PR DESCRIPTION
## Description

Add the ability in mini.files extra to pick an existing window when the nvim-window-picker plugin is installed. The mini.files extra already offers the ability to open in a new split, but often the splits already exist. In that case it makes sense to be able to pick the window. A similar approach is used by neotree.

## Related Issue(s)

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
