### PR TITLE
fix(helm): broken helm highlighting

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/helm.lua
+++ b/lua/lazyvim/plugins/extras/lang/helm.lua
@@ -6,7 +6,8 @@ return {
     })
   end,
 
-  { "towolf/vim-helm", ft = "helm" },
+  { "qvalentin/helm-ls.nvim", ft = "helm" },
+
   {
     "nvim-treesitter/nvim-treesitter",
     opts = { ensure_installed = { "helm" } },
@@ -17,17 +18,6 @@ return {
     opts = {
       servers = {
         helm_ls = {},
-      },
-      setup = {
-        yamlls = function()
-          LazyVim.lsp.on_attach(function(client, buffer)
-            if vim.bo[buffer].filetype == "helm" then
-              vim.schedule(function()
-                vim.cmd("LspStop ++force yamlls")
-              end)
-            end
-          end, "yamlls")
-        end,
       },
     },
   },


### PR DESCRIPTION
## Description

This PR replaces the towolf/vim-helm plugin with a newer, lua implementation of the plugin. This fixes syntax highlighting and makes the workaround for the ftdetect/lsp load order superfluous.

## Related Issue(s)

  - Fixes #5334 

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
