### PR TITLE
fix(blink): `cmdline` is now top-level on main branch

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -79,7 +79,6 @@ return {
         -- with blink.compat
         compat = {},
         default = { "lsp", "path", "snippets", "buffer" },
-        cmdline = {},
       },
 
       keymap = {
@@ -89,6 +88,15 @@ return {
     },
     ---@param opts blink.cmp.Config | { sources: { compat: string[] } }
     config = function(_, opts)
+      -- HACK: remove when next `blink.cmp` stable release is available
+      -- and just do `opts.cmdline.sources = {}` directly in `opts`
+      -- Should be greater than current 0.11.0
+      if not vim.g.lazyvim_blink_main then
+        opts.sources["cmdline"] = {}
+      else
+        opts.cmdline = opts.cmdline or {}
+        opts.cmdline.sources = {}
+      end
       -- setup compat sources
       local enabled = opts.sources.default
       for _, source in ipairs(opts.sources.compat or {}) do


### PR DESCRIPTION
## Description
This `blink.cmp` [commit](https://github.com/Saghen/blink.cmp/commit/93215d80346e14763a67d97785dccb1e1c3a6775) introduced a breaking change on main branch. `cmdline` is now top-level and the option is `opts.cmdline.sources = {}`.

I also added a note to remove this hack when the next blink stable release comes out, which should be greater than current 0.11.0 and just do it normally in `opts` instead.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None.
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
