### PR TITLE
feat(general): add support for Ctrl + Backspace to delete a word

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -16,6 +16,10 @@ map("n", "<C-j>", "<C-w>j", { desc = "Go to Lower Window", remap = true })
 map("n", "<C-k>", "<C-w>k", { desc = "Go to Upper Window", remap = true })
 map("n", "<C-l>", "<C-w>l", { desc = "Go to Right Window", remap = true })
 
+-- Delete an entire word in insert mode with <ctrl> backspace
+map("i", "<C-BS>", "<C-w>", { desc = "Delete entire word in insert mode" })
+map("i", "<C-H>", "<C-w>", { desc = "Delete entire word in insert mode" })
+
 -- Resize window using <ctrl> arrow keys
 map("n", "<C-Up>", "<cmd>resize +2<cr>", { desc = "Increase Window Height" })
 map("n", "<C-Down>", "<cmd>resize -2<cr>", { desc = "Decrease Window Height" })


### PR DESCRIPTION
## Description

I've added a keymap to make Vim more accessible to newcomers by introducing support for deleting a word using `Ctrl + Backspace` in insert mode. My intent with this mapping was to replicate the behavior of `Ctrl + Backspace`, which is specifically used in many editors (e.g., VS Code, Sublime, IntelliJ) to delete entire words. This behavior is common in other editors and enhances the onboarding experience for users transitioning to Vim.

The keymap maps `<C-BS>` to Vim's built-in `<C-w>` command, which is already familiar to experienced Vim/Neovim users for deleting the previous word.

Even if this functionality already exists, I believe someone will find it helpful ;). 
Both `<C-BS>` and `<C-H>` are included to ensure compatibility, as key interpretation can vary across terminals, but either keymap can be removed accordingly based on the terminal's behavior.
```lua
map("i", "<C-BS>", "<C-w>", { desc = "Delete the previous word in insert mode" })
map("i", "<C-H>", "<C-w>", { desc = "Delete the previous word in insert mode" })
```

### More on key interpretation

We can check our terminal's interpretation by running `cat -v` in our terminal and pressing `Ctrl + Backspace`. 
> For example, If we see `^H` (`^` represents `Ctrl`), our terminal supports `<C-H>` version. In this case, we can remove the `<C-BS>` keymap.


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
