### PR TITLE
fix(blink): remove compatibility with 0.7.6 release

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -118,17 +118,6 @@ return {
         end
       end
 
-      ---  NOTE: compat with latest version. Currenlty 0.7.6
-      if not vim.g.lazyvim_blink_main then
-        ---@diagnostic disable-next-line: inject-field
-        opts.sources.completion = opts.sources.completion or {}
-        opts.sources.completion.enabled_providers = enabled
-        if vim.tbl_get(opts, "completion", "menu", "draw", "treesitter") then
-          ---@diagnostic disable-next-line: assign-type-mismatch
-          opts.completion.menu.draw.treesitter = true
-        end
-      end
-
       -- Unset custom prop to pass blink.cmp validation
       opts.sources.compat = nil
 


### PR DESCRIPTION
## Description

With the version update 5 mins ago, I got an error with this setting.

I'm not sure if removal is the correct way to fix this but it does runs well on my local.

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
