### PR TITLE
fix(extras.project): open projects picker from dashboard with snacks backend

### DIFF
--- a/lua/lazyvim/plugins/extras/util/project.lua
+++ b/lua/lazyvim/plugins/extras/util/project.lua
@@ -80,6 +80,8 @@ pick = function()
 
     fzf_lua.fzf_exec(results, opts)
   end
+elseif LazyVim.pick.picker.name == "snacks" then
+  Snacks.picker.projects()
 end
 
 return {

--- a/lua/lazyvim/plugins/extras/util/project.lua
+++ b/lua/lazyvim/plugins/extras/util/project.lua
@@ -79,9 +79,9 @@ pick = function()
     }
 
     fzf_lua.fzf_exec(results, opts)
+  elseif LazyVim.pick.picker.name == "snacks" then
+    Snacks.picker.projects()
   end
-elseif LazyVim.pick.picker.name == "snacks" then
-  Snacks.picker.projects()
 end
 
 return {


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Clicking on `p` on the dashboard, the projects picker opens, even with snacks' picker. This previously did nothing.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
