### PR TITLE
fix(extras.treesitter-context): change event back to `LazyFile`

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/treesitter-context.lua
+++ b/lua/lazyvim/plugins/extras/ui/treesitter-context.lua
@@ -1,7 +1,7 @@
 -- Show context of the current function
 return {
   "nvim-treesitter/nvim-treesitter-context",
-  event = "VeryLazy",
+  event = "LazyFile",
   opts = function()
     local tsc = require("treesitter-context")
     Snacks.toggle({


### PR DESCRIPTION
## Description

Load treesitter-context on `LazyFile` instead of `VeryLazy`. IMHO it didn't make sense to load the plugin earlier just so that the toggle is available, especially when the toggle won't actually have any effect anything until a file is opened.

~Previously, treesitter-context was loaded on `VeryLazy` and its toggle map in `opt`, which also `require`d it. Now, mapping happens in config, after treesitter-context is setup (also how toggle is handled in other extras, eg for render-markdown).~

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
