### PR TITLE
feat(refactoring): fallback to using vim ui select for refactoring.nvim

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/refactoring.lua
+++ b/lua/lazyvim/plugins/extras/editor/refactoring.lua
@@ -1,10 +1,10 @@
 local pick = function()
+  local refactoring = require("refactoring")
   if LazyVim.pick.picker.name == "telescope" then
     return require("telescope").extensions.refactoring.refactors()
   elseif LazyVim.pick.picker.name == "fzf" then
     local fzf_lua = require("fzf-lua")
-    local results = require("refactoring").get_refactors()
-    local refactoring = require("refactoring")
+    local results = refactoring.get_refactors()
 
     local opts = {
       fzf_opts = {},
@@ -16,6 +16,8 @@ local pick = function()
       },
     }
     fzf_lua.fzf_exec(results, opts)
+  else
+    refactoring.select_refactor()
   end
 end
 


### PR DESCRIPTION
## Description

Fallback to using `require("refactoring").select_refactor()`  if neither of `telescope` or `fzf-lua` is installed. Since `select_refactor()` uses `vim.ui.select` internally, it can use `snacks.picker` if it is enabled.
## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [ x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
