### PR TITLE
fix(angular): make angularls work for nx workspaces as well

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/angular.lua
+++ b/lua/lazyvim/plugins/extras/lang/angular.lua
@@ -31,7 +31,13 @@ return {
     "neovim/nvim-lspconfig",
     opts = {
       servers = {
-        angularls = {},
+        angularls = {
+          -- Make sure it works for Nx workspaces as well
+          root_dir = function(fname)
+            return require("lspconfig.util").root_pattern("nx.json", "angular.json")(fname)
+                or vim.loop.cwd()
+          end,
+        },
       },
       setup = {
         angularls = function()

--- a/lua/lazyvim/plugins/extras/lang/angular.lua
+++ b/lua/lazyvim/plugins/extras/lang/angular.lua
@@ -34,7 +34,7 @@ return {
         angularls = {
           -- Make sure it works for Nx workspaces as well
           root_dir = function(fname)
-            return require("lspconfig.util").root_pattern("nx.json", "angular.json")(fname) or vim.loop.cwd()
+            return require("lspconfig.util").root_pattern("nx.json", "angular.json")(fname)
           end,
         },
       },

--- a/lua/lazyvim/plugins/extras/lang/angular.lua
+++ b/lua/lazyvim/plugins/extras/lang/angular.lua
@@ -34,8 +34,7 @@ return {
         angularls = {
           -- Make sure it works for Nx workspaces as well
           root_dir = function(fname)
-            return require("lspconfig.util").root_pattern("nx.json", "angular.json")(fname)
-                or vim.loop.cwd()
+            return require("lspconfig.util").root_pattern("nx.json", "angular.json")(fname) or vim.loop.cwd()
           end,
         },
       },


### PR DESCRIPTION
## Description
Nx workspaces are not supported out-of-the-box since the root dir is not found (in case of Nx workspaces there is no angular.json, but rather an nx.json in the root dir). With this modification the LSP works as intended.

## Related Issue(s)
https://github.com/LazyVim/LazyVim/issues/5601 


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
