### PR TITLE
fix(project): ensure keymap works with snacks

### DIFF
--- a/lua/lazyvim/plugins/extras/util/project.lua
+++ b/lua/lazyvim/plugins/extras/util/project.lua
@@ -3,6 +3,8 @@ local pick = nil
 pick = function()
   if LazyVim.pick.picker.name == "telescope" then
     return vim.cmd("Telescope projects")
+  elseif LazyVim.pick.picker.name == "snacks" then
+    return Snacks.picker.projects()
   elseif LazyVim.pick.picker.name == "fzf" then
     local fzf_lua = require("fzf-lua")
     local project = require("project_nvim.project")


### PR DESCRIPTION
## Description

Currently the project keymap (\<leader\>fp) while using snacks is not working. This would fix it.

## Related Issue(s)

## Screenshots

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
