### PR TITLE
fix(luasnip): schedule `jump` to be compatible with blink, nvim-cmp still works after change

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/luasnip.lua
+++ b/lua/lazyvim/plugins/extras/coding/luasnip.lua
@@ -30,7 +30,9 @@ return {
     opts = function()
       LazyVim.cmp.actions.snippet_forward = function()
         if require("luasnip").jumpable(1) then
-          require("luasnip").jump(1)
+          vim.schedule(function()
+            require("luasnip").jump(1)
+          end)
           return true
         end
       end


### PR DESCRIPTION
## Description
Schedule `jump` in Luasnip `snippet_forward`, so that it doesn't get stuck before the last placeholder.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #5469
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
