### PR TITLE
fix(blink): unset provider.kind

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -92,6 +92,8 @@ return {
           table.insert(enabled, source)
         end
       end
+
+      -- Unset custom prop to pass blink.cmp validation
       opts.sources.compat = nil
 
       -- check if we need to override symbol kinds
@@ -115,6 +117,9 @@ return {
             end
             return items
           end
+
+          -- Unset custom prop to pass blink.cmp validation
+          provider.kind = nil
         end
       end
 


### PR DESCRIPTION
## Description

Unsets `sources.providers[provider].kind` custom properties to pass blink.cmp config validation.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

![Screenshot 2024-12-12 at 23 21 47](https://github.com/user-attachments/assets/21866a51-d0d5-4ee5-9cc3-3ce7f2eb6415)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
