### PR TITLE
feat(lualine): add fzf extensions.

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -159,7 +159,7 @@ return {
             end,
           },
         },
-        extensions = { "neo-tree", "lazy" },
+        extensions = { "neo-tree", "lazy", "fzf" },
       }
 
       -- do not add trouble symbols if aerial is enabled


### PR DESCRIPTION
## Description

Similar to #5175, add `fzf` integration with other plugins.

Note that similar to #5175, integration with `fzf` is included unconditionally. I think we don't need to check if the users choose `fzf` as their default picker to conditionally add the fzf integration with lualine.

## Screenshots

** Before **:

<img width="446" alt="Screenshot 2024-12-19 at 17 58 30" src="https://github.com/user-attachments/assets/b9974180-92e7-47fe-8f48-b153f29e0c72" />

** After **:

<img width="204" alt="Screenshot 2024-12-19 at 17 59 28" src="https://github.com/user-attachments/assets/777c3433-2347-4b6a-a5cd-435404b1386a" />


