### PR TITLE
fix(rust): add bacon-ls to mason

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -49,7 +49,7 @@ return {
       opts.ensure_installed = opts.ensure_installed or {}
       vim.list_extend(opts.ensure_installed, { "codelldb" })
       if diagnostics == "bacon-ls" then
-        vim.list_extend(opts.ensure_installed, { "bacon" })
+        vim.list_extend(opts.ensure_installed, { "bacon", "bacon-ls" })
       end
     end,
   },


### PR DESCRIPTION
## Description

The bacon extra also needs `bacon-ls` to be installed. Otherwise the executable won't be found.

https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#bacon_ls
> It requires bacon and bacon-ls to be installed on the system using [mason.nvim](https://github.com/williamboman/mason.nvim) or manually

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
