### PR TITLE
fix(ui): actually disable mini-indentscope on snacks_dashboard

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/mini-indentscope.lua
+++ b/lua/lazyvim/plugins/extras/ui/mini-indentscope.lua
@@ -34,6 +34,13 @@ return {
           vim.b.miniindentscope_disable = true
         end,
       })
+
+      vim.api.nvim_create_autocmd("User", {
+        pattern = "SnacksDashboardOpened",
+        callback = function(data)
+          vim.b[data.buf].miniindentscope_disable = true
+        end,
+      })
     end,
   },
   {


### PR DESCRIPTION
## Description

Disables mini.indentscope for the buffer on which the `SnacksDashboardOpened` autocmd is called.

## Related Issue(s)

closes #4944

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
