### PR TITLE
Extra lang Scala: Only use `nvim-metals` plugin to implement

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/scala.lua
+++ b/lua/lazyvim/plugins/extras/lang/scala.lua
@@ -11,66 +11,70 @@ return {
   },
   {
     "scalameta/nvim-metals",
-    ft = { "scala", "sbt" },
-    config = function() end,
-  },
-  {
-    "neovim/nvim-lspconfig",
-    opts = {
-      servers = {
-        metals = {
-          keys = {
-            {
-              "<leader>me",
-              function()
-                require("telescope").extensions.metals.commands()
-              end,
-              desc = "Metals commands",
-            },
-            {
-              "<leader>mc",
-              function()
-                require("metals").compile_cascade()
-              end,
-              desc = "Metals compile cascade",
-            },
-            {
-              "<leader>mh",
-              function()
-                require("metals").hover_worksheet()
-              end,
-              desc = "Metals hover worksheet",
-            },
-          },
-          init_options = {
-            statusBarProvider = "off",
-          },
-          settings = {
-            showImplicitArguments = true,
-            excludedPackages = { "akka.actor.typed.javadsl", "com.github.swagger.akka.javadsl" },
-          },
-        },
-      },
-      setup = {
-        metals = function(_, opts)
-          local metals = require("metals")
-          local metals_config = vim.tbl_deep_extend("force", metals.bare_config(), opts)
-          metals_config.on_attach = LazyVim.has("nvim-dap") and metals.setup_dap or nil
-
-          local nvim_metals_group = vim.api.nvim_create_augroup("nvim-metals", { clear = true })
-          vim.api.nvim_create_autocmd("FileType", {
-            pattern = { "scala", "sbt" },
-            callback = function()
-              metals.initialize_or_attach(metals_config)
-            end,
-            group = nvim_metals_group,
-          })
-          return true
+    dependencies = {
+      "nvim-lua/plenary.nvim",
+    },
+    keys = {
+      {
+        "<leader>me",
+        function()
+          require("telescope").extensions.metals.commands()
         end,
+        desc = "Metals commands",
+      },
+      {
+        "<leader>mc",
+        function()
+          require("metals").compile_cascade()
+        end,
+        desc = "Metals compile cascade",
+      },
+      {
+        "<leader>mh",
+        function()
+          require("metals").hover_worksheet()
+        end,
+        desc = "Metals hover worksheet",
       },
     },
-  },
+    ft = { "scala", "sbt", "java" },
+    opts = function()
+      local metals_config = require("metals").bare_config()
 
+      metals_config.init_options.statusBarProvider = "off"
+
+      metals_config.settings = {
+        verboseCompilation = true,
+        showImplicitArguments = true,
+        showImplicitConversionsAndClasses = true,
+        showInferredType = true,
+        superMethodLensesEnabled = true,
+        excludedPackages = {
+          "akka.actor.typed.javadsl",
+          "org.apache.pekko.actor.typed.javadsl",
+          "com.github.swagger.akka.javadsl",
+        },
+        testUserInterface = "Test Explorer",
+      }
+
+      metals_config.on_attach = function(client, bufnr)
+        -- your on_attach function
+        require("metals").setup_dap()
+      end
+
+      return metals_config
+    end,
+    config = function(self, metals_config)
+      local nvim_metals_group = vim.api.nvim_create_augroup("nvim-metals", { clear = true })
+      vim.api.nvim_create_autocmd("FileType", {
+        pattern = self.ft,
+        callback = function()
+          require("metals").initialize_or_attach(metals_config)
+        end,
+        group = nvim_metals_group,
+      })
+    end,
+  },
   {
     "mfussenegger/nvim-dap",
     optional = true,


### PR DESCRIPTION

## Description
Scala lang Extra should NOT be configured via `neovim/nvim-lspconfig`. This PR removes `neovim/nvim-lspconfig` config and replace it by `nvim-metals` only. From [nvim-metals README.md](https://github.com/scalameta/nvim-metals): _"NOTE: This plugin works without needing to install neovim/nvim-lspconfig. If you have it installed for other languages, that's not a problem, but make sure you do not have Metals configured through nvim-lspconfig while using this plugin"_

## Related Issue(s)

No specific issue, this is attempt to follow users guide of Scala nvim plugin : https://github.com/scalameta/nvim-metals

## Screenshots

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
