### PR TITLE
fix(copilot-chat): switch from deprecated picker integrations

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/copilot-chat.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot-chat.lua
@@ -1,28 +1,3 @@
-local M = {}
-
----@param kind string
-function M.pick(kind)
-  return function()
-    local actions = require("CopilotChat.actions")
-    local items = actions[kind .. "_actions"]()
-    if not items then
-      LazyVim.warn("No " .. kind .. " found on the current line")
-      return
-    end
-    local map = {
-      telescope = "telescope",
-      fzf = "fzflua",
-      snacks = "snacks",
-    }
-    for _, def in pairs(LazyVim.config.get_defaults()) do
-      if def.enabled and map[def.name] then
-        return require("CopilotChat.integrations." .. map[def.name]).pick(items)
-      end
-    end
-    Snacks.notify.error("No picker found")
-  end
-end
-
 return {
   {
     "CopilotC-Nvim/CopilotChat.nvim",
@@ -62,16 +37,25 @@ return {
       {
         "<leader>aq",
         function()
-          local input = vim.fn.input("Quick Chat: ")
-          if input ~= "" then
-            require("CopilotChat").ask(input)
-          end
+          vim.ui.input({
+            prompt = "Quick Chat: ",
+          }, function(input)
+            if input ~= "" then
+              require("CopilotChat").ask(input)
+            end
+          end)
         end,
         desc = "Quick Chat (CopilotChat)",
         mode = { "n", "v" },
       },
-      -- Show prompts actions with telescope
-      { "<leader>ap", M.pick("prompt"), desc = "Prompt Actions (CopilotChat)", mode = { "n", "v" } },
+      {
+        "<leader>ap",
+        function()
+          require("CopilotChat").select_prompt()
+        end,
+        desc = "Prompt Actions (CopilotChat)",
+        mode = { "n", "v" },
+      },
     },
     config = function(_, opts)
       local chat = require("CopilotChat")


### PR DESCRIPTION
- Instead of using picker integrations (that are now deprecated), switch to using CopilotChat.select_prompt() that is using `vim.ui.select` which brings the selector integration responsibility to pickers instead of plugin
- Use vim.ui.input instead of vim.fn.input for consistency

Reason why this was deprecated in CopilotChat.nvim (by me) and will be removed in future is because these integrations never made any sense anyway when `vim.ui.select` overrides exist.

## Screenshots

Using fzf-lua in my config, outside of LazyNvim but same thing applies:

![image](https://github.com/user-attachments/assets/a5171ffe-63a6-4b79-9925-fd8bef52e52f)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
