### PR TITLE
Fixed jdtls bin path for a proper lsp initialization

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -85,10 +85,13 @@ return {
     dependencies = { "folke/which-key.nvim" },
     ft = java_filetypes,
     opts = function()
-      local cmd = { vim.fn.exepath("jdtls") }
+      local cmd = { vim.fn.exepath("jdtls") } -- Can be empty if executed too early
       if LazyVim.has("mason.nvim") then
         local mason_registry = require("mason-registry")
         local lombok_jar = mason_registry.get_package("jdtls"):get_install_path() .. "/lombok.jar"
+
+        -- Should be re-executed after require("mason-registry") to get a real value
+        cmd = { vim.fn.exepath("jdtls") }
         table.insert(cmd, string.format("--jvm-arg=-javaagent:%s", lombok_jar))
       end
       return {


### PR DESCRIPTION
## Description

java extra is failing with following error
```
...r/neovim/0.10.4_1/share/nvim/runtime/lua/vim/lsp/rpc.lua:800: Spawning language server with cmd: `{ "", "--jvm-arg=-javaagent:/Users/d1/.local/share/lazyvim/mason/packages/jdtls/lombok.jar", "-configuration", "/Users/d1/.cache/lazyvim/jdtls/java_sandbox/config", "-data", "/Users/d1/.cache/lazyvim/jdtls/java_sandbox/workspace" }` failed with error message: ...r/neovim/0.10.4_1/share/nvim/runtime/lua/vim/_system.lua:245: EACCES: permission denied
```

As you see from the error an actual cmd is empty.
It happens when `vim.fn.exepath("jdtls")` is executed too early and returns `""`.
Executing `vim.fn.exepath("jdtls")` after `require("mason-registry")` solves this problem for neovim 0.14.4_1.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
