### PR TITLE
feat(chezmoi): enhance fzf-lua chezmoi picker and add snacks.dasbhoard entry

### DIFF
--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -55,6 +55,7 @@ return {
   },
   {
     "xvzc/chezmoi.nvim",
+    cmd = { "ChezmoiEdit" },
     keys = {
       {
         "<leader>sz",

--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -110,6 +110,27 @@ return {
       table.insert(opts.config.center, 5, projects)
     end,
   },
+  {
+    "folke/snacks.nvim",
+    optional = true,
+    opts = function(_, opts)
+      local chezmoi_entry = {
+        icon = " ",
+        key = "c",
+        desc = "Config",
+        action = pick_chezmoi,
+      }
+      local config_index
+      for i = #opts.dashboard.preset.keys, 1, -1 do
+        if opts.dashboard.preset.keys[i].key == "c" then
+          table.remove(opts.dashboard.preset.keys, i)
+          config_index = i
+          break
+        end
+      end
+      table.insert(opts.dashboard.preset.keys, config_index, chezmoi_entry)
+    end,
+  },
 
   -- Filetype icons
   {

--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -5,7 +5,7 @@ local pick_chezmoi = function()
     local fzf_lua = require("fzf-lua")
     local actions = {
       ["enter"] = function(selected)
-        fzf_lua.actions.vimcmd_entry("ChezmoiEdit", selected, {cwd = os.getenv("HOME")})
+        fzf_lua.actions.vimcmd_entry("ChezmoiEdit", selected, { cwd = os.getenv("HOME") })
       end,
     }
     require("fzf-lua").files({ cmd = "chezmoi managed --include=files,symlinks", actions = actions })

--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -8,7 +8,7 @@ local pick_chezmoi = function()
         fzf_lua.actions.vimcmd_entry("ChezmoiEdit", selected, { cwd = os.getenv("HOME") })
       end,
     }
-    require("fzf-lua").files({ cmd = "chezmoi managed --include=files,symlinks", actions = actions })
+    fzf_lua.files({ cmd = "chezmoi managed --include=files,symlinks", actions = actions })
   elseif LazyVim.pick.picker.name == "snacks" then
     local results = require("chezmoi.commands").list({
       args = {

--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -3,22 +3,12 @@ local pick_chezmoi = function()
     require("telescope").extensions.chezmoi.find_files()
   elseif LazyVim.pick.picker.name == "fzf" then
     local fzf_lua = require("fzf-lua")
-    local results = require("chezmoi.commands").list()
-    local chezmoi = require("chezmoi.commands")
-
-    local opts = {
-      fzf_opts = {},
-      fzf_colors = true,
-      actions = {
-        ["default"] = function(selected)
-          chezmoi.edit({
-            targets = { "~/" .. selected[1] },
-            args = { "--watch" },
-          })
-        end,
-      },
+    local actions = {
+      ["enter"] = function(selected)
+        fzf_lua.actions.vimcmd_entry("ChezmoiEdit", selected, {cwd = os.getenv("HOME")})
+      end,
     }
-    fzf_lua.fzf_exec(results, opts)
+    require("fzf-lua").files({ cmd = "chezmoi managed --include=files,symlinks", actions = actions })
   elseif LazyVim.pick.picker.name == "snacks" then
     local results = require("chezmoi.commands").list({
       args = {


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

This PR enhances the fzf-lua picker for chezmoi by using the built-in `files` picker and by opening the selected file with `ChezmoiEdit` and `vimcmd_entry` to parse the entry. This simplifies the code and adds icons and file preview.

The PR also replaces the config entry in snacks.dashboard with the chezmoi picker, similar to what was already implemented for dashboard-nvim

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

Current picker:

![image](https://github.com/user-attachments/assets/d0be9279-f199-4349-8055-04d8a351c6f9)


New picker:

![image](https://github.com/user-attachments/assets/c68fcb6a-79fa-4f65-8c48-60ce64450350)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
