### PR TITLE
fix(java): only setup debug adapter config if mason is installed

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -148,7 +148,12 @@ return {
       -- if nvim-dap is enabled with java debug/test.
       local mason_registry = require("mason-registry")
       local bundles = {} ---@type string[]
-      if opts.dap and LazyVim.has("nvim-dap") and mason_registry.is_installed("java-debug-adapter") then
+      if
+        LazyVim.has("mason.nvim")
+        and opts.dap
+        and LazyVim.has("nvim-dap")
+        and mason_registry.is_installed("java-debug-adapter")
+      then
         local java_dbg_pkg = mason_registry.get_package("java-debug-adapter")
         local java_dbg_path = java_dbg_pkg:get_install_path()
         local jar_patterns = {
@@ -240,7 +245,12 @@ return {
               },
             })
 
-            if opts.dap and LazyVim.has("nvim-dap") and mason_registry.is_installed("java-debug-adapter") then
+            if
+              LazyVim.has("mason.nvim")
+              and opts.dap
+              and LazyVim.has("nvim-dap")
+              and mason_registry.is_installed("java-debug-adapter")
+            then
               -- custom init for Java debugger
               require("jdtls").setup_dap(opts.dap)
               require("jdtls.dap").setup_dap_main_class_configs(opts.dap_main)


### PR DESCRIPTION
## Description
This prevents the following error when opening java files when mason is disabled (e.g: NixOS)

```
Failed to run `config` for nvim-jdtls

...im/lazy/LazyVim/lua/lazyvim/plugins/extras/lang/java.lua:149: module 'mason-registry' not found:
	no field package.preload['mason-registry']
cache_loader: module mason-registry not found
cache_loader_lib: module mason-registry not found
	no file '/nix/store/j3563y13yim4m7qdwk0m8h22648wbifj-luajit-2.1.1713773202-env/share/lua/5.1/mason-registry.lua'
	no file '/nix/store/j3563y13yim4m7qdwk0m8h22648wbifj-luajit-2.1.1713773202-env/share/lua/5.1/mason-registry/init.lua'
	no file '/nix/store/j3563y13yim4m7qdwk0m8h22648wbifj-luajit-2.1.1713773202-env/lib/lua/5.1/mason-registry.so'

# stacktrace:
  - /LazyVim/lua/lazyvim/plugins/extras/lang/java.lua:149 _in_ **config**
  - /nix/store/xgn4baapvvk35ssi47bsmmyawl83917g-neovim-unwrapped-0.10.2/share/nvim/runtime/filetype.lua:36
  - /nix/store/xgn4baapvvk35ssi47bsmmyawl83917g-neovim-unwrapped-0.10.2/share/nvim/runtime/filetype.lua:35
```

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
