### PR TITLE
refactor(blink): use upstream <Tab> keymap fn

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -109,13 +109,7 @@ return {
       if not opts.keymap["<Tab>"] then
         if opts.keymap.preset == "super-tab" then -- super-tab
           opts.keymap["<Tab>"] = {
-            function(cmp)
-              if cmp.snippet_active() then
-                return cmp.accept()
-              else
-                return cmp.select_and_accept()
-              end
-            end,
+            require("blink.cmp.keymap.presets")["super-tab"]["<Tab>"][1],
             LazyVim.cmp.map({ "snippet_forward", "ai_accept" }),
             "fallback",
           }


### PR DESCRIPTION
## Description

Replace re-defined super-tab `<Tab>` keymap function with the original upstream one, so upstream fixes can propagate.

Related to #5127 

## Related Issue(s)

none

## Screenshots

none

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
