### PR TITLE
feat(snippets): mini.snippets standalone and blink.resubscribe

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/mini-snippets.lua
+++ b/lua/lazyvim/plugins/extras/coding/mini-snippets.lua
@@ -140,21 +140,25 @@ return {
       end
 
       -- Standalone --
+      local blink = require("blink.cmp")
       expand_select_override = function(snippets, insert)
         -- Schedule, otherwise blink's virtual text is not removed on vim.ui.select
-        require("blink.cmp").cancel()
+        blink.cancel()
         vim.schedule(function()
           MiniSnippets.default_select(snippets, insert)
         end)
       end
       --
       -- Blink performs a require on blink.cmp.sources.snippets.default
-      -- By removing the source, the default engine will not be used
+      -- By removing the source, that default engine will not be used
       opts.sources.default = vim.tbl_filter(function(source)
         return source ~= "snippets"
       end, opts.sources.default)
       opts.snippets = { -- need to repeat blink's preset here
-        expand = expand_from_lsp,
+        expand = function(snippet)
+          expand_from_lsp(snippet)
+          blink.resubscribe()
+        end,
         active = function()
           return MiniSnippets.session.get(false) ~= nil
         end,


### PR DESCRIPTION

## Description


When using blink.cmp and mini.snippets, the same problem regarding outdated completion items as solved in [nvim-cmp](https://github.com/hrsh7th/nvim-cmp/pull/2126) can arise.

[This](https://github.com/Saghen/blink.cmp/pull/1035) PR has been included into main.
When the PR is included into the next stable release, this PR can be merged.
Current blink release: 0.11.0


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
