### PR TITLE
fix(fzf): fzf.lua compatible hidden scrollbar

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/fzf.lua
+++ b/lua/lazyvim/plugins/extras/editor/fzf.lua
@@ -89,9 +89,6 @@ return {
       return {
         "default-title",
         fzf_colors = true,
-        fzf_opts = {
-          ["--no-scrollbar"] = true,
-        },
         defaults = {
           -- formatter = "path.filename_first",
           formatter = "path.dirname_first",
@@ -115,6 +112,9 @@ return {
             winopts = {
               title = " " .. vim.trim((fzf_opts.prompt or "Select"):gsub("%s*:%s*$", "")) .. " ",
               title_pos = "center",
+              preview = {
+                scrollbar = false,
+              },
             },
           }, fzf_opts.kind == "codeaction" and {
             winopts = {


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
`--no-scrollbar` option is not supported by [fzf-lua](https://github.com/ibhagwan/fzf-lua)
The recommended way is to set `winopts.preview.scrollbar=false`

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
