### PR TITLE
Fix: Enable venv-selector even when telescope is not available

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -116,9 +116,6 @@ return {
     "linux-cultist/venv-selector.nvim",
     branch = "regexp", -- Use this branch for the new version
     cmd = "VenvSelect",
-    enabled = function()
-      return LazyVim.has("telescope.nvim")
-    end,
     opts = {
       settings = {
         options = {


### PR DESCRIPTION
## Description

Enable the `venv-selector` plugin even when the telescope plugin is not available. Now the `venv-selector` plugin supports `fzf-lua` and native selection and by default, it chooses the previous, if available.

More on this PR: https://github.com/linux-cultist/venv-selector.nvim/pull/188

## Related Issue(s)

None

## Screenshots

N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
