### PR TITLE
fix(keymaps): remove unneeded and ambiguous `<leader>w` keymap

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -182,7 +182,6 @@ map("t", "<C-/>", "<cmd>close<cr>", { desc = "Hide Terminal" })
 map("t", "<c-_>", "<cmd>close<cr>", { desc = "which_key_ignore" })
 
 -- windows
-map("n", "<leader>w", "<c-w>", { desc = "Windows", remap = true })
 map("n", "<leader>-", "<C-W>s", { desc = "Split Window Below", remap = true })
 map("n", "<leader>|", "<C-W>v", { desc = "Split Window Right", remap = true })
 map("n", "<leader>wd", "<C-W>c", { desc = "Delete Window", remap = true })


### PR DESCRIPTION
## Description

The `<leader>w` mapping, described as "Windows", was causing potentially timeout-related bugs with many other mappings that also started with `<leader>w`.

The problems caused by this are described in detail in issue #5456 and in discussion #4157.

@dpetka2001 Suggested removing it as an experiment, which I tried and found to work.

<!--
  - Fixes #5456
  - Fixes #4157
-->

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
