### PR TITLE
fix(supermaven): blink.cmp integration

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/supermaven.lua
+++ b/lua/lazyvim/plugins/extras/ai/supermaven.lua
@@ -44,38 +44,19 @@ return {
   },
 
   -- blink.cmp integration
-  --
-  -- FIXME: this currently doesn't work properly
-  -- {
-  --   "saghen/blink.cmp",
-  --   optional = true,
-  --   opts = {
-  --     sources = {
-  --       compat = vim.g.ai_cmp and { "supermaven" } or nil,
-  --     },
-  --   },
-  --   dependencies = {
-  --     "supermaven-nvim",
-  --     vim.g.ai_cmp and "saghen/blink.compat" or nil,
-  --   },
-  -- },
-  --
-  -- Disabble cmp integration for now
   {
     "saghen/blink.cmp",
     optional = true,
     ---@module 'blink.cmp'
     ---@type blink.cmp.Config
     opts = {
-      completion = { ghost_text = { enabled = false } },
+      sources = {
+        compat = vim.g.ai_cmp and { "supermaven" } or nil,
+      },
     },
     dependencies = {
-      {
-        "supermaven-nvim",
-        opts = {
-          disable_inline_completion = false,
-        },
-      },
+      "supermaven-nvim",
+      vim.g.ai_cmp and "saghen/blink.compat" or nil,
     },
   },
 


### PR DESCRIPTION
## Description

Supermaven completion now works with the latest release of blink.cmp and blink.compat. I'll also take a look at the other ai extras soon.

~A draft for now, until some issues with ghost text are resolved, see https://github.com/Saghen/blink.cmp/issues/257. Alternatively, enabling the supermaven extra could disable ghost text.~

## Screenshots

![image](https://github.com/user-attachments/assets/feb8003d-85c5-49a4-80df-7f57b240d371)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
