### PR TITLE
Add keymap for FzfLua git_stash

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/fzf.lua
+++ b/lua/lazyvim/plugins/extras/editor/fzf.lua
@@ -227,6 +227,7 @@ return {
       -- git
       { "<leader>gc", "<cmd>FzfLua git_commits<CR>", desc = "Commits" },
       { "<leader>gs", "<cmd>FzfLua git_status<CR>", desc = "Status" },
+      { "<leader>gz", "<cmd>FzfLua git_stash<CR>", desc = "Stashes" },
       -- search
       { '<leader>s"', "<cmd>FzfLua registers<cr>", desc = "Registers" },
       { "<leader>sa", "<cmd>FzfLua autocmds<cr>", desc = "Auto Commands" },


### PR DESCRIPTION
## Description
Add a keymap for FzfLua git_stash bound to <leader>gz, inspired by Doom Emacs’ use of z for stash-related commands in Magit.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
