### PR TITLE
perf(java): setting opts.dap_main to false to disable main class scan

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -130,6 +130,7 @@ return {
 
         -- These depend on nvim-dap, but can additionally be disabled by setting false here.
         dap = { hotcodereplace = "auto", config_overrides = {} },
+        -- Can set this to false to disable main class scan, which is a performance killer for large project
         dap_main = {},
         test = true,
         settings = {
@@ -246,7 +247,9 @@ return {
               if opts.dap and LazyVim.has("nvim-dap") and mason_registry.is_installed("java-debug-adapter") then
                 -- custom init for Java debugger
                 require("jdtls").setup_dap(opts.dap)
-                require("jdtls.dap").setup_dap_main_class_configs(opts.dap_main)
+                if opts.dap_main then
+                  require("jdtls.dap").setup_dap_main_class_configs(opts.dap_main)
+                end
 
                 -- Java Test require Java debugger to work
                 if opts.test and mason_registry.is_installed("java-test") then


### PR DESCRIPTION
## Description

For large Java project, calling `require("jdtls.dap").setup_dap_main_class_configs(opts.dap_main)` has a huge performance impact on the LSP. I tested on a Java project with 3.7K java source files and 12K other files, a simple go_definition can take about 20-30 seconds.

This change allow user to set the `opts.dap_main` to false so we can skip the main class scan. By using the `.lazy.lua` project specific setting, we can easily customize this option per project. 

## Related Issue(s)

#5387 

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
