### PR TITLE
feat(plugins): add vim-sleuth

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -385,6 +385,11 @@ return {
     },
   },
 
+  -- Heuristically set buffer options (tab size, expand tabs to spaces)
+  {
+    "tpope/vim-sleuth",
+  },
+
   {
     import = "lazyvim.plugins.extras.editor.fzf",
     enabled = function()


### PR DESCRIPTION
## Description

This PR adds a new plugin: [vim-sleuth](https://github.com/tpope/vim-sleuth), a tpope classic.

LazyVim lists, in it's feature-set, the ability to "Transform your Neovim into a full-fledged IDE". A very common (and useful) feature in IDEs is "detect indentation", which automatically changes your tab-size and preferred tab-method to match the currently opened file. `vim-sleuth` beautifully provides that feature, requiring no tweaking out of the box.

I think it makes sense to add this plugin as one more "IDE emulation" feature that LazyVim already has many of (Tree-based file explorer panel, search by file with preview, code completion popup, tabs, etc.) - it was in fact one of the first additions I made to my config after installing LazyVim, since I came from VsCode.

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
