### PR TITLE
fix(blink): allow user to overwrite `<Tab>` mapping

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -102,7 +102,7 @@ return {
       end
 
       -- fix super-tab completion
-      if opts.keymap.preset == "super-tab" then
+      if opts.keymap.preset == "super-tab" and not opts.keymap["<Tab>"] then
         opts.keymap["<Tab>"] = {
           function(cmp)
             if cmp.snippet_active() then


### PR DESCRIPTION
## Description
Users can't overwrite `<Tab>` mapping with recent [commit](https://github.com/LazyVim/LazyVim/commit/413566af591e9152f156944bff35c89d5d973148)
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #5095
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
