### PR TITLE
refactor(blink): color swatch icon upstreamed

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -169,9 +169,7 @@ return {
     "saghen/blink.cmp",
     opts = function(_, opts)
       opts.appearance = opts.appearance or {}
-      opts.appearance.kind_icons = vim.tbl_extend("keep", {
-        Color = "██", -- Use block instead of icon for color items to make swatches more usable
-      }, LazyVim.config.icons.kinds)
+      opts.appearance.kind_icons = vim.tbl_extend("force", opts.appearance.kind_icons or {}, LazyVim.config.icons.kinds)
     end,
   },
 


### PR DESCRIPTION
## Description

I've upstreamed the block char vs. icon replacement for Tailwind colors so we shouldn't need this here anymore. I've replaced it by extending the default blink icons instead, just in case they introduce an icon which isn't yet covered by Lazy's, it would still show up (unlikely, but better, no?).

## Related Issue(s)

none

## Screenshots

none

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
