### PR TITLE
fix(python): enable venv-selector w/o telescope

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -116,9 +116,7 @@ return {
     "linux-cultist/venv-selector.nvim",
     branch = "regexp", -- Use this branch for the new version
     cmd = "VenvSelect",
-    enabled = function()
-      return LazyVim.has("telescope.nvim")
-    end,
+    enabled = true,
     opts = {
       settings = {
         options = {
@@ -128,7 +126,23 @@ return {
     },
     --  Call config for python files and load the cached venv automatically
     ft = "python",
-    keys = { { "<leader>cv", "<cmd>:VenvSelect<cr>", desc = "Select VirtualEnv", ft = "python" } },
+    keys = {
+      {
+        "<leader>cv",
+        function()
+          if LazyVim.has("telescope.nvim") then
+            vim.cmd(":VenvSelect")
+          else
+            vim.notify(
+              "VenvSelect currently requires Telescope.nvim: https://github.com/LazyVim/LazyVim/discussions/5081",
+              vim.log.levels.WARN
+            )
+          end
+        end,
+        desc = "Select VirtualEnv",
+        ft = "python",
+      },
+    },
   },
 
   {


### PR DESCRIPTION
## Description

Re-enable venv-selector, disable the `VenvSelect` command if telescope is absent.

### Why

The visual selection of a venv of venv-selector is currently not compatible with fzf-lua. Disabling the plugin as a whole breaks the python extra, since other plugins (dap, lsp, testing, etc.) need the venv selection that venv-selector performs heuristically w/o user selection.

## Related Issue(s)

https://github.com/LazyVim/LazyVim/discussions/5081
https://github.com/linux-cultist/venv-selector.nvim/issues/142

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
