### PR TITLE
fix(codeium): doesnt automatically load when `vim.g.ai_cmp` is set to false

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/codeium.lua
+++ b/lua/lazyvim/plugins/extras/ai/codeium.lua
@@ -4,6 +4,7 @@ return {
   {
     "Exafunction/codeium.nvim",
     cmd = "Codeium",
+    event = "InsertEnter",
     build = ":Codeium Auth",
     opts = {
       enable_cmp_source = vim.g.ai_cmp,


### PR DESCRIPTION
## Description

I think the title of the PR says it all. Before the user has to manually load/trigger the plugin via the cmd (`:Codeium Auth`) or by requiring.

PS: The copilot extra also has this event.

~~PPS: Ive also noticed that supermaven doesnt have this event setup, perhaps it suffers to the same issue when this option is disabled?~~

Edit:
For the PPS, have tested supermaven, i can confirm, it loads properly.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
