### PR TITLE
fix(snacks.picker): fix mapping for `Recent (cwd)`

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/snacks_picker.lua
+++ b/lua/lazyvim/plugins/extras/editor/snacks_picker.lua
@@ -46,7 +46,7 @@ return {
       { "<leader>fF", LazyVim.pick("files", { root = false }), desc = "Find Files (cwd)" },
       { "<leader>fg", function() Snacks.picker.git_files() end, desc = "Find Files (git-files)" },
       { "<leader>fr", LazyVim.pick("oldfiles"), desc = "Recent" },
-      { "<leader>fR", LazyVim.pick("oldfiles", { only_cwd = true }), desc = "Recent (cwd)" },
+      { "<leader>fR", LazyVim.pick("oldfiles", { filter = { cwd = true }}), desc = "Recent (cwd)" },
       -- git
       { "<leader>gc", function() Snacks.picker.git_log() end, desc = "Git Log" },
       { "<leader>gs", function() Snacks.picker.git_status() end, desc = "Git Status" },


### PR DESCRIPTION
## Description
The mapping `<leader>fR` was showing all recent files instead of the ones in the `cwd` only.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
