### PR TITLE
fix(extras.ui.mini-animate): associate toggle keymap with plugin

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -149,7 +149,6 @@ Snacks.toggle.option("showtabline", { off = 0, on = vim.o.showtabline > 0 and vi
 Snacks.toggle.treesitter():map("<leader>uT")
 Snacks.toggle.option("background", { off = "light", on = "dark" , name = "Dark Background" }):map("<leader>ub")
 Snacks.toggle.dim():map("<leader>uD")
-Snacks.toggle.animate():map("<leader>ua")
 Snacks.toggle.indent():map("<leader>ug")
 Snacks.toggle.scroll():map("<leader>uS")
 Snacks.toggle.profiler():map("<leader>dpp")

--- a/lua/lazyvim/plugins/extras/ui/mini-animate.lua
+++ b/lua/lazyvim/plugins/extras/ui/mini-animate.lua
@@ -60,5 +60,14 @@ return {
         },
       })
     end,
+    keys = {
+      {
+        "<leader>ua",
+        function()
+          Snacks.toggle.animate()
+        end,
+        desc = "Toggle Animation",
+      },
+    },
   },
 }


### PR DESCRIPTION
## Description

Currently, the `<leader>ua` keymap is managed independent of whether the extra plugin is installed. This PR associates the binding with the plugin.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
