### PR TITLE
feat(extras): added twig language

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/twig.lua
+++ b/lua/lazyvim/plugins/extras/lang/twig.lua
@@ -1,0 +1,44 @@
+return {
+  {
+    'nvim-treesitter/nvim-treesitter',
+    opts = { ensure_installed = { 'twig' } },
+  },
+  {
+    'williamboman/mason.nvim',
+    opts = {
+      ensure_installed = {
+        'twiggy-language-server',
+        'twigcs',
+        'twig-cs-fixer',
+      },
+    },
+  },
+  {
+    'nvimtools/none-ls.nvim',
+    optional = true,
+    opts = function(_, opts)
+      local nls = require('null-ls')
+      opts.sources = opts.sources or {}
+      table.insert(opts.sources, nls.builtins.diagnostics.twigcs)
+      -- Twig-CS-Fixer builtin not available in none-ls
+    end,
+  },
+  {
+    'mfussenegger/nvim-lint',
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        twig = { 'twigcs' },
+      },
+    },
+  },
+  {
+    'stevearc/conform.nvim',
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        twig = { 'twig-cs-fixer' },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Description

Adds Twig templates language support as en extra.

Explanation for the tools choices:
- Linter/formatter: Twigcs and Twig-cs-fixer both follow the [coding standards](https://twig.symfony.com/doc/3.x/coding_standards.html) recommended by the Symfony Project, maintainers of Twig.
- LSP: I don't know it Twiggy is considered a standard in the community. I picked it because it's the only server specific to Twig. The other options are HTML servers that also include support for several templates languages. I've been using it for a while and it works fine. It adds much needed snippets (Twig syntax involves tags that are difficult to type on most keyboards) and does not conflict with Twigcs diagnostics.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
