### PR TITLE
feat(mini-snippets): add leaner support for package.json

### DIFF
--- a/lua/lazyvim/plugins/xtras.lua
+++ b/lua/lazyvim/plugins/xtras.lua
@@ -4,6 +4,7 @@ local prios = {
   ["lazyvim.plugins.extras.dap.core"] = 1,
   ["lazyvim.plugins.extras.coding.nvim-cmp"] = 2,
   ["lazyvim.plugins.extras.ui.edgy"] = 2,
+  ["lazyvim.plugins.extras.coding.mini-snippets"] = 4,
   ["lazyvim.plugins.extras.lang.typescript"] = 5,
   ["lazyvim.plugins.extras.coding.blink"] = 5,
   ["lazyvim.plugins.extras.formatting.prettier"] = 10,


### PR DESCRIPTION
## Related Issue(s)

- echasnovski/mini.nvim#1571
- #5669

## Same functionality now with 60% less LOC!

There is no need for any of the previous `json` validation when the paths are provided explicitly.
This also adds compatibility with `from_lang` so the user is not required to create a `package.json`.
The extra should be loaded before `lang` extras in case they add to `lang_additions`. It works without setting a priority since `coding` comes first alphabetically and `lang.typescript` does not add any options, but I wanted to be more explicit.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
