### PR TITLE
fix(luasnip): correct name to not show duplicate snippets

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/luasnip.lua
+++ b/lua/lazyvim/plugins/extras/coding/luasnip.lua
@@ -72,7 +72,15 @@ return {
       { "saadparwaiz1/cmp_luasnip" },
     },
     opts = {
-      sources = { compat = { "luasnip" } },
+      sources = {
+        default = { "luasnip" },
+        providers = {
+          luasnip = {
+            name = "Luasnip",
+            module = "blink.compat.source",
+          },
+        },
+      },
       snippets = {
         expand = function(snippet)
           require("luasnip").lsp_expand(snippet)


### PR DESCRIPTION
## Description
Using `compat = { "luasnip" }` causes the following `sources.providers.luasnip.name = "luasnip"`. Instead manually defining `sources.defaults` and `sources.providers.luasnip.name = "Luasnip"` seems to solve the problem of duplicate snippets appearing with blink+Luasnip enabled. 

Not sure why the `name` matters. I just saw in `blink.cmp` that they also have a source for Luasnip (although it only supports the latest stable version of Luasnip) and in their documentation they register the source with `name = Luasnip`. 

On the other side `blink.compat` docs say to use the same name as you would use with `nvim-cmp`, so in this case it should be `name = "luasnip"`.

@folke I would appreciate it if you could solve some light as to why this happens and also verify if my proposed solution doesn't have any side-effects. Testing locally, this change got rid of duplicate snippets for me.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #5210
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
