### PR TITLE
docs(NEWS): fix instruction to stay on nvim-cmp

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@ With these changes, default **LazyVim** is now just `34` plugins.
 - [fzf-lua](https://github.com/ibhagwan/fzf-lua) as a replacement for [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
   - to use **telescope.nvim** instead, enable the `editor.telescope` extra
 - [blink.cmp](https://github.com/saghen/blink.cmp) as a replacement for [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
-  - to use **nvim-cmp** instead, enable the `coding.nvim-cmp` extra
+  - to use **nvim-cmp** instead, set `vim.g.lazyvim_cmp = "nvim-cmp"`
 
 ### Removed Plugins
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Enabling the nvim-cmp extra does not disable the blink extra. Since these two extras disable each other, users are actually left with no completion engine.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
N/A

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
