### PR TITLE
Add an option to prevent LSP keymaps from being applied to specified filetypes

### DIFF
--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -42,6 +42,9 @@ vim.g.root_spec = { "lsp", { ".git", "lua" }, "cwd" }
 -- for detecting the LSP root
 vim.g.root_lsp_ignore = { "copilot" }
 
+-- Filetypes to ignore LSP keymaps
+vim.g.keymaps_lsp_ignore_ft = {}
+
 -- Hide deprecation warnings
 vim.g.deprecation_warnings = false
 

--- a/lua/lazyvim/plugins/extras/ai/copilot-chat.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot-chat.lua
@@ -75,6 +75,9 @@ return {
         end,
       })
 
+      -- Add copilot-chat to the list of filetypes that should ignore LSP keymaps
+      vim.g.keymaps_lsp_ignore_ft = vim.list_extend(vim.g.keymaps_lsp_ignore_ft or {}, { "copilot-chat" })
+
       chat.setup(opts)
     end,
   },

--- a/lua/lazyvim/plugins/lsp/keymaps.lua
+++ b/lua/lazyvim/plugins/lsp/keymaps.lua
@@ -6,6 +6,13 @@ M._keys = nil
 ---@alias LazyKeysLspSpec LazyKeysSpec|{has?:string|string[], cond?:fun():boolean}
 ---@alias LazyKeysLsp LazyKeys|{has?:string|string[], cond?:fun():boolean}
 
+---@param buffer integer
+---@return boolean
+function M.is_ignored(buffer)
+  local ft = vim.bo[buffer].filetype
+  return vim.tbl_contains(vim.g.keymaps_lsp_ignore_ft or {}, ft)
+end
+
 ---@return LazyKeysLspSpec[]
 function M.get()
   if M._keys then
@@ -64,7 +71,7 @@ end
 ---@return LazyKeysLsp[]
 function M.resolve(buffer)
   local Keys = require("lazy.core.handler.keys")
-  if not Keys.resolve then
+  if M.is_ignored(buffer) or not Keys.resolve then
     return {}
   end
   local spec = vim.tbl_extend("force", {}, M.get())


### PR DESCRIPTION
## Description

Currently LSP keymaps overwrite all other keymaps due to how they're loaded. This change adds the ability to prevent LSP keymaps from being applied to specific buffers of specified filetypes

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
