### PR TITLE
fix(ui): disable mini.indentscope on `ft=snacks_dashboard`

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/mini-indentscope.lua
+++ b/lua/lazyvim/plugins/extras/ui/mini-indentscope.lua
@@ -23,6 +23,7 @@ return {
           "mason",
           "neo-tree",
           "notify",
+          "snacks_dashboard",
           "snacks_notif",
           "snacks_terminal",
           "snacks_win",


### PR DESCRIPTION
## Description

mini.indentscope would act on the snacks dashboard if it was somehow loaded while the dashboard is still open.

## Related Issue(s)

I forgot about mini.indentscope in #4895 :)

## Screenshots

**Actually** fixes this:
![image](https://github.com/user-attachments/assets/1f77cf1d-c9c1-48d1-9bf3-8508782e8dd1)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
