### PR TITLE
feat(extras.ai): blink.cmp integration and kind overrides for menu drawing

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/codeium.lua
+++ b/lua/lazyvim/plugins/extras/ai/codeium.lua
@@ -66,18 +66,7 @@ return {
       completion = {
         menu = {
           draw = {
-            components = {
-              kind = {
-                text = function(ctx)
-                  return ctx.source_name == "codeium" and "Codeium" or ctx.kind
-                end,
-                highlight = function(ctx)
-                  return ctx.source_name == "codeium" and "BlinkCmpKindCodeium"
-                    or require("blink.cmp.completion.windows.render.tailwind").get_hl(ctx)
-                    or ("BlinkCmpKind" .. ctx.kind)
-                end,
-              },
-            },
+            override_kind_by_source_name = { codeium = "Codeium" },
           },
         },
       },

--- a/lua/lazyvim/plugins/extras/ai/codeium.lua
+++ b/lua/lazyvim/plugins/extras/ai/codeium.lua
@@ -63,13 +63,7 @@ return {
       sources = {
         compat = { "codeium" },
       },
-      completion = {
-        menu = {
-          draw = {
-            override_kind_by_source_name = { codeium = "Codeium" },
-          },
-        },
-      },
+      providers = { codeium = { kind = "Codeium" } },
     },
   } or nil,
 }

--- a/lua/lazyvim/plugins/extras/ai/codeium.lua
+++ b/lua/lazyvim/plugins/extras/ai/codeium.lua
@@ -55,17 +55,32 @@ return {
     end,
   },
 
-  {
+  vim.g.ai_cmp and {
     "saghen/blink.cmp",
     optional = true,
+    dependencies = { "codeium.nvim", "saghen/blink.compat" },
     opts = {
       sources = {
-        compat = vim.g.ai_cmp and { "codeium" } or nil,
+        compat = { "codeium" },
+      },
+      completion = {
+        menu = {
+          draw = {
+            components = {
+              kind = {
+                text = function(ctx)
+                  return ctx.source_name == "codeium" and "Codeium" or ctx.kind
+                end,
+                highlight = function(ctx)
+                  return ctx.source_name == "codeium" and "BlinkCmpKindCodeium"
+                    or require("blink.cmp.completion.windows.render.tailwind").get_hl(ctx)
+                    or ("BlinkCmpKind" .. ctx.kind)
+                end,
+              },
+            },
+          },
+        },
       },
     },
-    dependencies = {
-      "codeium.nvim",
-      vim.g.ai_cmp and "saghen/blink.compat" or nil,
-    },
-  },
+  } or nil,
 }

--- a/lua/lazyvim/plugins/extras/ai/codeium.lua
+++ b/lua/lazyvim/plugins/extras/ai/codeium.lua
@@ -62,8 +62,8 @@ return {
     opts = {
       sources = {
         compat = { "codeium" },
+        providers = { codeium = { kind = "Codeium" } },
       },
-      providers = { codeium = { kind = "Codeium" } },
     },
   } or nil,
 }

--- a/lua/lazyvim/plugins/extras/ai/copilot.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot.lua
@@ -110,18 +110,7 @@ return {
       completion = {
         menu = {
           draw = {
-            components = {
-              kind = {
-                text = function(ctx)
-                  return ctx.source_name == "copilot" and "Copilot" or ctx.kind
-                end,
-                highlight = function(ctx)
-                  return ctx.source_name == "copilot" and "BlinkCmpKindCopilot"
-                    or require("blink.cmp.completion.windows.render.tailwind").get_hl(ctx)
-                    or ("BlinkCmpKind" .. ctx.kind)
-                end,
-              },
-            },
+            override_kind_by_source_name = { copilot = "Copilot" },
           },
         },
       },

--- a/lua/lazyvim/plugins/extras/ai/copilot.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot.lua
@@ -94,31 +94,37 @@ return {
     },
   },
 
