### PR TITLE
fix(luasnip): correctly remove duplicate snippets

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/luasnip.lua
+++ b/lua/lazyvim/plugins/extras/coding/luasnip.lua
@@ -68,7 +68,6 @@ return {
     "saghen/blink.cmp",
     optional = true,
     opts = {
-      sources = { default = { "luasnip" } },
       snippets = {
         expand = function(snippet)
           require("luasnip").lsp_expand(snippet)
@@ -84,5 +83,17 @@ return {
         end,
       },
     },
+  },
+
+  -- Luasnip sources for blink
+  {
+    "saghen/blink.cmp",
+    optional = true,
+    opts = function(_, opts)
+      table.insert(opts.sources.default, "luasnip")
+      opts.sources.default = vim.tbl_filter(function(p)
+        return p ~= "snippets"
+      end, opts.sources.default)
+    end,
   },
 }


### PR DESCRIPTION
## Description
Remove `snippets` from `opts.sources.default` when Luasnip is enabled to not get duplicate snippets.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #5210
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
