### PR TITLE
fix(extras): remove deprecated gopls analyzer

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -37,7 +37,6 @@ return {
                 rangeVariableTypes = true,
               },
               analyses = {
-                fieldalignment = true,
                 nilness = true,
                 unusedparams = true,
                 unusedwrite = true,


### PR DESCRIPTION
## Description

In June of 2024, the gopls team removed the `fieldalignment` analyzer due to its "poor fit" in the gopls analyzer suite.
See https://go-review.googlesource.com/c/tools/+/590375 for the release notes.
And see this [discussion](https://github.com/golang/go/issues/67762#issuecomment-2145034364) which encouraged the deletion.

This PR removes that field from the go lsp config.

## Related Issue(s)

The current go lsp config enables the `fieldalignment` field which results in deprecation warnings when the language server spins up.

## Screenshots

![image](https://github.com/user-attachments/assets/21bbb895-6eaa-403a-8f6c-d688a7dd4965)

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
