### PR TITLE
fix(supermaven): add supermaven to the completion provider list

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/supermaven.lua
+++ b/lua/lazyvim/plugins/extras/ai/supermaven.lua
@@ -49,6 +49,9 @@ return {
     dependencies = { "supermaven-nvim", "saghen/blink.compat" },
     opts = {
       sources = {
+        completion = {
+          enabled_providers = { "lsp", "path", "snippets", "buffer", "supermaven" },
+        },
         compat = { "supermaven" },
         providers = { supermaven = { kind = "Supermaven" } },
       },


### PR DESCRIPTION
I observed that Supermaven suggestions were not appearing because of a missing configuration setting.
