### PR TITLE
fix(go): remove depricated analyses option `fieldalignment`

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -37,7 +37,6 @@ return {
                 rangeVariableTypes = true,
               },
               analyses = {
-                fieldalignment = true,
                 nilness = true,
                 unusedparams = true,
                 unusedwrite = true,


### PR DESCRIPTION
gopls depricated analyzer fieldalignment. I was getting this error:

```
LSP[gopls] Invalid settings: setting option "analyses": this setting is deprecated, 
use "the 'fieldalignment' analyzer was removed in gopls/v0.17.0; 
instead, hover over struct fields to see size/offset information (https://go.dev/issue/66861)" instead
```
this pr fixes it