### PR TITLE
fix(luasnip): add missing optional tag to garymjr/nvim-snippets

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/luasnip.lua
+++ b/lua/lazyvim/plugins/extras/coding/luasnip.lua
@@ -1,6 +1,6 @@
 return {
   -- disable builtin snippet support
-  { "garymjr/nvim-snippets", enabled = false },
+  { "garymjr/nvim-snippets", optional = true, enabled = false },
 
   -- add luasnip
   {


### PR DESCRIPTION
## Description

This pull request fixes an issue where the `nvim-snippets` plugin was incorrectly marked as disabled due to the missing optional tag in the configuration. By adding the `optional = true` tag, the plugin will no longer appear as disabled when it is not installed.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/8391b047-22e6-416b-acb8-3b8af3932469)

After:
![image](https://github.com/user-attachments/assets/8c1775ce-8aa9-434e-986d-a1db3ac7bd56)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
