### PR TITLE
fix(blink): <Tab> should respect manual selection

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -110,7 +110,7 @@ return {
         if opts.keymap.preset == "super-tab" then -- super-tab
           opts.keymap["<Tab>"] = {
             function(cmp)
-              if cmp.snippet_active() then
+              if cmp.snippet_active() or opts.completion.list.selection == "manual" then
                 return cmp.accept()
               else
                 return cmp.select_and_accept()


### PR DESCRIPTION
## Description

When the `completion.list.selection` option is set to `"manual"` the custom `<Tab>` keymap doesn't respect it and still selects and accepts the first option.

Simply ensuring `cmp.accept()` is triggered when this option is set (instead of `cmp.select_and_accept()`) works because `blink` internally checks whether a completion item is selected, and if it isn't it exits without executing anything.

## Related Issue(s)

none

## Screenshots

none

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
