### PR TITLE
fix(clangd): avoid nil-indexing the completion sorting comparators

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -105,6 +105,8 @@ return {
   {
     "hrsh7th/nvim-cmp",
     opts = function(_, opts)
+      opts.sorting = opts.sorting or {}
+      opts.sorting.comparators = opts.sorting.comparators or {}
       table.insert(opts.sorting.comparators, 1, require("clangd_extensions.cmp_scores"))
     end,
   },


### PR DESCRIPTION
## Description

This prevents the following popup appearing when opening nvim:

```
Failed to run `config` for nvim-cmp

.../lazy/LazyVim/lua/lazyvim/plugins/extras/lang/clangd.lua:108: attempt to index field 'sorting' (a nil value)

# stacktrace:
  - /LazyVim/lua/lazyvim/plugins/extras/lang/clangd.lua:108 _in_ **values**
  - ~/.config/nvim/lua/config/lazy.lua:17
  - ~/.config/nvim/init.lua:2
  
```

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
