### PR TITLE
feat(bufferline): add keymap to rename current tab

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -197,6 +197,7 @@ map("n", "<leader><tab><tab>", "<cmd>tabnew<cr>", { desc = "New Tab" })
 map("n", "<leader><tab>]", "<cmd>tabnext<cr>", { desc = "Next Tab" })
 map("n", "<leader><tab>d", "<cmd>tabclose<cr>", { desc = "Close Tab" })
 map("n", "<leader><tab>[", "<cmd>tabprevious<cr>", { desc = "Previous Tab" })
+map("n", "<leader><tab>r", ":BufferLineTabRename ", { desc = "Rename Current Tab" })
 
 -- native snippets. only needed on < 0.11, as 0.11 creates these by default
 if vim.fn.has("nvim-0.11") == 0 then


### PR DESCRIPTION
## Description

Adds a keymap to rename current tab, using a command from [bufferline.nvim](https://github.com/akinsho/bufferline.nvim)

This command requires an argument (the new name), so the keymap opens a command prompt for the user to type the name. For some reason, using `<cmd>BufferLineTabRename ` syntax outputs an error because of the lack of a `<cr>` at the end, whereas `:BufferLineTabRename ` allows the partial command.

I'm unsure about how clear it is for the user that they have to type a name after the command in the prompt. But I don't see a way to improve the UX on this.

## Screenshots

![2024-12-23_14-26](https://github.com/user-attachments/assets/43813b1a-e6da-4519-bdf5-628873b81c96)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
