### PR TITLE
fix(vscode): disable animate in vscode

### DIFF
--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -7,7 +7,7 @@ vim.g.autoformat = true
 
 -- Snacks animations
 -- Set to `false` to globally disable all snacks animations
-vim.g.snacks_animate = true
+vim.g.snacks_animate = not vim.g.vscode
 
 -- LazyVim picker to use.
 -- Can be one of: telescope, fzf


### PR DESCRIPTION
## Description

Snacks smooth scroll and other animations cause conflicts in vscode. They should be disabled in vscode. Let me know if you'd instead want to make a change to the vscode extra. 

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
