### PR TITLE
fix(blink): make sure to use `LazyVim.config.icons.kinds`

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/blink.lua
+++ b/lua/lazyvim/plugins/extras/coding/blink.lua
@@ -143,6 +143,7 @@ return {
             items = transform_items and transform_items(ctx, items) or items
             for _, item in ipairs(items) do
               item.kind = kind_idx or item.kind
+              item.kind_icon = LazyVim.config.icons.kinds[item.kind_name] or item.kind_icon or nil
             end
             return items
           end


### PR DESCRIPTION
## Description
This blink [commit](https://github.com/Saghen/blink.cmp/commit/010d939e7fd6cb8d8e4a9b1dec228b8405d15fb4) made a change, so that third party sources can provide their own `item.kind_icon` and `item.kind_name`. The problem is that these icons will take precedence over `config.kind_icons[kind]`, which LazyVim sets [here](https://github.com/LazyVim/LazyVim/blob/541b83276e0fe92f7d0d6c9f283cd15ccba5a2fd/lua/lazyvim/plugins/extras/coding/blink.lua#L164-L164).

I noticed that `blink-cmp-copilot` also started providing its own in the items that it returns. I noticed this because I have the following in my configuration `columns = { { "label", "label_description", gap = 1 }, { "kind_icon", "kind" } }`.  The icon that it uses is a smaller icon one character long, which by default it will scale up and show normally like the LazyVim icon. But when you put another component next to it (like `kind`) in the `columns` field, then it shows the normal size of the icon next to the `kind` and it looks kinda weird compared to the default LazyVim icon.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots
Before (the default icon provided by `blink-cmp-copilot`)
![2025-02-22_02-17](https://github.com/user-attachments/assets/aa7da566-a577-4d32-822c-f2d891b3c047)

After (the LazyVim icon)
![2025-02-22_02-18](https://github.com/user-attachments/assets/342580a9-5a36-47fa-aad7-c139f2765d74)

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
