### PR TITLE
feat(r): add blink support for cmp-r

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/r.lua
+++ b/lua/lazyvim/plugins/extras/lang/r.lua
@@ -53,15 +53,13 @@ return {
     dependencies = {
       "R-nvim/cmp-r",
     },
-    opts = function(_, opts)
-      table.insert(opts.sources.compat or {}, "cmp_r")
-
-      opts.sources.providers["cmp-r"] = vim.tbl_deep_extend(
-        "force",
-        opts.sources.providers["cmp-r"] or {},
-        { name = "cmp_r", module = "blink.compat.source" }
-      )
-    end,
+    opts = {
+      sources = {
+        compat = {
+          cmp_r = { name = "cmp_r", module = "blink.compat.source" },
+        },
+      },
+    },
   },
   {
     "hrsh7th/nvim-cmp",


### PR DESCRIPTION
## Description

The [blink.cmp](https://github.com/Saghen/blink.cmp) plugin is great but [cmp-r](https://github.com/R-nvim/cmp-r) support hasn't been added yet, which is present for [nvim-cmp](https://github.com/hrsh7th/nvim-cmp). This pull request implements this support.

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
