### PR TITLE
Improved plugin doc strings

### DIFF
--- a/lua/lazyvim/plugins/coding.lua
+++ b/lua/lazyvim/plugins/coding.lua
@@ -1,5 +1,7 @@
 return {
-  -- auto pairs
+  -- Auto pairs
+  -- Automatically inserts a matching closing character
+  -- when you type an opening character like `"`, `[`, or `(`.
   {
     "echasnovski/mini.pairs",
     event = "VeryLazy",
@@ -20,14 +22,18 @@ return {
     end,
   },
 
-  -- comments
+  -- Improves comment syntax, lets Neovim handle multiple
+  -- types of comments for a single language, and relaxes rules
+  -- for uncommenting.
   {
     "folke/ts-comments.nvim",
     event = "VeryLazy",
     opts = {},
   },
 
-  -- Better text-objects
+  -- Extends the a & i text objects, this adds the ability to select
+  -- arguments, function calls, text within quotes and brackets, and to
+  -- repeat those selections to select an outer text object.
   {
     "echasnovski/mini.ai",
     event = "VeryLazy",
@@ -64,6 +70,8 @@ return {
     end,
   },
 
+  -- Configures LuaLS to support auto-completion and type checking
+  -- while editing your Neovim configuration.
   {
     "folke/lazydev.nvim",
     ft = "lua",

--- a/lua/lazyvim/plugins/extras/ui/edgy.lua
+++ b/lua/lazyvim/plugins/extras/ui/edgy.lua
@@ -1,5 +1,5 @@
 return {
-  -- edgy
+  -- Create and display predefined window layouts.
   {
     "folke/edgy.nvim",
     event = "VeryLazy",

--- a/lua/lazyvim/plugins/extras/ui/mini-animate.lua
+++ b/lua/lazyvim/plugins/extras/ui/mini-animate.lua
@@ -8,7 +8,8 @@ return {
     },
   },
 
-  -- setup animate
+  -- Animates many common Neovim actions, like scrolling,
+  -- moving the cursor, and resizing windows.
   {
     "echasnovski/mini.animate",
     event = "VeryLazy",

--- a/lua/lazyvim/plugins/extras/ui/smear-cursor.lua
+++ b/lua/lazyvim/plugins/extras/ui/smear-cursor.lua
@@ -1,3 +1,4 @@
+-- Animates cursor movement with a smear effect.
 return {
   "sphamba/smear-cursor.nvim",
   event = "VeryLazy",

--- a/lua/lazyvim/plugins/linting.lua
+++ b/lua/lazyvim/plugins/linting.lua
@@ -1,4 +1,6 @@
 return {
+  -- Asynchronously calls language-specific linter tools and reports
+  -- their results via the `vim.diagnostic` module.
   {
     "mfussenegger/nvim-lint",
     event = "LazyFile",

--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -60,7 +60,8 @@ return {
     end,
   },
 
-  -- statusline
+  -- Displays a fancy status line with git status,
+  -- LSP diagnostics, filetype information, and more.
   {
     "nvim-lualine/lualine.nvim",
     event = "VeryLazy",


### PR DESCRIPTION
## Description

This improves the comment strings that produce documentation for different plugins. I often look at the docs to learn what stuff is already installed, and this would help people like me to quickly understand what some of the plugins do.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
