### PR TITLE
fix(sql): fix autocomplete when `omni` is used as a `blink.cmp` source

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/sql.lua
+++ b/lua/lazyvim/plugins/extras/lang/sql.lua
@@ -28,6 +28,11 @@ end
 
 local sql_ft = { "sql", "mysql", "plsql" }
 
+-- disable nvim default `sql_completion` plugin to be compatible with blink.cmp's omni
+-- while still showing some keywords from the syntax autocomplete sources
+vim.g.omni_sql_default_compl_type = "syntax"
+vim.g.loaded_sql_completion = true
+
 return {
   recommended = function()
     return LazyVim.extras.wants({


### PR DESCRIPTION
## Description

I was trying the `omni` source with `blink.cmp` and I had an error which you can read more about in this `nvim-compe` issue: https://github.com/hrsh7th/nvim-compe/issues/286 but the message keeps showing up after setting that to `syntax` so I mark the default plugin as loaded, and it works as expected, I think there are more items returned but I cannot confirm that :).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
