### PR TITLE
feat(java): enable `blink.cmp` capabilities to show signature documentation

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -182,7 +182,9 @@ return {
           },
           settings = opts.settings,
           -- enable CMP capabilities
-          capabilities = LazyVim.has("cmp-nvim-lsp") and require("cmp_nvim_lsp").default_capabilities() or nil,
+          capabilities = LazyVim.has("blink.cmp") and require("blink.cmp").get_lsp_capabilities() or LazyVim.has(
+            "cmp-nvim-lsp"
+          ) and require("cmp_nvim_lsp").default_capabilities() or nil,
         }, opts.jdtls)
 
         -- Existing server will be reused if the root_dir matches.


### PR DESCRIPTION
## Description

Enable `blink.cmp` capabilities to show Java signature documentation during completion.
See also: https://github.com/Saghen/blink.cmp/issues/151

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
