### PR TITLE
feat(extras): add lua-console.nvim

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/lua-console.lua
+++ b/lua/lazyvim/plugins/extras/coding/lua-console.lua
@@ -1,0 +1,9 @@
+return {
+  "yarospace/lua-console.nvim",
+  lazy = true,
+  keys = {
+    { "`", desc = "Lua-console - toggle" },
+    { "<Leader>`", desc = "Lua-console - attach to buffer" },
+  },
+  opts = {},
+}


### PR DESCRIPTION
## Description

[Lua-console.nvim](https://github.com/YaroSpace/lua-console.nvim) handy scratch pad / Lua REPL / debug console for Lua and Neovim  development, exploration and configuration.   A modernized and enhanced successor to `SnipRun / Luapad / Luadev`.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
