### PR TITLE
fix(ai): mappings for accept when `ai_cmp=false`

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/codeium.lua
+++ b/lua/lazyvim/plugins/extras/ai/codeium.lua
@@ -11,9 +11,7 @@ return {
       virtual_text = {
         enabled = not vim.g.ai_cmp,
         key_bindings = {
-          accept = false, -- handled by nvim-cmp / blink.cmp
-          next = "<M-]>",
-          prev = "<M-[>",
+          accept = not vim.g.ai_cmp and "<M-l>" or false, -- handled by nvim-cmp / blink.cmp
         },
       },
     },
@@ -39,11 +37,13 @@ return {
     optional = true,
     dependencies = { "codeium.nvim" },
     opts = function(_, opts)
-      table.insert(opts.sources, 1, {
-        name = "codeium",
-        group_index = 1,
-        priority = 100,
-      })
+      if vim.g.ai_cmp then
+        table.insert(opts.sources, 1, {
+          name = "codeium",
+          group_index = 1,
+          priority = 100,
+        })
+      end
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/ai/copilot.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot.lua
@@ -11,9 +11,7 @@ return {
         enabled = not vim.g.ai_cmp,
         auto_trigger = true,
         keymap = {
-          accept = false, -- handled by nvim-cmp / blink.cmp
-          next = "<M-]>",
-          prev = "<M-[>",
+          accept = not vim.g.ai_cmp and "<M-l>" or false, -- handled by nvim-cmp / blink.cmp
         },
       },
       panel = { enabled = false },

--- a/lua/lazyvim/plugins/extras/ai/supermaven.lua
+++ b/lua/lazyvim/plugins/extras/ai/supermaven.lua
@@ -8,7 +8,7 @@ return {
     },
     opts = {
       keymaps = {
-        accept_suggestion = nil, -- handled by nvim-cmp / blink.cmp
+        accept_suggestion = not vim.g.ai_cmp and "<M-l>" or nil, -- handled by nvim-cmp / blink.cmp
       },
       disable_inline_completion = vim.g.ai_cmp,
       ignore_filetypes = { "bigfile", "snacks_input", "snacks_notif" },


### PR DESCRIPTION
## Description
Define `accept` mappings when `ai_cmp = false` (I chose the default for Copilot for every plugin as `<Tab>` is used by LazyVim) and also for Codeium only create the `nvim-cmp` source if `ai_cmp = true`.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
