### PR TITLE
feat(chezmoi): add snacks picker integration for chezmoi files

### DIFF
--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -46,8 +46,8 @@ local pick_chezmoi = function()
     local opts = {
       items = items,
       format = "filename",
-      confirm = function(_, item)
-        -- picker:close()
+      confirm = function(picker, item)
+        picker:close()
         require("chezmoi.commands").edit({
           targets = { item.text },
           args = { "--watch" },

--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -19,6 +19,42 @@ local pick_chezmoi = function()
       },
     }
     fzf_lua.fzf_exec(results, opts)
+  elseif LazyVim.pick.picker.name == "snacks" then
+    local results = require("chezmoi.commands").list({
+      args = {
+        "--path-style",
+        "absolute",
+        "--include",
+        "files",
+        "--exclude",
+        "externals",
+      },
+    })
+    local items = {}
+
+    for i, czFile in ipairs(results) do
+      table.insert(items, {
+        idx = i,
+        score = i,
+        text = czFile,
+        name = czFile,
+        file = czFile,
+      })
+    end
+
+    ---@type snacks.picker.Config
+    local opts = {
+      items = items,
+      format = "filename",
+      confirm = function(_, item)
+        -- picker:close()
+        require("chezmoi.commands").edit({
+          targets = { item.text },
+          args = { "--watch" },
+        })
+      end,
+    }
+    Snacks.picker.pick(opts)
   end
 end
 

--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -32,12 +32,9 @@ local pick_chezmoi = function()
     })
     local items = {}
 
-    for i, czFile in ipairs(results) do
+    for _, czFile in ipairs(results) do
       table.insert(items, {
-        idx = i,
-        score = i,
         text = czFile,
-        name = czFile,
         file = czFile,
       })
     end
@@ -45,7 +42,6 @@ local pick_chezmoi = function()
     ---@type snacks.picker.Config
     local opts = {
       items = items,
-      format = "filename",
       confirm = function(picker, item)
         picker:close()
         require("chezmoi.commands").edit({


### PR DESCRIPTION
## Description

We have a new picker Snacks picker, it means telescope and fzf-lua can be uninstalled. But chezmoi files still listed only with telescope and fzf-lua. In this pr we add snacks.picker integration if the user has chosen snacks.picker in the LazyVimExtras.
