### PR TITLE
fix(extras/rust): fix config key for files.exclude

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -93,9 +93,10 @@ return {
               },
             },
             files = {
-              excludeDirs = {
+              exclude = {
                 ".direnv",
                 ".git",
+                ".jj",
                 ".github",
                 ".gitlab",
                 "bin",


### PR DESCRIPTION
## Description

It seems like the key changed its name from `files.excludeDirs` to `files.exclude` at some point. At least that is the (only) name that can be found in the docs now: https://rust-analyzer.github.io/book/configuration.html (ctrl+f for "files.exclude")

Also add `".jj"` as an excluded directory, which is like `".git"` but for jujutsu (https://jj-vcs.github.io/jj/latest/cli-reference/#jj-git-init).

---

As an aside, `cargo.loadOutDirsFromCheck` also does not seem to exist (anymore). But I don't know more about that option, so I haven't touched it in this PR.

## Related Issue(s)

Not sure if any.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
