### PR TITLE
feat(core): new LazyVim release v14.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,60 @@
 # What's new?
 
+## 14.x
+
+Big new release with a lot of changes and improvements!
+Two new plugins have been added, and a lot of plugins have been replaced.
+With these changes, default **LazyVim** is now just `34` plugins.
+
+### Added Plugins
+
+- [fzf-lua](https://github.com/ibhagwan/fzf-lua) as a replacement for [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
+  - to use **telescope.nvim** instead, enable the `ui.telescope` extra
+- [blink.cmp](https://github.com/saghm/blink.cmp) as a replacement for [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
+  - to use **nvim-cmp** instead, enable the `nvim-cmp` extra
+
+### Removed Plugins
+
+- [dressing.nvim](https://github.com/stevearc/dressing.nvim) (replaced with [fzf-lua](https://github.com/ibhagwan/fzf-lua) and [snacks.input](https://github.com/folke/snacks.nvim))
+- [telescope-fzf-native.nvim](https://github.com/nvim-telescope/telescope-fzf-native.nvim) (replaced with [fzf-lua](https://github.com/ibhagwan/fzf-lua))
+- [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) (replaced with [fzf-lua](https://github.com/ibhagwan/fzf-lua))
+- [indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim) (replaced with [snacks.indent](https://github.com/Folke/snacks.nvim))
+  - to use **indent-blankline.nvim** instead, enable the `indent-blankline` extra
+- [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) (replaced with [blink](https://github.com/Saghen/blink.cmp))
+- [nvim-snippets](https://github.com/hrsh7th/vim-vsnip) (replaced with [blink](https://github.com/Saghen/blink.cmp))
+- [cmp-buffer](https://github.com/hrsh7th/cmp-buffer) (replaced with [blink](https://github.com/Saghen/blink.cmp))
+- [cmp-nvim-lsp](https://github.com/hrsh7th/cmp-nvim-lsp) (replaced with [blink](https://github.com/Saghen/blink.cmp))
+- [cmp-path](https://github.com/hrsh7th/cmp-path) (replaced with [blink](https://github.com/Saghen/blink.cmp))
+
+### Changes
+
+- added [`snacks.input`](https://github.com/folke/snacks.nvim/blob/main/docs/input.md)
+- added [`snacks.scroll`](https://github.com/folke/snacks.nvim/blob/main/docs/scroll.md)
+- added [`snacks.indent`](https://github.com/folke/snacks.nvim/blob/main/docs/indent.md)
+- added [`snacks.scope`](https://github.com/folke/snacks.nvim/blob/main/docs/scope.md)
+- added [`snacks.dim`](https://github.com/folke/snacks.nvim/blob/main/docs/dim.md)
+- added [`snacks.zen`](https://github.com/folke/snacks.nvim/blob/main/docs/zen.md)
+- changed default [`which-key`](https://github.com/folke/which-key.nvim) preset to `helix`
+- drop `LazyVim.ui.fg` in favor of [`Snacks.util.color`](https://github.com/folke/snacks.nvim/blob/main/docs/util.md)
+
+To disable **all animations**, add the following to your `options.lua`:
+
+```lua
+vim.g.snacks_animate = false
+```
+
+### Keymaps
+
+- `<leader>z` to toggle [zen mode](https://github.com/folke/snacks.nvim/blob/main/docs/zen.md)
+- `<leader>Z` to toggle [zoom mode](https://github.com/folke/snacks.nvim/blob/main/docs/zen.md)
+- `<leader>uD` to toggle [dimming](https://github.com/folke/snacks.nvim/blob/main/docs/dim.md)
+- `<leader>ua` to toggle [animations](https://github.com/folke/snacks.nvim/blob/main/docs/animate.md)
+- `<leader>uS` to toggle [scroll](https://github.com/folke/snacks.nvim/blob/main/docs/scroll.md)
+- `<leader>ug` to toggle [indent guides](https://github.com/folke/snacks.nvim/blob/main/docs/indent.md)
+- [`snacks.profiler`](https://github.com/folke/snacks.nvim/blob/main/docs/profiler.md) keymaps under `<leader>dp`
+
+---
+
 ## 13.x
 
 - **LazyVim** now uses `Snacks.dashboard` as the default dashboard.
@@ -20,6 +75,8 @@
   - `Snacks.notifier` for notifications instead of `nvim-notify`
   - `Snacks.terminal` is similar to `lazyterm`, but has more features
     and creates bottom splits by default (similar to the `edgy` integrating)
+
+---
 
 ## 12.x
 
@@ -47,6 +104,8 @@
 
 - moved `neoconf.nvim` to extras. Project specific LSP settings
   can be done with a `.lazy.lua` file instead.
+
+---
 
 ## 11.x
 
@@ -106,6 +165,8 @@ Additionally, some core plugins have been moved to extras.
   - `mini.surround`
   - `mini.indentscope` scopes are now also highlighted with `indent-blankline`
   - `nvim-treesitter-context`
+
+---
 
 ## 10.x
 

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -135,6 +135,8 @@ Snacks.toggle.dim():map("<leader>uD")
 Snacks.toggle.animate():map("<leader>ua")
 Snacks.toggle.indent():map("<leader>ug")
 Snacks.toggle.scroll():map("<leader>uS")
+Snacks.toggle.profiler():map("<leader>dpp")
+Snacks.toggle.profiler_highlights():map("<leader>dph")
 if vim.lsp.inlay_hint then
   Snacks.toggle.inlay_hints():map("<leader>uh")
 end

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -179,8 +179,8 @@ map("n", "<leader>w", "<c-w>", { desc = "Windows", remap = true })
 map("n", "<leader>-", "<C-W>s", { desc = "Split Window Below", remap = true })
 map("n", "<leader>|", "<C-W>v", { desc = "Split Window Right", remap = true })
 map("n", "<leader>wd", "<C-W>c", { desc = "Delete Window", remap = true })
-Snacks.toggle.zoom():map("<leader>wm"):map("<leader>Z")
-Snacks.toggle.zen():map("<leader>z")
+Snacks.toggle.zoom():map("<leader>wm"):map("<leader>uZ")
+Snacks.toggle.zen():map("<leader>uz")
 
 -- tabs
 map("n", "<leader><tab>l", "<cmd>tablast<cr>", { desc = "Last Tab" })

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -133,6 +133,7 @@ Snacks.toggle.treesitter():map("<leader>uT")
 Snacks.toggle.option("background", { off = "light", on = "dark" , name = "Dark Background"}):map("<leader>ub")
 Snacks.toggle.dim():map("<leader>uD")
 Snacks.toggle.animate():map("<leader>ua")
+Snacks.toggle.indent():map("<leader>ug")
 if vim.lsp.inlay_hint then
   Snacks.toggle.inlay_hints():map("<leader>uh")
 end

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -176,7 +176,7 @@ map("n", "<leader>w", "<c-w>", { desc = "Windows", remap = true })
 map("n", "<leader>-", "<C-W>s", { desc = "Split Window Below", remap = true })
 map("n", "<leader>|", "<C-W>v", { desc = "Split Window Right", remap = true })
 map("n", "<leader>wd", "<C-W>c", { desc = "Delete Window", remap = true })
-Snacks.toggle.zoom():map("<leader>wm")
+Snacks.toggle.zoom():map("<leader>wm"):map("<leader>Z")
 
 -- tabs
 map("n", "<leader><tab>l", "<cmd>tablast<cr>", { desc = "Last Tab" })

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -132,6 +132,7 @@ Snacks.toggle.option("showtabline", {off = 0, on = vim.o.showtabline > 0 and vim
 Snacks.toggle.treesitter():map("<leader>uT")
 Snacks.toggle.option("background", { off = "light", on = "dark" , name = "Dark Background"}):map("<leader>ub")
 Snacks.toggle.dim():map("<leader>uD")
+Snacks.toggle.animate():map("<leader>ua")
 if vim.lsp.inlay_hint then
   Snacks.toggle.inlay_hints():map("<leader>uh")
 end

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -134,6 +134,7 @@ Snacks.toggle.option("background", { off = "light", on = "dark" , name = "Dark B
 Snacks.toggle.dim():map("<leader>uD")
 Snacks.toggle.animate():map("<leader>ua")
 Snacks.toggle.indent():map("<leader>ug")
+Snacks.toggle.scroll():map("<leader>uS")
 if vim.lsp.inlay_hint then
   Snacks.toggle.inlay_hints():map("<leader>uh")
 end

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -177,6 +177,7 @@ map("n", "<leader>-", "<C-W>s", { desc = "Split Window Below", remap = true })
 map("n", "<leader>|", "<C-W>v", { desc = "Split Window Right", remap = true })
 map("n", "<leader>wd", "<C-W>c", { desc = "Delete Window", remap = true })
 Snacks.toggle.zoom():map("<leader>wm"):map("<leader>Z")
+Snacks.toggle.zen():map("<leader>z")
 
 -- tabs
 map("n", "<leader><tab>l", "<cmd>tablast<cr>", { desc = "Last Tab" })

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -175,7 +175,7 @@ map("n", "<leader>w", "<c-w>", { desc = "Windows", remap = true })
 map("n", "<leader>-", "<C-W>s", { desc = "Split Window Below", remap = true })
 map("n", "<leader>|", "<C-W>v", { desc = "Split Window Right", remap = true })
 map("n", "<leader>wd", "<C-W>c", { desc = "Delete Window", remap = true })
-LazyVim.ui.maximize():map("<leader>wm")
+Snacks.toggle.zoom():map("<leader>wm")
 
 -- tabs
 map("n", "<leader><tab>l", "<cmd>tablast<cr>", { desc = "Last Tab" })

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -131,6 +131,7 @@ Snacks.toggle.option("conceallevel", {off = 0, on = vim.o.conceallevel > 0 and v
 Snacks.toggle.option("showtabline", {off = 0, on = vim.o.showtabline > 0 and vim.o.showtabline or 2, name = "Tabline"}):map("<leader>uA")
 Snacks.toggle.treesitter():map("<leader>uT")
 Snacks.toggle.option("background", { off = "light", on = "dark" , name = "Dark Background"}):map("<leader>ub")
+Snacks.toggle.dim():map("<leader>uD")
 if vim.lsp.inlay_hint then
   Snacks.toggle.inlay_hints():map("<leader>uh")
 end

--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -5,6 +5,10 @@ vim.g.maplocalleader = "\\"
 -- LazyVim auto format
 vim.g.autoformat = true
 
+-- Snacks animations
+-- Set to `false` to globally disable all snacks animations
+vim.g.snacks_animate = true
+
 -- LazyVim picker to use.
 -- Can be one of: telescope, fzf
 -- Leave it to "auto" to automatically use the picker

--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -11,6 +11,12 @@ vim.g.autoformat = true
 -- enabled with `:LazyExtras`
 vim.g.lazyvim_picker = "auto"
 
+-- LazyVim completion engine to use.
+-- Can be one of: nvim-cmp, blink.cmp
+-- Leave it to "auto" to automatically use the completion engine
+-- enabled with `:LazyExtras`
+vim.g.lazyvim_cmp = "auto"
+
 -- if the completion engine supports the AI source,
 -- use that instead of inline suggestions
 vim.g.ai_cmp = true

--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -1,113 +1,14 @@
 return {
-
-  -- auto completion
   {
-    "hrsh7th/nvim-cmp",
-    version = false, -- last release is way too old
-    event = "InsertEnter",
-    dependencies = {
-      "hrsh7th/cmp-nvim-lsp",
-      "hrsh7th/cmp-buffer",
-      "hrsh7th/cmp-path",
-    },
-    -- Not all LSP servers add brackets when completing a function.
-    -- To better deal with this, LazyVim adds a custom option to cmp,
-    -- that you can configure. For example:
-    --
-    -- ```lua
-    -- opts = {
-    --   auto_brackets = { "python" }
-    -- }
-    -- ```
-    opts = function()
-      vim.api.nvim_set_hl(0, "CmpGhostText", { link = "Comment", default = true })
-      local cmp = require("cmp")
-      local defaults = require("cmp.config.default")()
-      local auto_select = true
-      return {
-        auto_brackets = {}, -- configure any filetype to auto add brackets
-        completion = {
-          completeopt = "menu,menuone,noinsert" .. (auto_select and "" or ",noselect"),
-        },
-        preselect = auto_select and cmp.PreselectMode.Item or cmp.PreselectMode.None,
-        mapping = cmp.mapping.preset.insert({
-          ["<C-b>"] = cmp.mapping.scroll_docs(-4),
-          ["<C-f>"] = cmp.mapping.scroll_docs(4),
-          ["<C-n>"] = cmp.mapping.select_next_item({ behavior = cmp.SelectBehavior.Insert }),
-          ["<C-p>"] = cmp.mapping.select_prev_item({ behavior = cmp.SelectBehavior.Insert }),
-          ["<C-Space>"] = cmp.mapping.complete(),
-          ["<CR>"] = LazyVim.cmp.confirm({ select = auto_select }),
-          ["<C-y>"] = LazyVim.cmp.confirm({ select = true }),
-          ["<S-CR>"] = LazyVim.cmp.confirm({ behavior = cmp.ConfirmBehavior.Replace }), -- Accept currently selected item. Set `select` to `false` to only confirm explicitly selected items.
-          ["<C-CR>"] = function(fallback)
-            cmp.abort()
-            fallback()
-          end,
-          ["<tab>"] = function(fallback)
-            return LazyVim.cmp.map({ "snippet_forward", "ai_accept" }, fallback)()
-          end,
-        }),
-        sources = cmp.config.sources({
-          { name = "nvim_lsp" },
-          { name = "path" },
-        }, {
-          { name = "buffer" },
-        }),
-        formatting = {
-          format = function(entry, item)
-            local icons = LazyVim.config.icons.kinds
-            if icons[item.kind] then
-              item.kind = icons[item.kind] .. item.kind
-            end
-
-            local widths = {
-              abbr = vim.g.cmp_widths and vim.g.cmp_widths.abbr or 40,
-              menu = vim.g.cmp_widths and vim.g.cmp_widths.menu or 30,
-            }
-
-            for key, width in pairs(widths) do
-              if item[key] and vim.fn.strdisplaywidth(item[key]) > width then
-                item[key] = vim.fn.strcharpart(item[key], 0, width - 1) .. "…"
-              end
-            end
-
-            return item
-          end,
-        },
-        experimental = {
-          -- only show ghost text when we show ai completions
-          ghost_text = vim.g.ai_cmp and {
-            hl_group = "CmpGhostText",
-          } or false,
-        },
-        sorting = defaults.sorting,
-      }
+    import = "lazyvim.plugins.extras.coding.nvim-cmp",
+    enabled = function()
+      return LazyVim.cmp_engine() == "nvim-cmp"
     end,
-    main = "lazyvim.util.cmp",
   },
-
-  -- snippets
   {
-    "nvim-cmp",
-    optional = true,
-    dependencies = {
-      {
-        "garymjr/nvim-snippets",
-        opts = {
-          friendly_snippets = true,
-        },
-        dependencies = { "rafamadriz/friendly-snippets" },
-      },
-    },
-    opts = function(_, opts)
-      opts.snippet = {
-        expand = function(item)
-          return LazyVim.cmp.expand(item.body)
-        end,
-      }
-      if LazyVim.has("nvim-snippets") then
-        table.insert(opts.sources, { name = "snippets" })
-      end
+    import = "lazyvim.plugins.extras.coding.blink",
+    enabled = function()
+      return LazyVim.cmp_engine() == "blink.cmp"
     end,
   },
 
@@ -188,13 +89,5 @@ return {
         { path = "lazy.nvim", words = { "LazyVim" } },
       },
     },
-  },
-  -- Add lazydev source to cmp
-  {
-    "hrsh7th/nvim-cmp",
-    optional = true,
-    opts = function(_, opts)
-      table.insert(opts.sources, { name = "lazydev", group_index = 0 })
-    end,
   },
 }

--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -160,7 +160,6 @@ return {
             { "%u[%l%d]+%f[^%l%d]", "%f[%S][%l%d]+%f[^%l%d]", "%f[%P][%l%d]+%f[^%l%d]", "^[%l%d]+%f[^%l%d]" },
             "^().*()$",
           },
-          i = LazyVim.mini.ai_indent, -- indent
           g = LazyVim.mini.ai_buffer, -- buffer
           u = ai.gen_spec.function_call(), -- u for "Usage"
           U = ai.gen_spec.function_call({ name_pattern = "[%w_]" }), -- without dot in function name

--- a/lua/lazyvim/plugins/compat/nvim-0_9.lua
+++ b/lua/lazyvim/plugins/compat/nvim-0_9.lua
@@ -4,6 +4,9 @@ return {
   { "garymjr/nvim-snippets", enabled = false },
   { import = "lazyvim.plugins.extras.coding.luasnip" },
 
+  -- Use nvim-cmp instead of blink.cmp
+  { import = "lazyvim.plugins.extras.coding.nvim-cmp" },
+
   -- Use mini.comment instead of ts-comments
   { "folke/ts-comments.nvim", enabled = false },
   { import = "lazyvim.plugins.extras.coding.mini-comment" },

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -183,6 +183,8 @@ return {
           mode = { "n", "v" },
           { "<leader><tab>", group = "tabs" },
           { "<leader>c", group = "code" },
+          { "<leader>d", group = "debug" },
+          { "<leader>dp", group = "profiler" },
           { "<leader>f", group = "file/find" },
           { "<leader>g", group = "git" },
           { "<leader>gh", group = "hunks" },

--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -176,6 +176,7 @@ return {
     event = "VeryLazy",
     opts_extend = { "spec" },
     opts = {
+      preset = "helix",
       defaults = {},
       spec = {
         {

--- a/lua/lazyvim/plugins/extras/ai/copilot.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot.lua
@@ -58,57 +58,59 @@ return {
     end,
   },
 
-  -- copilot cmp source
-  {
-    "nvim-cmp",
-    optional = true,
-    dependencies = { -- this will only be evaluated if nvim-cmp is enabled
-      {
-        "zbirenbaum/copilot-cmp",
-        enabled = vim.g.ai_cmp, -- only enable if wanted
-        opts = {},
-        config = function(_, opts)
-          local copilot_cmp = require("copilot_cmp")
-          copilot_cmp.setup(opts)
-          -- attach cmp source whenever copilot attaches
-          -- fixes lazy-loading issues with the copilot cmp source
-          LazyVim.lsp.on_attach(function()
-            copilot_cmp._on_insert_enter({})
-          end, "copilot")
-        end,
-        specs = {
-          {
-            "nvim-cmp",
-            optional = true,
-            ---@param opts cmp.ConfigSchema
-            opts = function(_, opts)
-              table.insert(opts.sources, 1, {
-                name = "copilot",
-                group_index = 1,
-                priority = 100,
-              })
-            end,
+  vim.g.ai_cmp
+      and {
+        -- copilot cmp source
+        {
+          "nvim-cmp",
+          optional = true,
+          dependencies = { -- this will only be evaluated if nvim-cmp is enabled
+            {
+              "zbirenbaum/copilot-cmp",
+              opts = {},
+              config = function(_, opts)
+                local copilot_cmp = require("copilot_cmp")
+                copilot_cmp.setup(opts)
+                -- attach cmp source whenever copilot attaches
+                -- fixes lazy-loading issues with the copilot cmp source
+                LazyVim.lsp.on_attach(function()
+                  copilot_cmp._on_insert_enter({})
+                end, "copilot")
+              end,
+              specs = {
+                {
+                  "nvim-cmp",
+                  optional = true,
+                  ---@param opts cmp.ConfigSchema
+                  opts = function(_, opts)
+                    table.insert(opts.sources, 1, {
+                      name = "copilot",
+                      group_index = 1,
+                      priority = 100,
+                    })
+                  end,
+                },
+              },
+            },
           },
         },
-      },
-    },
-  },
-
-  vim.g.ai_cmp and {
-    "saghen/blink.cmp",
-    optional = true,
-    dependencies = { "giuxtaposition/blink-cmp-copilot" },
-    opts = {
-      sources = {
-        default = { "copilot" },
-        providers = {
-          copilot = {
-            name = "copilot",
-            module = "blink-cmp-copilot",
-            kind = "Copilot",
+        {
+          "saghen/blink.cmp",
+          optional = true,
+          dependencies = { "giuxtaposition/blink-cmp-copilot" },
+          opts = {
+            sources = {
+              default = { "copilot" },
+              providers = {
+                copilot = {
+                  name = "copilot",
+                  module = "blink-cmp-copilot",
+                  kind = "Copilot",
+                },
+              },
+            },
           },
         },
-      },
-    },
-  } or nil,
+      }
+    or nil,
 }

--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -7,10 +7,6 @@ end
 
 return {
   {
-    "hrsh7th/nvim-cmp",
-    enabled = false,
-  },
-  {
     "saghen/blink.cmp",
     version = not vim.g.lazyvim_blink_main and "*",
     build = vim.g.lazyvim_blink_main and "cargo build --release",

--- a/lua/lazyvim/plugins/extras/coding/nvim-cmp.lua
+++ b/lua/lazyvim/plugins/extras/coding/nvim-cmp.lua
@@ -48,6 +48,7 @@ return {
           end,
         }),
         sources = cmp.config.sources({
+          { name = "lazydev" },
           { name = "nvim_lsp" },
           { name = "path" },
         }, {
@@ -86,19 +87,9 @@ return {
     main = "lazyvim.util.cmp",
   },
 
-  -- Add lazydev source to cmp
-  {
-    "hrsh7th/nvim-cmp",
-    optional = true,
-    opts = function(_, opts)
-      table.insert(opts.sources, { name = "lazydev", group_index = 0 })
-    end,
-  },
-
   -- snippets
   {
     "nvim-cmp",
-    optional = true,
     dependencies = {
       {
         "garymjr/nvim-snippets",

--- a/lua/lazyvim/plugins/extras/coding/nvim-cmp.lua
+++ b/lua/lazyvim/plugins/extras/coding/nvim-cmp.lua
@@ -1,0 +1,122 @@
+return {
+
+  -- Setup nvim-cmp
+  {
+    "hrsh7th/nvim-cmp",
+    version = false, -- last release is way too old
+    event = "InsertEnter",
+    dependencies = {
+      "hrsh7th/cmp-nvim-lsp",
+      "hrsh7th/cmp-buffer",
+      "hrsh7th/cmp-path",
+    },
+    -- Not all LSP servers add brackets when completing a function.
+    -- To better deal with this, LazyVim adds a custom option to cmp,
+    -- that you can configure. For example:
+    --
+    -- ```lua
+    -- opts = {
+    --   auto_brackets = { "python" }
+    -- }
+    -- ```
+    opts = function()
+      vim.api.nvim_set_hl(0, "CmpGhostText", { link = "Comment", default = true })
+      local cmp = require("cmp")
+      local defaults = require("cmp.config.default")()
+      local auto_select = true
+      return {
+        auto_brackets = {}, -- configure any filetype to auto add brackets
+        completion = {
+          completeopt = "menu,menuone,noinsert" .. (auto_select and "" or ",noselect"),
+        },
+        preselect = auto_select and cmp.PreselectMode.Item or cmp.PreselectMode.None,
+        mapping = cmp.mapping.preset.insert({
+          ["<C-b>"] = cmp.mapping.scroll_docs(-4),
+          ["<C-f>"] = cmp.mapping.scroll_docs(4),
+          ["<C-n>"] = cmp.mapping.select_next_item({ behavior = cmp.SelectBehavior.Insert }),
+          ["<C-p>"] = cmp.mapping.select_prev_item({ behavior = cmp.SelectBehavior.Insert }),
+          ["<C-Space>"] = cmp.mapping.complete(),
+          ["<CR>"] = LazyVim.cmp.confirm({ select = auto_select }),
+          ["<C-y>"] = LazyVim.cmp.confirm({ select = true }),
+          ["<S-CR>"] = LazyVim.cmp.confirm({ behavior = cmp.ConfirmBehavior.Replace }), -- Accept currently selected item. Set `select` to `false` to only confirm explicitly selected items.
+          ["<C-CR>"] = function(fallback)
+            cmp.abort()
+            fallback()
+          end,
+          ["<tab>"] = function(fallback)
+            return LazyVim.cmp.map({ "snippet_forward", "ai_accept" }, fallback)()
+          end,
+        }),
+        sources = cmp.config.sources({
+          { name = "nvim_lsp" },
+          { name = "path" },
+        }, {
+          { name = "buffer" },
+        }),
+        formatting = {
+          format = function(entry, item)
+            local icons = LazyVim.config.icons.kinds
+            if icons[item.kind] then
+              item.kind = icons[item.kind] .. item.kind
+            end
+
+            local widths = {
+              abbr = vim.g.cmp_widths and vim.g.cmp_widths.abbr or 40,
+              menu = vim.g.cmp_widths and vim.g.cmp_widths.menu or 30,
+            }
+
+            for key, width in pairs(widths) do
+              if item[key] and vim.fn.strdisplaywidth(item[key]) > width then
+                item[key] = vim.fn.strcharpart(item[key], 0, width - 1) .. "…"
+              end
+            end
+
+            return item
+          end,
+        },
+        experimental = {
+          -- only show ghost text when we show ai completions
+          ghost_text = vim.g.ai_cmp and {
+            hl_group = "CmpGhostText",
+          } or false,
+        },
+        sorting = defaults.sorting,
+      }
+    end,
+    main = "lazyvim.util.cmp",
+  },
+
+  -- Add lazydev source to cmp
+  {
+    "hrsh7th/nvim-cmp",
+    optional = true,
+    opts = function(_, opts)
+      table.insert(opts.sources, { name = "lazydev", group_index = 0 })
+    end,
+  },
+
+  -- snippets
+  {
+    "nvim-cmp",
+    optional = true,
+    dependencies = {
+      {
+        "garymjr/nvim-snippets",
+        opts = {
+          friendly_snippets = true,
+        },
+        dependencies = { "rafamadriz/friendly-snippets" },
+      },
+    },
+    opts = function(_, opts)
+      opts.snippet = {
+        expand = function(item)
+          return LazyVim.cmp.expand(item.body)
+        end,
+      }
+      if LazyVim.has("nvim-snippets") then
+        table.insert(opts.sources, { name = "snippets" })
+      end
+    end,
+  },
+}

--- a/lua/lazyvim/plugins/extras/dap/core.lua
+++ b/lua/lazyvim/plugins/extras/dap/core.lua
@@ -33,7 +33,6 @@ return {
 
     -- stylua: ignore
     keys = {
-      { "<leader>d", "", desc = "+debug", mode = {"n", "v"} },
       { "<leader>dB", function() require("dap").set_breakpoint(vim.fn.input('Breakpoint condition: ')) end, desc = "Breakpoint Condition" },
       { "<leader>db", function() require("dap").toggle_breakpoint() end, desc = "Toggle Breakpoint" },
       { "<leader>dc", function() require("dap").continue() end, desc = "Run/Continue" },
@@ -46,7 +45,7 @@ return {
       { "<leader>dl", function() require("dap").run_last() end, desc = "Run Last" },
       { "<leader>do", function() require("dap").step_out() end, desc = "Step Out" },
       { "<leader>dO", function() require("dap").step_over() end, desc = "Step Over" },
-      { "<leader>dp", function() require("dap").pause() end, desc = "Pause" },
+      { "<leader>dP", function() require("dap").pause() end, desc = "Pause" },
       { "<leader>dr", function() require("dap").repl.toggle() end, desc = "Toggle REPL" },
       { "<leader>ds", function() require("dap").session() end, desc = "Session" },
       { "<leader>dt", function() require("dap").terminate() end, desc = "Terminate" },

--- a/lua/lazyvim/plugins/extras/lang/git.lua
+++ b/lua/lazyvim/plugins/extras/lang/git.lua
@@ -10,6 +10,7 @@ return {
 
   {
     "nvim-cmp",
+    optional = true,
     dependencies = {
       { "petertriho/cmp-git", opts = {} },
     },

--- a/lua/lazyvim/plugins/extras/ui/indent-blankline.lua
+++ b/lua/lazyvim/plugins/extras/ui/indent-blankline.lua
@@ -1,0 +1,51 @@
+return {
+  -- disable snacks indent when animate is enabled
+  {
+    "snacks.nvim",
+    opts = {
+      indent = { enabled = false },
+    },
+  },
+  {
+    "lukas-reineke/indent-blankline.nvim",
+    event = "LazyFile",
+    opts = function()
+      Snacks.toggle({
+        name = "Indention Guides",
+        get = function()
+          return require("ibl.config").get_config(0).enabled
+        end,
+        set = function(state)
+          require("ibl").setup_buffer(0, { enabled = state })
+        end,
+      }):map("<leader>ug")
+
+      return {
+        indent = {
+          char = "│",
+          tab_char = "│",
+        },
+        scope = { show_start = false, show_end = false },
+        exclude = {
+          filetypes = {
+            "Trouble",
+            "alpha",
+            "dashboard",
+            "help",
+            "lazy",
+            "mason",
+            "neo-tree",
+            "notify",
+            "snacks_dashboard",
+            "snacks_notif",
+            "snacks_terminal",
+            "snacks_win",
+            "toggleterm",
+            "trouble",
+          },
+        },
+      }
+    end,
+    main = "ibl",
+  },
+}

--- a/lua/lazyvim/plugins/extras/ui/indent-blankline.lua
+++ b/lua/lazyvim/plugins/extras/ui/indent-blankline.lua
@@ -1,5 +1,5 @@
 return {
-  -- disable snacks indent when animate is enabled
+  -- disable snacks indent when indent-blankline is enabled
   {
     "snacks.nvim",
     opts = {

--- a/lua/lazyvim/plugins/extras/ui/mini-animate.lua
+++ b/lua/lazyvim/plugins/extras/ui/mini-animate.lua
@@ -1,54 +1,64 @@
 -- animations
 return {
-  "echasnovski/mini.animate",
-  recommended = true,
-  event = "VeryLazy",
-  cond = vim.g.neovide == nil,
-  opts = function(_, opts)
-    -- don't use animate when scrolling with the mouse
-    local mouse_scrolled = false
-    for _, scroll in ipairs({ "Up", "Down" }) do
-      local key = "<ScrollWheel" .. scroll .. ">"
-      vim.keymap.set({ "", "i" }, key, function()
-        mouse_scrolled = true
-        return key
-      end, { expr = true })
-    end
+  -- disable snacks scroll when animate is enabled
+  {
+    "snacks.nvim",
+    opts = {
+      scroll = { enabled = false },
+    },
+  },
 
-    vim.api.nvim_create_autocmd("FileType", {
-      pattern = "grug-far",
-      callback = function()
-        vim.b.minianimate_disable = true
-      end,
-    })
+  -- setup animate
+  {
+    "echasnovski/mini.animate",
+    event = "VeryLazy",
+    cond = vim.g.neovide == nil,
+    opts = function(_, opts)
+      -- don't use animate when scrolling with the mouse
+      local mouse_scrolled = false
+      for _, scroll in ipairs({ "Up", "Down" }) do
+        local key = "<ScrollWheel" .. scroll .. ">"
+        vim.keymap.set({ "", "i" }, key, function()
+          mouse_scrolled = true
+          return key
+        end, { expr = true })
+      end
 
-    Snacks.toggle({
-      name = "Mini Animate",
-      get = function()
-        return not vim.g.minianimate_disable
-      end,
-      set = function(state)
-        vim.g.minianimate_disable = not state
-      end,
-    }):map("<leader>ua")
+      vim.api.nvim_create_autocmd("FileType", {
+        pattern = "grug-far",
+        callback = function()
+          vim.b.minianimate_disable = true
+        end,
+      })
 
-    local animate = require("mini.animate")
-    return vim.tbl_deep_extend("force", opts, {
-      resize = {
-        timing = animate.gen_timing.linear({ duration = 50, unit = "total" }),
-      },
-      scroll = {
-        timing = animate.gen_timing.linear({ duration = 150, unit = "total" }),
-        subscroll = animate.gen_subscroll.equal({
-          predicate = function(total_scroll)
-            if mouse_scrolled then
-              mouse_scrolled = false
-              return false
-            end
-            return total_scroll > 1
-          end,
-        }),
-      },
-    })
-  end,
+      Snacks.toggle({
+        name = "Mini Animate",
+        get = function()
+          return not vim.g.minianimate_disable
+        end,
+        set = function(state)
+          vim.g.minianimate_disable = not state
+        end,
+      }):map("<leader>ua")
+
+      local animate = require("mini.animate")
+      return vim.tbl_deep_extend("force", opts, {
+        resize = {
+          timing = animate.gen_timing.linear({ duration = 50, unit = "total" }),
+        },
+        scroll = {
+          timing = animate.gen_timing.linear({ duration = 150, unit = "total" }),
+          subscroll = animate.gen_subscroll.equal({
+            predicate = function(total_scroll)
+              if mouse_scrolled then
+                mouse_scrolled = false
+                return false
+              end
+              return total_scroll > 1
+            end,
+          }),
+        },
+      })
+    end,
+  },
 }

--- a/lua/lazyvim/plugins/init.lua
+++ b/lua/lazyvim/plugins/init.lua
@@ -10,16 +10,6 @@ end
 
 require("lazyvim.config").init()
 
--- Terminal Mappings
-local function term_nav(dir)
-  ---@param self snacks.terminal
-  return function(self)
-    return self:is_floating() and "<c-" .. dir .. ">" or vim.schedule(function()
-      vim.cmd.wincmd(dir)
-    end)
-  end
-end
-
 return {
   { "folke/lazy.nvim", version = "*" },
   { "LazyVim/LazyVim", priority = 10000, lazy = false, opts = {}, cond = true, version = "*" },
@@ -27,37 +17,7 @@ return {
     "folke/snacks.nvim",
     priority = 1000,
     lazy = false,
-    opts = function()
-      ---@type snacks.Config
-      return {
-        bigfile = { enabled = true },
-        notifier = { enabled = true },
-        quickfile = { enabled = true },
-        statuscolumn = { enabled = false }, -- we set this in options.lua
-        scroll = { enabled = true },
-        scope = { enabled = true },
-        indent = { enabled = true },
-        terminal = {
-          win = {
-            keys = {
-              nav_h = { "<C-h>", term_nav("h"), desc = "Go to Left Window", expr = true, mode = "t" },
-              nav_j = { "<C-j>", term_nav("j"), desc = "Go to Lower Window", expr = true, mode = "t" },
-              nav_k = { "<C-k>", term_nav("k"), desc = "Go to Upper Window", expr = true, mode = "t" },
-              nav_l = { "<C-l>", term_nav("l"), desc = "Go to Right Window", expr = true, mode = "t" },
-            },
-          },
-        },
-        toggle = { map = LazyVim.safe_keymap_set },
-        words = { enabled = true },
-      }
-    end,
-    -- stylua: ignore
-    keys = {
-      { "<leader>.",  function() Snacks.scratch() end, desc = "Toggle Scratch Buffer" },
-      { "<leader>S",  function() Snacks.scratch.select() end, desc = "Select Scratch Buffer" },
-      { "<leader>n", function() Snacks.notifier.show_history() end, desc = "Notification History" },
-      { "<leader>un", function() Snacks.notifier.hide() end, desc = "Dismiss All Notifications" },
-    },
+    opts = {},
     config = function(_, opts)
       local notify = vim.notify
       require("snacks").setup(opts)

--- a/lua/lazyvim/plugins/init.lua
+++ b/lua/lazyvim/plugins/init.lua
@@ -34,6 +34,7 @@ return {
         notifier = { enabled = true },
         quickfile = { enabled = true },
         statuscolumn = { enabled = false }, -- we set this in options.lua
+        indent = { enabled = true },
         terminal = {
           win = {
             keys = {

--- a/lua/lazyvim/plugins/init.lua
+++ b/lua/lazyvim/plugins/init.lua
@@ -34,6 +34,7 @@ return {
         notifier = { enabled = true },
         quickfile = { enabled = true },
         statuscolumn = { enabled = false }, -- we set this in options.lua
+        scroll = { enabled = true },
         indent = { enabled = true },
         terminal = {
           win = {

--- a/lua/lazyvim/plugins/init.lua
+++ b/lua/lazyvim/plugins/init.lua
@@ -35,6 +35,7 @@ return {
         quickfile = { enabled = true },
         statuscolumn = { enabled = false }, -- we set this in options.lua
         scroll = { enabled = true },
+        scope = { enabled = true },
         indent = { enabled = true },
         terminal = {
           win = {

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -109,25 +109,25 @@ return {
             {
               function() return require("noice").api.status.command.get() end,
               cond = function() return package.loaded["noice"] and require("noice").api.status.command.has() end,
-              color = function() return LazyVim.ui.fg("Statement") end,
+              color = function() return { fg = Snacks.util.color("Statement") } end,
             },
             -- stylua: ignore
             {
               function() return require("noice").api.status.mode.get() end,
               cond = function() return package.loaded["noice"] and require("noice").api.status.mode.has() end,
-              color = function() return LazyVim.ui.fg("Constant") end,
+              color = function() return { fg = Snacks.util.color("Constant") } end,
             },
             -- stylua: ignore
             {
               function() return "  " .. require("dap").status() end,
               cond = function() return package.loaded["dap"] and require("dap").status() ~= "" end,
-              color = function() return LazyVim.ui.fg("Debug") end,
+              color = function() return { fg = Snacks.util.color("Debug") } end,
             },
             -- stylua: ignore
             {
               require("lazy.status").updates,
               cond = require("lazy.status").has_updates,
-              color = function() return LazyVim.ui.fg("Special") end,
+              color = function() return { fg = Snacks.util.color("Special") } end,
             },
             {
               "diff",

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -278,8 +278,6 @@ return {
     },
     -- stylua: ignore
     keys = {
-      { "<leader>.",  function() Snacks.scratch() end, desc = "Toggle Scratch Buffer" },
-      { "<leader>S",  function() Snacks.scratch.select() end, desc = "Select Scratch Buffer" },
       { "<leader>n", function() Snacks.notifier.show_history() end, desc = "Notification History" },
       { "<leader>un", function() Snacks.notifier.hide() end, desc = "Dismiss All Notifications" },
     },

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -105,6 +105,7 @@ return {
             { LazyVim.lualine.pretty_path() },
           },
           lualine_x = {
+            Snacks.profiler.status(),
             -- stylua: ignore
             {
               function() return require("noice").api.status.command.get() end,

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -268,6 +268,7 @@ return {
     "snacks.nvim",
     opts = {
       indent = { enabled = true },
+      input = { enabled = true },
       notifier = { enabled = true },
       scope = { enabled = true },
       scroll = { enabled = true },

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -185,50 +185,6 @@ return {
     end,
   },
 
-  -- indent guides for Neovim
-  {
-    "lukas-reineke/indent-blankline.nvim",
-    event = "LazyFile",
-    opts = function()
-      Snacks.toggle({
-        name = "Indention Guides",
-        get = function()
-          return require("ibl.config").get_config(0).enabled
-        end,
-        set = function(state)
-          require("ibl").setup_buffer(0, { enabled = state })
-        end,
-      }):map("<leader>ug")
-
-      return {
-        indent = {
-          char = "│",
-          tab_char = "│",
-        },
-        scope = { show_start = false, show_end = false },
-        exclude = {
-          filetypes = {
-            "Trouble",
-            "alpha",
-            "dashboard",
-            "help",
-            "lazy",
-            "mason",
-            "neo-tree",
-            "notify",
-            "snacks_dashboard",
-            "snacks_notif",
-            "snacks_terminal",
-            "snacks_win",
-            "toggleterm",
-            "trouble",
-          },
-        },
-      }
-    end,
-    main = "ibl",
-  },
-
   -- Highly experimental plugin that completely replaces the UI for messages, cmdline and the popupmenu.
   {
     "folke/noice.nvim",

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -265,7 +265,27 @@ return {
   { "MunifTanjim/nui.nvim", lazy = true },
 
   {
-    "folke/snacks.nvim",
+    "snacks.nvim",
+    opts = {
+      indent = { enabled = true },
+      notifier = { enabled = true },
+      scope = { enabled = true },
+      scroll = { enabled = true },
+      statuscolumn = { enabled = false }, -- we set this in options.lua
+      toggle = { map = LazyVim.safe_keymap_set },
+      words = { enabled = true },
+    },
+    -- stylua: ignore
+    keys = {
+      { "<leader>.",  function() Snacks.scratch() end, desc = "Toggle Scratch Buffer" },
+      { "<leader>S",  function() Snacks.scratch.select() end, desc = "Select Scratch Buffer" },
+      { "<leader>n", function() Snacks.notifier.show_history() end, desc = "Notification History" },
+      { "<leader>un", function() Snacks.notifier.hide() end, desc = "Dismiss All Notifications" },
+    },
+  },
+
+  {
+    "snacks.nvim",
     opts = {
       dashboard = {
         preset = {

--- a/lua/lazyvim/plugins/util.lua
+++ b/lua/lazyvim/plugins/util.lua
@@ -27,6 +27,12 @@ return {
         },
       },
     },
+    -- stylua: ignore
+    keys = {
+      { "<leader>.",  function() Snacks.scratch() end, desc = "Toggle Scratch Buffer" },
+      { "<leader>S",  function() Snacks.scratch.select() end, desc = "Select Scratch Buffer" },
+      { "<leader>dps", function() Snacks.profiler.scratch() end, desc = "Profiler Scratch Buffer" },
+    },
   },
 
   -- Session management. This saves your session in the background,

--- a/lua/lazyvim/plugins/util.lua
+++ b/lua/lazyvim/plugins/util.lua
@@ -1,4 +1,33 @@
+-- Terminal Mappings
+local function term_nav(dir)
+  ---@param self snacks.terminal
+  return function(self)
+    return self:is_floating() and "<c-" .. dir .. ">" or vim.schedule(function()
+      vim.cmd.wincmd(dir)
+    end)
+  end
+end
+
 return {
+
+  -- Snacks utils
+  {
+    "snacks.nvim",
+    opts = {
+      bigfile = { enabled = true },
+      quickfile = { enabled = true },
+      terminal = {
+        win = {
+          keys = {
+            nav_h = { "<C-h>", term_nav("h"), desc = "Go to Left Window", expr = true, mode = "t" },
+            nav_j = { "<C-j>", term_nav("j"), desc = "Go to Lower Window", expr = true, mode = "t" },
+            nav_k = { "<C-k>", term_nav("k"), desc = "Go to Upper Window", expr = true, mode = "t" },
+            nav_l = { "<C-l>", term_nav("l"), desc = "Go to Right Window", expr = true, mode = "t" },
+          },
+        },
+      },
+    },
+  },
 
   -- Session management. This saves your session in the background,
   -- keeping track of open buffers, window arrangement, and more.

--- a/lua/lazyvim/util/deprecated.lua
+++ b/lua/lazyvim/util/deprecated.lua
@@ -13,6 +13,12 @@ M.moved = {
   ui = {
     statuscolumn = { "Snacks.statuscolumn" },
     bufremove = { "Snacks.bufdelete" },
+    fg = {
+      "{ fg = Snacks.util.color(...) }",
+      fn = function(...)
+        return { fg = Snacks.util.color(...) }
+      end,
+    },
   },
 }
 
@@ -33,6 +39,9 @@ function M.decorate(name, mod)
       if M.moved[name][k] then
         local to = M.moved[name][k][1]
         LazyVim.deprecate("LazyVim." .. name .. "." .. k, to)
+        if M.moved[name][k].fn then
+          return M.moved[name][k].fn
+        end
         local ret = vim.tbl_get(_G, unpack(vim.split(to, ".", { plain = true })))
         return ret
       end

--- a/lua/lazyvim/util/init.lua
+++ b/lua/lazyvim/util/init.lua
@@ -265,4 +265,13 @@ function M.memoize(fn)
   end
 end
 
+---@return "nvim-cmp" | "blink.cmp"
+function M.cmp_engine()
+  vim.g.lazyvim_cmp = vim.g.lazyvim_cmp or "auto"
+  if vim.g.lazyvim_cmp == "auto" then
+    return LazyVim.has_extra("nvim-cmp") and "nvim-cmp" or "blink.cmp"
+  end
+  return vim.g.lazyvim_cmp
+end
+
 return M

--- a/lua/lazyvim/util/lualine.lua
+++ b/lua/lazyvim/util/lualine.lua
@@ -17,7 +17,7 @@ function M.status(icon, status)
       return status() ~= nil
     end,
     color = function()
-      return LazyVim.ui.fg(colors[status()] or colors.ok)
+      return { fg = Snacks.util.color(colors[status()] or colors.ok) }
     end,
   }
 end
@@ -146,7 +146,7 @@ function M.root_dir(opts)
     other = true,
     icon = "󱉭 ",
     color = function()
-      return LazyVim.ui.fg("Special")
+      return { fg = Snacks.util.color("Special") }
     end,
   }, opts or {})
 

--- a/lua/lazyvim/util/pick.lua
+++ b/lua/lazyvim/util/pick.lua
@@ -45,7 +45,7 @@ end
 function M.want()
   vim.g.lazyvim_picker = vim.g.lazyvim_picker or "auto"
   if vim.g.lazyvim_picker == "auto" then
-    return LazyVim.has_extra("editor.fzf") and "fzf" or "telescope"
+    return LazyVim.has_extra("editor.telescope") and "telescope" or "fzf"
   end
   return vim.g.lazyvim_picker
 end

--- a/lua/lazyvim/util/pick.lua
+++ b/lua/lazyvim/util/pick.lua
@@ -42,6 +42,7 @@ function M.register(picker)
   return true
 end
 
+---@return "telescope" | "fzf"
 function M.want()
   vim.g.lazyvim_picker = vim.g.lazyvim_picker or "auto"
   if vim.g.lazyvim_picker == "auto" then

--- a/lua/lazyvim/util/ui.lua
+++ b/lua/lazyvim/util/ui.lua
@@ -24,11 +24,4 @@ function M.foldexpr()
   return vim.b[buf].ts_folds and vim.treesitter.foldexpr() or "0"
 end
 
----@return {fg?:string}?
-function M.fg(name)
-  local hl = vim.api.nvim_get_hl(0, { name = name, link = false })
-  local fg = hl and hl.fg or hl.foreground
-  return fg and { fg = string.format("#%06x", fg) } or nil
-end
-
 return M

--- a/lua/lazyvim/util/ui.lua
+++ b/lua/lazyvim/util/ui.lua
@@ -31,48 +31,4 @@ function M.fg(name)
   return fg and { fg = string.format("#%06x", fg) } or nil
 end
 
-function M.maximize()
-  ---@type {k:string, v:any}[]?
-  local maximized = nil
-  local toggle = Snacks.toggle({
-    name = "Maximize",
-    get = function()
-      return maximized ~= nil
-    end,
-    set = function(state)
-      if state then
-        maximized = {}
-        local function set(k, v)
-          table.insert(maximized, 1, { k = k, v = vim.o[k] })
-          vim.o[k] = v
-        end
-        set("winwidth", 999)
-        set("winheight", 999)
-        set("winminwidth", 10)
-        set("winminheight", 4)
-        vim.cmd("wincmd =")
-      else
-        for _, opt in ipairs(maximized) do
-          vim.o[opt.k] = opt.v
-        end
-        maximized = nil
-        vim.cmd("wincmd =")
-      end
-    end,
-  })
-
-  -- `QuitPre` seems to be executed even if we quit a normal window, so we don't want that
-  -- `VimLeavePre` might be another consideration? Not sure about differences between the 2
-  vim.api.nvim_create_autocmd("ExitPre", {
-    group = vim.api.nvim_create_augroup("lazyvim_restore_max_exit_pre", { clear = true }),
-    desc = "Restore width/height when close Neovim while maximized",
-    callback = function()
-      if toggle:get() then
-        toggle:set(false)
-      end
-    end,
-  })
-  return toggle
-end
-
 return M


### PR DESCRIPTION
# What's new?

## 14.x

Big new release with a lot of changes and improvements!
Two new plugins have been added, and a lot of plugins have been replaced.
With these changes, default **LazyVim** is now just `34` plugins.

### Added Plugins

- [fzf-lua](https://github.com/ibhagwan/fzf-lua) as a replacement for [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
  - to use **telescope.nvim** instead, enable the `ui.telescope` extra
- [blink.cmp](https://github.com/saghm/blink.cmp) as a replacement for [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
  - to use **nvim-cmp** instead, enable the `nvim-cmp` extra

### Removed Plugins

- [dressing.nvim](https://github.com/stevearc/dressing.nvim) (replaced with [fzf-lua](https://github.com/ibhagwan/fzf-lua) and [snacks.input](https://github.com/folke/snacks.nvim))
- [telescope-fzf-native.nvim](https://github.com/nvim-telescope/telescope-fzf-native.nvim) (replaced with [fzf-lua](https://github.com/ibhagwan/fzf-lua))
- [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) (replaced with [fzf-lua](https://github.com/ibhagwan/fzf-lua))
- [indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim) (replaced with [snacks.indent](https://github.com/Folke/snacks.nvim))
  - to use **indent-blankline.nvim** instead, enable the `indent-blankline` extra
- [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) (replaced with [blink](https://github.com/Saghen/blink.cmp))
- [nvim-snippets](https://github.com/hrsh7th/vim-vsnip) (replaced with [blink](https://github.com/Saghen/blink.cmp))
- [cmp-buffer](https://github.com/hrsh7th/cmp-buffer) (replaced with [blink](https://github.com/Saghen/blink.cmp))
- [cmp-nvim-lsp](https://github.com/hrsh7th/cmp-nvim-lsp) (replaced with [blink](https://github.com/Saghen/blink.cmp))
- [cmp-path](https://github.com/hrsh7th/cmp-path) (replaced with [blink](https://github.com/Saghen/blink.cmp))

### Changes

- added [`snacks.input`](https://github.com/folke/snacks.nvim/blob/main/docs/input.md)
- added [`snacks.scroll`](https://github.com/folke/snacks.nvim/blob/main/docs/scroll.md)
- added [`snacks.indent`](https://github.com/folke/snacks.nvim/blob/main/docs/indent.md)
- added [`snacks.scope`](https://github.com/folke/snacks.nvim/blob/main/docs/scope.md)
- added [`snacks.dim`](https://github.com/folke/snacks.nvim/blob/main/docs/dim.md)
- added [`snacks.zen`](https://github.com/folke/snacks.nvim/blob/main/docs/zen.md)
- changed default [`which-key`](https://github.com/folke/which-key.nvim) preset to `helix`
- drop `LazyVim.ui.fg` in favor of [`Snacks.util.color`](https://github.com/folke/snacks.nvim/blob/main/docs/util.md)

To disable **all animations**, add the following to your `options.lua`:

```lua
vim.g.snacks_animate = false
```

### Keymaps

- `<leader>z` to toggle [zen mode](https://github.com/folke/snacks.nvim/blob/main/docs/zen.md)
- `<leader>Z` to toggle [zoom mode](https://github.com/folke/snacks.nvim/blob/main/docs/zen.md)
- `<leader>uD` to toggle [dimming](https://github.com/folke/snacks.nvim/blob/main/docs/dim.md)
- `<leader>ua` to toggle [animations](https://github.com/folke/snacks.nvim/blob/main/docs/animate.md)
- `<leader>uS` to toggle [scroll](https://github.com/folke/snacks.nvim/blob/main/docs/scroll.md)
- `<leader>ug` to toggle [indent guides](https://github.com/folke/snacks.nvim/blob/main/docs/indent.md)
- [`snacks.profiler`](https://github.com/folke/snacks.nvim/blob/main/docs/profiler.md) keymaps under `<leader>dp`
