### PR TITLE
fix(snacks): use `Snacks.picker` for recent files

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/snacks_picker.lua
+++ b/lua/lazyvim/plugins/extras/editor/snacks_picker.lua
@@ -69,7 +69,7 @@ return {
       { "<leader>fF", LazyVim.pick("files", { root = false }), desc = "Find Files (cwd)" },
       { "<leader>fg", function() Snacks.picker.git_files() end, desc = "Find Files (git-files)" },
       { "<leader>fr", LazyVim.pick("oldfiles"), desc = "Recent" },
-      { "<leader>fR", LazyVim.pick("oldfiles", { filter = { cwd = true }}), desc = "Recent (cwd)" },
+      { "<leader>fR", function() Snacks.picker.recent({ filter = { cwd = true }}) end, desc = "Recent (cwd)" },
       { "<leader>fp", function() Snacks.picker.projects() end, desc = "Projects" },
       -- git
       { "<leader>gc", function() Snacks.picker.git_log() end, desc = "Git Log" },


### PR DESCRIPTION
## Description
Use `Snacks.picker` for recent files instead of `LazyVim.pick`, because `root_dir` is being propagated to `opts.cwd` and does not correctly filter out recent files when inside nested directories.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