-  -- blink.cmp
-  {
+  vim.g.ai_cmp and {
     "saghen/blink.cmp",
     optional = true,
-    dependencies = {
-      {
-        "giuxtaposition/blink-cmp-copilot",
-        enabled = vim.g.ai_cmp, -- only enable if needed
-        specs = {
-          {
-            "blink.cmp",
-            optional = true,
-            opts = {
-              sources = {
-                providers = {
-                  copilot = { name = "copilot", module = "blink-cmp-copilot" },
-                },
-                completion = {
-                  enabled_providers = { "copilot" },
-                },
+    dependencies = { "giuxtaposition/blink-cmp-copilot" },
+    opts = {
+      sources = {
+        completion = {
+          enabled_providers = { "copilot" },
+        },
+        providers = {
+          copilot = { name = "copilot", module = "blink-cmp-copilot" },
+        },
+      },
+      completion = {
+        menu = {
+          draw = {
+            components = {
+              kind = {
+                text = function(ctx)
+                  return ctx.source_name == "copilot" and "Copilot" or ctx.kind
+                end,
+                highlight = function(ctx)
+                  return ctx.source_name == "copilot" and "BlinkCmpKindCopilot"
+                    or require("blink.cmp.completion.windows.render.tailwind").get_hl(ctx)
+                    or ("BlinkCmpKind" .. ctx.kind)
+                end,
               },
             },
           },
         },
       },
     },
-  },
+  } or nil,
 }

--- a/lua/lazyvim/plugins/extras/ai/copilot.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot.lua
@@ -104,13 +104,10 @@ return {
           enabled_providers = { "copilot" },
         },
         providers = {
-          copilot = { name = "copilot", module = "blink-cmp-copilot" },
-        },
-      },
-      completion = {
-        menu = {
-          draw = {
-            override_kind_by_source_name = { copilot = "Copilot" },
+          copilot = {
+            name = "copilot",
+            module = "blink-cmp-copilot",
+            kind = "Copilot",
           },
         },
       },

--- a/lua/lazyvim/plugins/extras/ai/supermaven.lua
+++ b/lua/lazyvim/plugins/extras/ai/supermaven.lua
@@ -43,22 +43,34 @@ return {
     end,
   },
 
-  -- blink.cmp integration
-  {
+  vim.g.ai_cmp and {
     "saghen/blink.cmp",
     optional = true,
-    ---@module 'blink.cmp'
-    ---@type blink.cmp.Config
+    dependencies = { "supermaven-nvim", "saghen/blink.compat" },
     opts = {
       sources = {
-        compat = vim.g.ai_cmp and { "supermaven" } or nil,
+        compat = { "supermaven" },
+      },
+      completion = {
+        menu = {
+          draw = {
+            components = {
+              kind = {
+                text = function(ctx)
+                  return ctx.source_name == "supermaven" and "Supermaven" or ctx.kind
+                end,
+                highlight = function(ctx)
+                  return ctx.source_name == "supermaven" and "BlinkCmpKindSupermaven"
+                    or require("blink.cmp.completion.windows.render.tailwind").get_hl(ctx)
+                    or ("BlinkCmpKind" .. ctx.kind)
+                end,
+              },
+            },
+          },
+        },
       },
     },
-    dependencies = {
-      "supermaven-nvim",
-      vim.g.ai_cmp and "saghen/blink.compat" or nil,
-    },
-  },
+  } or nil,
 
   {
     "nvim-lualine/lualine.nvim",

--- a/lua/lazyvim/plugins/extras/ai/supermaven.lua
+++ b/lua/lazyvim/plugins/extras/ai/supermaven.lua
@@ -54,18 +54,7 @@ return {
       completion = {
         menu = {
           draw = {
-            components = {
-              kind = {
-                text = function(ctx)
-                  return ctx.source_name == "supermaven" and "Supermaven" or ctx.kind
-                end,
-                highlight = function(ctx)
-                  return ctx.source_name == "supermaven" and "BlinkCmpKindSupermaven"
-                    or require("blink.cmp.completion.windows.render.tailwind").get_hl(ctx)
-                    or ("BlinkCmpKind" .. ctx.kind)
-                end,
-              },
-            },
+            override_kind_by_source_name = { supermaven = "Supermaven" },
           },
         },
       },

--- a/lua/lazyvim/plugins/extras/ai/supermaven.lua
+++ b/lua/lazyvim/plugins/extras/ai/supermaven.lua
@@ -50,8 +50,8 @@ return {
     opts = {
       sources = {
         compat = { "supermaven" },
+        providers = { supermaven = { kind = "Supermaven" } },
       },
-      providers = { supermaven = { kind = "Supermaven" } },
     },
   } or nil,
 

--- a/lua/lazyvim/plugins/extras/ai/supermaven.lua
+++ b/lua/lazyvim/plugins/extras/ai/supermaven.lua
@@ -51,13 +51,7 @@ return {
       sources = {
         compat = { "supermaven" },
       },
-      completion = {
-        menu = {
-          draw = {
-            override_kind_by_source_name = { supermaven = "Supermaven" },
-          },
-        },
-      },
+      providers = { supermaven = { kind = "Supermaven" } },
     },
   } or nil,
 

--- a/lua/lazyvim/plugins/extras/ai/tabnine.lua
+++ b/lua/lazyvim/plugins/extras/ai/tabnine.lua
@@ -42,13 +42,7 @@ return {
       sources = {
         compat = { "cmp_tabnine" },
       },
-      completion = {
-        menu = {
-          draw = {
-            override_kind_by_source_name = { cmp_tabnine = "TabNine" },
-          },
-        },
-      },
+      providers = { cmp_tabnine = { kind = "TabNine" } },
     },
   },
 

--- a/lua/lazyvim/plugins/extras/ai/tabnine.lua
+++ b/lua/lazyvim/plugins/extras/ai/tabnine.lua
@@ -1,25 +1,22 @@
 return {
   -- Tabnine cmp source
   {
+    "tzachar/cmp-tabnine",
+    build = LazyVim.is_win() and "pwsh -noni .\\install.ps1" or "./install.sh",
+    opts = {
+      max_lines = 1000,
+      max_num_results = 3,
+      sort = true,
+    },
+    config = function(_, opts)
+      require("cmp_tabnine.config"):setup(opts)
+    end,
+  },
+
+  {
     "nvim-cmp",
     optional = true,
-    dependencies = {
-      {
-        "tzachar/cmp-tabnine",
-        build = {
-          LazyVim.is_win() and "pwsh -noni .\\install.ps1" or "./install.sh",
-        },
-        dependencies = "hrsh7th/nvim-cmp",
-        opts = {
-          max_lines = 1000,
-          max_num_results = 3,
-          sort = true,
-        },
-        config = function(_, opts)
-          require("cmp_tabnine.config"):setup(opts)
-        end,
-      },
-    },
+    dependencies = { "tzachar/cmp-tabnine" },
     ---@param opts cmp.ConfigSchema
     opts = function(_, opts)
       table.insert(opts.sources, 1, {
@@ -36,6 +33,36 @@ return {
       end)
     end,
   },
+
+  {
+    "saghen/blink.cmp",
+    optional = true,
+    dependencies = { "tzachar/cmp-tabnine", "saghen/blink.compat" },
+    opts = {
+      sources = {
+        compat = { "cmp_tabnine" },
+      },
+      completion = {
+        menu = {
+          draw = {
+            components = {
+              kind = {
+                text = function(ctx)
+                  return ctx.source_name == "cmp_tabnine" and "TabNine" or ctx.kind
+                end,
+                highlight = function(ctx)
+                  return ctx.source_name == "cmp_tabnine" and "BlinkCmpKindTabNine"
+                    or require("blink.cmp.completion.windows.render.tailwind").get_hl(ctx)
+                    or ("BlinkCmpKind" .. ctx.kind)
+                end,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
   -- Show TabNine status in lualine
   {
     "nvim-lualine/lualine.nvim",

--- a/lua/lazyvim/plugins/extras/ai/tabnine.lua
+++ b/lua/lazyvim/plugins/extras/ai/tabnine.lua
@@ -45,18 +45,7 @@ return {
       completion = {
         menu = {
           draw = {
-            components = {
-              kind = {
-                text = function(ctx)
-                  return ctx.source_name == "cmp_tabnine" and "TabNine" or ctx.kind
-                end,
-                highlight = function(ctx)
-                  return ctx.source_name == "cmp_tabnine" and "BlinkCmpKindTabNine"
-                    or require("blink.cmp.completion.windows.render.tailwind").get_hl(ctx)
-                    or ("BlinkCmpKind" .. ctx.kind)
-                end,
-              },
-            },
+            override_kind_by_source_name = { cmp_tabnine = "TabNine" },
           },
         },
       },

--- a/lua/lazyvim/plugins/extras/ai/tabnine.lua
+++ b/lua/lazyvim/plugins/extras/ai/tabnine.lua
@@ -41,8 +41,8 @@ return {
     opts = {
       sources = {
         compat = { "cmp_tabnine" },
+        providers = { cmp_tabnine = { kind = "TabNine" } },
       },
-      providers = { cmp_tabnine = { kind = "TabNine" } },
     },
   },
 

--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -45,7 +45,10 @@ return {
       completion = {
         menu = {
           winblend = vim.o.pumblend,
-          draw = { treesitter = true },
+          draw = {
+            override_kind_by_source_name = {},
+            treesitter = true,
+          },
         },
         documentation = {
           auto_show = true,
@@ -93,6 +96,23 @@ return {
           table.insert(enabled, source)
         end
       end
+
+      local override_kind_by_source_name = opts.completion.menu.draw.override_kind_by_source_name or {}
+      local kind = {
+        text = function(ctx)
+          local kind_override = override_kind_by_source_name[ctx.source_name]
+          return kind_override and kind_override or ctx.kind
+        end,
+        highlight = function(ctx)
+          local kind_override = override_kind_by_source_name[ctx.source_name]
+          return kind_override and "BlinkCmpKind" .. kind_override
+            or require("blink.cmp.completion.windows.render.tailwind").get_hl(ctx)
+            or ("BlinkCmpKind" .. ctx.kind)
+        end,
+      }
+
+      opts.completion.menu.draw.components =
+        vim.tbl_deep_extend("force", { kind = kind }, opts.completion.menu.draw.components or {})
       require("blink.cmp").setup(opts)
     end,
   },

--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -100,9 +100,12 @@ return {
         ---@cast provider blink.cmp.SourceProviderConfig|{kind?:string}
         if provider.kind then
           require("blink.cmp.types").CompletionItemKind[provider.kind] = provider.kind
+          ---@type fun(ctx: blink.cmp.Context, items: blink.cmp.CompletionItem[]): blink.cmp.CompletionItem[]
+          local transform_items = provider.transform_items
           ---@param ctx blink.cmp.Context
           ---@param items blink.cmp.CompletionItem[]
           provider.transform_items = function(ctx, items)
+            items = transform_items and transform_items(ctx, items) or items
             for _, item in ipairs(items) do
               item.kind = provider.kind or item.kind
             end

--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -52,7 +52,7 @@ return {
           auto_show_delay_ms = 200,
         },
         ghost_text = {
-          enabled = vim.g.ai_cmp,
+          enabled = true,
         },
       },
 

--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -54,7 +54,7 @@ return {
           auto_show_delay_ms = 200,
         },
         ghost_text = {
-          enabled = true,
+          enabled = vim.g.ai_cmp,
         },
       },
 

--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -44,7 +44,6 @@ return {
       nerd_font_variant = "mono",
       completion = {
         menu = {
-          winblend = vim.o.pumblend,
           draw = {
             override_kind_by_source_name = {},
             treesitter = true,


### PR DESCRIPTION
## Description

blink.cmp integration for codeium and copilot, and correct menu drawing for codeium, copilot, and supermaven.

I've simplified the blink.cmp config a bit for these extras (especially for copilot, which was extremely nested) by only including the blink.cmp spec if vim.g.ai_cmp is true.

Multiple AI extras can now be enabled at the same time with blink.cmp.

blink.cmp ghost text is now always enabled. Although some ai plugins always display virtual text, at worst it overlaps with blink's ghost text and is not noticable.

Lastly, I can't test copilot because I don't have a subscription, nor do I want to sign up for one, but it should work just as well as the others.

## Screenshots

With Codeium:
![image](https://github.com/user-attachments/assets/1485ee3f-1cba-440f-8a82-ec69b4a3f473)

Multiple extras enabled at the same time:
![image](https://github.com/user-attachments/assets/4364ee45-d79b-4f97-a4c0-cf2a2b6433c6)

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
