### PR TITLE
feat(vscode): add vscode-specific keymaps and sync undo/redo with vscode

### DIFF
--- a/lua/lazyvim/plugins/extras/vscode.lua
+++ b/lua/lazyvim/plugins/extras/vscode.lua
@@ -33,9 +33,18 @@ end
 vim.api.nvim_create_autocmd("User", {
   pattern = "LazyVimKeymapsDefaults",
   callback = function()
+    -- VSCode-specific keymaps for search and navigation
     vim.keymap.set("n", "<leader><space>", "<cmd>Find<cr>")
     vim.keymap.set("n", "<leader>/", [[<cmd>lua require('vscode').action('workbench.action.findInFiles')<cr>]])
     vim.keymap.set("n", "<leader>ss", [[<cmd>lua require('vscode').action('workbench.action.gotoSymbol')<cr>]])
+
+    -- Keep undo/redo lists in sync with VsCode
+    vim.keymap.set("n", "u", "<Cmd>call VSCodeNotify('undo')<CR>")
+    vim.keymap.set("n", "<C-r>", "<Cmd>call VSCodeNotify('redo')<CR>")
+
+    -- Navigate VSCode tabs like lazyvim buffers
+    vim.keymap.set("n", "<S-h>", "<Cmd>call VSCodeNotify('workbench.action.previousEditor')<CR>")
+    vim.keymap.set("n", "<S-l>", "<Cmd>call VSCodeNotify('workbench.action.nextEditor')<CR>")
   end,
 })
 


### PR DESCRIPTION
## Summary
This pull request introduces several new keymaps specifically for VSCode when using LazyVim. These changes aim to enhance the integration between VSCode and LazyVim by adding keymaps for, tab navigation, and syncing nvim undo/redo actions with vscode undo/redo.

## Changes
- Synced undo/redo lists with VSCode using `VSCodeNotify`: (check https://github.com/vscode-neovim/vscode-neovim/issues/1139 for more details)
  - `u` for undo
  - `<C-r>` for redo
- Enabled navigation of VSCode tabs similar to LazyVim buffers:
  - `<S-h>` to go to the previous editor
  - `<S-l>` to go to the next editor

## Additional Notes
These changes are intended to improve the user experience for those who use LazyVim within VSCode by providing more intuitive and consistent keybindings. Please test these keymaps to ensure they work as expected in your VSCode setup.