### PR TITLE
fix(rust): install bacon-ls

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -49,7 +49,7 @@ return {
       opts.ensure_installed = opts.ensure_installed or {}
       vim.list_extend(opts.ensure_installed, { "codelldb" })
       if diagnostics == "bacon-ls" then
-        vim.list_extend(opts.ensure_installed, { "bacon" })
+        vim.list_extend(opts.ensure_installed, { "bacon", "bacon-ls" })
       end
     end,
   },


### PR DESCRIPTION
mason-lspconfig.nvim does not have a mapping for bacon_ls

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.

I've never written a line of rust code.