### PR TITLE
fix(tailwind): additional settings

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/tailwind.lua
+++ b/lua/lazyvim/plugins/extras/lang/tailwind.lua
@@ -24,6 +24,9 @@ return {
           filetypes_include = {},
           -- to fully override the default_config, change the below
           -- filetypes = {}
+          -- additional settings for the server, e.g:
+          -- tailwindCSS = { includeLanguages = { someLang = "html" } }
+          settings = {},
         },
       },
       setup = {
@@ -40,16 +43,17 @@ return {
             return not vim.tbl_contains(opts.filetypes_exclude or {}, ft)
           end, opts.filetypes)
 
-          -- Additional settings for Phoenix projects
-          opts.settings = {
+          -- Add additional settings from opts
+          opts.settings = vim.tbl_deep_extend("error", {
             tailwindCSS = {
+              -- Additional settings for Phoenix projects
               includeLanguages = {
                 elixir = "html-eex",
                 eelixir = "html-eex",
                 heex = "html-eex",
               },
             },
-          }
+          }, opts.settings or {})
 
           -- Add additional filetypes
           vim.list_extend(opts.filetypes, opts.filetypes_include or {})


### PR DESCRIPTION
Make it possible to define your own tailwind settings in opts, and merge them with the default, additional Phoenix settings in tailwind.lua

## Description

Add the possibility to add your own tailwind settings in opts and have them deep merged into the default `opts.settings`

I needed this for configuring support for tailwind when coding on a [htmgo](https://htmgo.dev/docs/misc/tailwind-intellisense) project in Neovim.

E.g.
```lua
return {
  "neovim/nvim-lspconfig",
  opts = {
    servers = {
      tailwindcss = {
        filetypes_include = { "go" },
        settings = {
          tailwindCSS = {
            includeLanguages = {
              go = "html",
            },
            experimental = {
              classRegex = {
                { "Class\\(([^)]*)\\)", '["`]([^"`]*)["`]' },
                { "ClassX\\(([^)]*)\\)", '["`]([^"`]*)["`]' },
                { "ClassIf\\(([^)]*)\\)", '["`]([^"`]*)["`]' },
                { "Classes\\(([^)]*)\\)", '["`]([^"`]*)["`]' },
              },
            },
          },
        },
      },
    },
  },
}
```

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
