### PR TITLE
fix(bufferline): show default icons

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -40,7 +40,11 @@ return {
         },
         ---@param opts bufferline.IconFetcherOpts
         get_element_icon = function(opts)
-          return LazyVim.config.icons.ft[opts.filetype]
+          local lazyvim_icon = LazyVim.config.icons.ft[opts.filetype]
+          if lazyvim_icon then
+            return lazyvim_icon
+          end
+          return require("nvim-web-devicons").get_icon_by_filetype(opts.filetype, { default = false })
         end,
       },
     },


### PR DESCRIPTION
## Description

On my LazyVim, as well as on a fresh install in a docker container, the filetype icons are not visible in the bufferline (see picture below). This seems to be caused by the `get_element_icon` parameter in the `bufferline.nvim` spec, which only uses LazyVim's custom icons, which consists only in a `octo` entry in the fresh install.

This PR adds 3 lines to fallback to `nvim-web-devicons` default icons.

## Related Issue(s)

*None found*

## Screenshots

![image](https://github.com/user-attachments/assets/e2142f5e-c508-45a1-a7dd-51f8773c3dab)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
