### PR TITLE
feat(extras): add Chrome configuration to DAP in TypeScript extra

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -204,13 +204,12 @@ return {
     opts = function()
       local dap = require("dap")
       if not dap.adapters["pwa-node"] then
-        require("dap").adapters["pwa-node"] = {
+        dap.adapters["pwa-node"] = {
           type = "server",
           host = "localhost",
           port = "${port}",
           executable = {
             command = "node",
-            -- 💀 Make sure to update this path to point to your installation
             args = {
               LazyVim.get_pkg_path("js-debug-adapter", "/js-debug/src/dapDebugServer.js"),
               "${port}",
@@ -218,25 +217,20 @@ return {
           },
         }
       end
-      if not dap.adapters["node"] then
-        dap.adapters["node"] = function(cb, config)
-          if config.type == "node" then
-            config.type = "pwa-node"
-          end
-          local nativeAdapter = dap.adapters["pwa-node"]
-          if type(nativeAdapter) == "function" then
-            nativeAdapter(cb, config)
-          else
-            cb(nativeAdapter)
-          end
+
+      local adapters = { "pwa-node", "pwa-chrome" }
+      for _, adapter in ipairs(adapters) do
+        if not dap.adapters[adapter] then
+          dap.adapters[adapter] = dap.adapters["pwa-node"]
         end
       end
 
       local js_filetypes = { "typescript", "javascript", "typescriptreact", "javascriptreact" }
 
       local vscode = require("dap.ext.vscode")
-      vscode.type_to_filetypes["node"] = js_filetypes
-      vscode.type_to_filetypes["pwa-node"] = js_filetypes
+      for _, adapter in ipairs(adapters) do
+        vscode.type_to_filetypes[adapter] = js_filetypes
+      end
 
       for _, language in ipairs(js_filetypes) do
         if not dap.configurations[language] then
@@ -254,6 +248,48 @@ return {
               name = "Attach",
               processId = require("dap.utils").pick_process,
               cwd = "${workspaceFolder}",
+            },
+            {
+              type = "pwa-chrome",
+              request = "launch",
+              name = 'Launch Chrome with "localhost"',
+              url = function()
+                local co = coroutine.running()
+                return coroutine.create(function()
+                  vim.ui.input({ prompt = "Enter URL: ", default = "http://localhost:3000" }, function(url)
+                    if url == nil or url == "" then
+                      return
+                    else
+                      coroutine.resume(co, url)
+                    end
+                  end)
+                end)
+              end,
+              port = 9222,
+              webRoot = vim.fn.getcwd(),
+              protocol = "inspector",
+              sourceMaps = true,
+              userDataDir = false,
+              skipFiles = { "<node_internals>/**", "node_modules/**", "${workspaceFolder}/node_modules/**" },
+              resolveSourceMapLocations = {
+                "${workspaceFolder}/apps/**/**",
+                "${workspaceFolder}/**",
+                "!**/node_modules/**",
+              },
+            },
+            {
+              type = "pwa-chrome",
+              request = "attach",
+              name = "Attach Program (pwa-chrome, select port)",
+              program = "${file}",
+              cwd = vim.fn.getcwd(),
+              sourceMaps = true,
+              protocol = "inspector",
+              port = function()
+                return vim.fn.input("Select port: ", 9222)
+              end,
+              webRoot = "${workspaceFolder}",
+              skipFiles = { "<node_internals>/**", "node_modules/**" },
             },
           }
         end


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
 This PR adds Chrome configuration to the TypeScript extra DAP setup. It no longer relies only on pwa-node, allowing you to launch or attach to a Chrome remote debugging session as well.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
