### PR TITLE
feat(snacks.picker): added support for Project shortcuts in other dashboards

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/snacks_picker.lua
+++ b/lua/lazyvim/plugins/extras/editor/snacks_picker.lua
@@ -169,6 +169,50 @@ return {
     end,
   },
   {
+    "goolord/alpha-nvim",
+    optional = true,
+    opts = function(_, dashboard)
+      local button = dashboard.button("p", " " .. " Projects", [[<cmd> lua Snacks.picker.projects() <cr>]])
+      button.opts.hl = "AlphaButtons"
+      button.opts.hl_shortcut = "AlphaShortcut"
+      table.insert(dashboard.section.buttons.val, 4, button)
+    end,
+  },
+  {
+    "echasnovski/mini.starter",
+    optional = true,
+    opts = function(_, opts)
+      local items = {
+        {
+          name = "Projects",
+          action = [[lua Snacks.picker.projects()]],
+          section = string.rep(" ", 22) .. "Telescope",
+        },
+      }
+      vim.list_extend(opts.items, items)
+    end,
+  },
+  {
+    "nvimdev/dashboard-nvim",
+    optional = true,
+    opts = function(_, opts)
+      if not vim.tbl_get(opts, "config", "center") then
+        return
+      end
+      local projects = {
+        action = "lua Snacks.picker.projects()",
+        desc = " Projects",
+        icon = " ",
+        key = "p",
+      }
+
+      projects.desc = projects.desc .. string.rep(" ", 43 - #projects.desc)
+      projects.key_format = "  %s"
+
+      table.insert(opts.config.center, 3, projects)
+    end,
+  },
+  {
     "folke/flash.nvim",
     optional = true,
     specs = {

--- a/lua/lazyvim/plugins/xtras.lua
+++ b/lua/lazyvim/plugins/xtras.lua
@@ -11,6 +11,9 @@ local prios = {
   -- default priority is 50
   ["lazyvim.plugins.extras.editor.aerial"] = 100,
   ["lazyvim.plugins.extras.editor.outline"] = 100,
+  ["lazyvim.plugins.extras.ui.alpha"] = 19,
+  ["lazyvim.plugins.extras.ui.dashboard-nvim"] = 19,
+  ["lazyvim.plugins.extras.ui.mini-starter"] = 19,
 }
 
 if vim.g.xtras_prios then


### PR DESCRIPTION
…shboard-nvim, and mini-starter

## Description

Though the snacks.picker extra provides a project picker, it only adds the 'Projects' shortcut to snacks' dashboard, and no to the other three dashboard extra: alpha, dashboard-nvim and mini-starter. In this PR, I added the 'Projects' shortcuts to these three dashboard extras.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

- Fixes #5465

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

alpha

![image](https://github.com/user-attachments/assets/c050f260-8602-4660-a386-62ab8400ef87)

dashboard-nvim

![image](https://github.com/user-attachments/assets/8973cd62-ba97-4330-9462-74163b58dca9)

mini.starter

![image](https://github.com/user-attachments/assets/a31ec27d-7efb-4aa3-a136-2a4ffedf5ba1)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
