### PR TITLE
feat: add aider as AI pair programming buddy

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/aider.lua
+++ b/lua/lazyvim/plugins/extras/ai/aider.lua
@@ -1,0 +1,24 @@
+return {
+  {
+    "GeorgesAlkhouri/nvim-aider",
+    cmd = {
+      "AiderTerminalToggle",
+    },
+    keys = {
+      { "<leader>ai", "<cmd>AiderTerminalToggle<cr>", desc = "Aider: Open Terminal " },
+      { "<leader>al", "<cmd>AiderTerminalSend<cr>", desc = "Aider: Send", mode = { "n", "v" } },
+      { "<leader>ak", "<cmd>AiderQuickSendCommand<cr>", desc = "Aider: Send Command" },
+      { "<leader>aj", "<cmd>AiderQuickSendBuffer<cr>", desc = "Aider: Send Buffer" },
+      { "<leader>a+", "<cmd>AiderQuickAddFile<cr>", desc = "Aider: Add File" },
+      { "<leader>a-", "<cmd>AiderQuickDropFile<cr>", desc = "Aider: Drop File" },
+    },
+    dependencies = {
+      "nvim-telescope/telescope.nvim",
+    },
+    opts = {
+      win = {
+        wo = { winbar = "Aider" },
+      },
+    },
+  },
+}


### PR DESCRIPTION
I've been using [aider.chat ](https://aider.chat/) a lot in another tab in my terminal. 

My current AI workflow sometimes involves using avante.nvim, for simpler tasks and aider.chat for more complex tasks that spans multiple files and concepts.

So I've been having fun using @georgesalkhouri's https://github.com/GeorgesAlkhouri/nvim-aider inside Neovim/LazyVim.

The only problem is that when I go back to an already opened aider panel, my cursor goes to the wrong insert position (everything works, it's just the cursor position that gets in the wrong place).

I've adjusted the keymaps so that it stays on the right side of the keyboard (mainly ijkl) and don't clash with other ai tools.