### PR TITLE
fix(go): update go.lua to eliminate fieldalignment from analyses

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -37,7 +37,6 @@ return {
                 rangeVariableTypes = true,
               },
               analyses = {
-                fieldalignment = true,
                 nilness = true,
                 unusedparams = true,
                 unusedwrite = true,


### PR DESCRIPTION
## Description

Removed a setting from the go lang plugin. The setting now just causes an error:
LSP[gopls] Invalid settings: setting option "analyses": this setting is deprecated, use "the 'fieldalignment' analyzer was removed in gopls/v0.17.0; instead, hover over struct fields to see size/offset information (https://go.dev/issue/66861)" instead

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.

Note: submitted similar request as f96aac6 but was rejected by CI/CD for naming reasons. Changing the name did not help. Retrying.