### PR TITLE
fix(extras.vscode): replace `VSCodeNotify` deprecated API usage

### DIFF
--- a/lua/lazyvim/plugins/extras/vscode.lua
+++ b/lua/lazyvim/plugins/extras/vscode.lua
@@ -30,7 +30,7 @@ Config.options.defaults.cond = function(plugin)
 end
 vim.g.snacks_animate = false
 
--- Add some vscode specific keymaps
+-- Add some VSCode specific keymaps
 vim.api.nvim_create_autocmd("User", {
   pattern = "LazyVimKeymapsDefaults",
   callback = function()
@@ -39,13 +39,13 @@ vim.api.nvim_create_autocmd("User", {
     vim.keymap.set("n", "<leader>/", [[<cmd>lua require('vscode').action('workbench.action.findInFiles')<cr>]])
     vim.keymap.set("n", "<leader>ss", [[<cmd>lua require('vscode').action('workbench.action.gotoSymbol')<cr>]])
 
-    -- Keep undo/redo lists in sync with VsCode
-    vim.keymap.set("n", "u", "<Cmd>call VSCodeNotify('undo')<CR>")
-    vim.keymap.set("n", "<C-r>", "<Cmd>call VSCodeNotify('redo')<CR>")
+    -- Keep undo/redo lists in sync with VSCode
+    vim.keymap.set("n", "u", [[<cmd>lua require('vscode').action('undo')<cr>]])
+    vim.keymap.set("n", "<C-r>", [[<cmd>lua require('vscode').action('redo')<cr>]])
 
     -- Navigate VSCode tabs like lazyvim buffers
-    vim.keymap.set("n", "<S-h>", "<Cmd>call VSCodeNotify('workbench.action.previousEditor')<CR>")
-    vim.keymap.set("n", "<S-l>", "<Cmd>call VSCodeNotify('workbench.action.nextEditor')<CR>")
+    vim.keymap.set("n", "<S-h>", [[<cmd>lua require('vscode').action('workbench.action.previousEditor')<cr>]])
+    vim.keymap.set("n", "<S-l>", [[<cmd>lua require('vscode').action('workbench.action.nextEditor')<cr>]])
   end,
 })
 


### PR DESCRIPTION
## Description

Replace the deprecated `call VSCodeNotify(...)` API calls with `lua require('vscode').action(...)`.

The VSCode Neovim extension marked `VSCodeNotify` API as deprecated (see the extension's [README.md section](https://github.com/vscode-neovim/vscode-neovim?tab=readme-ov-file#vimscript)). Since some of the existing keymappings already use the new recommended extension's API, we can migrate the deprecated calls to make the code look consistent.

Also, use `VSCode` name consistently in the comment sections of this extra.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
