### PR TITLE
fix(blink): remove unnecessary `sources` from `cmdline`

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -83,7 +83,6 @@ return {
 
       cmdline = {
         enabled = false,
-        sources = {},
       },
 
       keymap = {


### PR DESCRIPTION
## Description
Like Saghen already mentioned in the other PR, this [commit](https://github.com/Saghen/blink.cmp/commit/19f60a675eaaf4b160bd6458bfd72fc005da5b3f) does a check based on the `enabled` field before adding sources, so it's no longer needed to define it.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
