### PR TITLE
feat(projects): add support for snacks picker in project.lua

### DIFF
--- a/lua/lazyvim/plugins/extras/util/project.lua
+++ b/lua/lazyvim/plugins/extras/util/project.lua
@@ -3,6 +3,8 @@ local pick = nil
 pick = function()
   if LazyVim.pick.picker.name == "telescope" then
     return vim.cmd("Telescope projects")
+  elseif LazyVim.pick.picker.name == "snacks" then
+    require("snacks").picker.projects()
   elseif LazyVim.pick.picker.name == "fzf" then
     local fzf_lua = require("fzf-lua")
     local project = require("project_nvim.project")


### PR DESCRIPTION
Fixes #5465
This update introduces the ability to use the "snacks" picker in the project selection functionality. Users can now choose projects using the snacks picker alongside existing options like telescope and fzf.

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
