### PR TITLE
fix(grug-far): add support for GrugFarWithin so it gets loaded by default

### DIFF
--- a/lua/lazyvim/plugins/editor.lua
+++ b/lua/lazyvim/plugins/editor.lua
@@ -4,7 +4,7 @@ return {
   {
     "MagicDuck/grug-far.nvim",
     opts = { headerMaxWidth = 80 },
-    cmd = "GrugFar",
+    cmd = { "GrugFar", "GrugFarWithin" },
     keys = {
       {
         "<leader>sr",


### PR DESCRIPTION
## Description

https://github.com/MagicDuck/grug-far.nvim is the default find and replace plugin for LazyVim.

It recently added support for being able to do a find / replace within a visual selection to limit the scope of a search.

It did that by introducing a new command called `:GrugFarWithin`. This PR adds that as a `cmd` so it gets loaded by default. Without this PR, you cannot call this command unless you first call `:GrugFar`. This was identified by the author of Grug Far.

## Related Issue(s)

There is no issue in this repo, but this feature is related to: https://github.com/MagicDuck/grug-far.nvim/issues/357

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.

I also want to give a shout-out to @MagicDuck who is the author of the plugin. He implemented this feature so fast and has been super helpful in his repo's issue tracker.