### PR TITLE
fix(blink): `blink` released new version, remove previous hack

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -81,6 +81,10 @@ return {
         default = { "lsp", "path", "snippets", "buffer" },
       },
 
+      cmdline = {
+        sources = {},
+      },
+
       keymap = {
         preset = "enter",
         ["<C-y>"] = { "select_and_accept" },
@@ -88,15 +92,6 @@ return {
     },
     ---@param opts blink.cmp.Config | { sources: { compat: string[] } }
     config = function(_, opts)
-      -- HACK: remove when next `blink.cmp` stable release is available
-      -- and just do `opts.cmdline.sources = {}` directly in `opts`
-      -- Should be greater than current 0.11.0
-      if not vim.g.lazyvim_blink_main then
-        opts.sources["cmdline"] = {}
-      else
-        opts.cmdline = opts.cmdline or {}
-        opts.cmdline.sources = {}
-      end
       -- setup compat sources
       local enabled = opts.sources.default
       for _, source in ipairs(opts.sources.compat or {}) do


### PR DESCRIPTION
## Description
`blink.cmp` just made a new stable release. So, remove the hack and define the option properly in `opts`.

If I knew it would make a release tonight, I'd definitely hold off my recent PR.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
