### PR TITLE
fix(snacks.picker): fix mapping for Projects for consistency

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/snacks_picker.lua
+++ b/lua/lazyvim/plugins/extras/editor/snacks_picker.lua
@@ -74,7 +74,7 @@ return {
       { "<leader>sR", function() Snacks.picker.resume() end, desc = "Resume" },
       { "<leader>sq", function() Snacks.picker.qflist() end, desc = "Quickfix List" },
       { "<leader>uC", function() Snacks.picker.colorschemes() end, desc = "Colorschemes" },
-      { "<leader>qp", function() Snacks.picker.projects() end, desc = "Projects" },
+      { "<leader>fp", function() Snacks.picker.projects() end, desc = "Projects" },
     },
   },
   {


### PR DESCRIPTION
## Description

`<leader>fp` is the mapping for Telescope and fzf for [Projects](https://www.lazyvim.org/extras/util/project). This PR makes this shortcut consistent for snacks picker.

## Related Issue(s)

## Screenshots

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
