### PR TITLE
feat(octo): add support for snacks picker

### DIFF
--- a/lua/lazyvim/plugins/extras/util/octo.lua
+++ b/lua/lazyvim/plugins/extras/util/octo.lua
@@ -42,12 +42,14 @@ return {
     "pwntester/octo.nvim",
     opts = function(_, opts)
       vim.treesitter.language.register("markdown", "octo")
-      if LazyVim.has("telescope.nvim") then
+      if LazyVim.has_extra("editor.telescope") then
         opts.picker = "telescope"
-      elseif LazyVim.has("fzf-lua") then
+      elseif LazyVim.has_extra("editor.fzf") then
         opts.picker = "fzf-lua"
+      elseif LazyVim.has_extra("editor.snacks_picker") then
+        opts.picker = "snacks"
       else
-        LazyVim.error("`octo.nvim` requires `telescope.nvim` or `fzf-lua`")
+        LazyVim.error("`octo.nvim` requires `telescope.nvim` or `fzf-lua` or `snacks.nvim`")
       end
 
       -- Keep some empty windows in sessions


### PR DESCRIPTION
## Description
A [PR](https://github.com/pwntester/octo.nvim/pull/858) has landed in `octo.nvim` that adds initial support for `snacks.picker`. Enable it in `octo.nvim` Extra if user uses `snacks.picker`.

I also changed the checks to use `has_extra`. This was needed for `snacks.picker`, since `has("snacks.nvim")` doesn't ensure that user also has `snacks.picker` enabled. For the others I just changed it for conformity, but if you think there might be something wrong about that (that I'm unable to think of), please feel free to change them back.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
