### PR TITLE
fix(blink): `draw.treesitter` expects table

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -53,7 +53,7 @@ return {
         },
         menu = {
           draw = {
-            treesitter = true,
+            treesitter = { "lsp" },
           },
         },
         documentation = {


### PR DESCRIPTION
## Description
If you would like to enable more sources feel free. I just went with the recommended setting in blink's default configuration. Although on their repo the have it to empty table, but I assumed since you had it to `true` you would at least want the `lsp` source.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
