### PR TITLE
fix(nlua): debugger not responding

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/fzf.lua
+++ b/lua/lazyvim/plugins/extras/editor/fzf.lua
@@ -45,8 +45,9 @@ return {
     "ibhagwan/fzf-lua",
     cmd = "FzfLua",
     opts = function(_, opts)
-      local config = require("fzf-lua.config")
-      local actions = require("fzf-lua.actions")
+      local fzf = require("fzf-lua")
+      local config = fzf.config
+      local actions = fzf.actions
 
       -- Quickfix
       config.defaults.keymap.fzf["ctrl-q"] = "select-all+accept"


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Reference: https://github.com/jbyuki/one-small-step-for-vimkind/issues/45#issuecomment-2125749906

Fix nlua debug adapter not responding, which for some reason because of `fzf-lua`.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

No screenshot instead I'm providing how to reproduce with assumption `dap.nlua` extra is enabled. Steps:

1. Launch the nlua `:lua require'osv'.launch({port=8086})`

2. Attach from any neovim instance to the debugger

   1. Run the debugger
      - Can do `<leader>dc`; or
      - Can do `:lua require'dap'.continue()`
   2. Choose `Attach to running Neovim instance (port = 8086)`

3. Prior to this changes, debugger will got timeout like the following

   ```text
   Debug adapter didn't respond. Either the adapter is slow (then wait and ignore this) or there is a problem with your adapter or `nlua` configuration. Check the logs for errors (:help dap.set_log_level)
   ```

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
