### PR TITLE
feat(supermaven): support word-completion

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/supermaven.lua
+++ b/lua/lazyvim/plugins/extras/ai/supermaven.lua
@@ -20,16 +20,22 @@ return {
     "supermaven-inc/supermaven-nvim",
     opts = function()
       require("supermaven-nvim.completion_preview").suggestion_group = "SupermavenSuggestion"
-      LazyVim.cmp.actions.ai_accept = function()
-        local suggestion = require("supermaven-nvim.completion_preview")
-        if suggestion.has_suggestion() then
-          LazyVim.create_undo()
-          vim.schedule(function()
-            suggestion.on_accept_suggestion()
-          end)
-          return true
+
+      local ai_accept = function(partial)
+        return function()
+          local suggestion = require("supermaven-nvim.completion_preview")
+          if suggestion.has_suggestion() then
+            LazyVim.create_undo()
+            vim.schedule(function()
+              suggestion.on_accept_suggestion(partial)
+            end)
+            return true
+          end
         end
       end
+
+      LazyVim.cmp.actions.ai_accept = ai_accept(false)
+      LazyVim.cmp.actions.ai_accept_word = ai_accept(true)
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -85,6 +85,10 @@ return {
       keymap = {
         preset = "enter",
         ["<C-y>"] = { "select_and_accept" },
+        ["<S-Tab>"] = {
+          LazyVim.cmp.map({ "snippet_backward", "ai_accept_word" }),
+          "fallback",
+        },
       },
     },
     ---@param opts blink.cmp.Config | { sources: { compat: string[] } }


### PR DESCRIPTION


## Description

The supermaven-plugin supports partial completion, which is essentially expanding the next word. 
This PR extends the configuration to make word-completion available with S-Tab in blink, in the same fashion as `ai_complete` is working.

<!--

## Related Issue(s)

  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>

## Screenshots

-->

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
