### PR TITLE
fix(venvSelect): remove telescope requirement

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -116,9 +116,6 @@ return {
     "linux-cultist/venv-selector.nvim",
     branch = "regexp", -- Use this branch for the new version
     cmd = "VenvSelect",
-    enabled = function()
-      return LazyVim.has("telescope.nvim")
-    end,
     opts = {
       settings = {
         options = {


### PR DESCRIPTION
## Description

In VenvSelect, commit [c745e9c86](https://github.com/linux-cultist/venv-selector.nvim/commit/c745e9c862561be17904495a276d3d44e2f2d9e9) (in the `regexp` branch) introduced support for native pickers, thus Telescope is not a requirement, opening the use for other pickers, like snacks'.

## Related Issue(s)

Related to #3612.

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
