### PR TITLE
fix(python): always enable venv-selector

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -116,9 +116,6 @@ return {
     "linux-cultist/venv-selector.nvim",
     branch = "regexp", -- Use this branch for the new version
     cmd = "VenvSelect",
-    enabled = function()
-      return LazyVim.has("telescope.nvim")
-    end,
     opts = {
       settings = {
         options = {


### PR DESCRIPTION
venv-selector works with fzf.lua and native picker also now - https://github.com/linux-cultist/venv-selector.nvim/pull/188

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Enable venv-selector.nvim even if telescope is not installed.
Previously, it worked only with telescope installed but now it works with fzf.lua and native picker also. This was implemented in https://github.com/linux-cultist/venv-selector.nvim/pull/188

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
NA

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
NA

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
