### PR TITLE
feat(nix): add nixfmt to mason install

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/nix.lua
+++ b/lua/lazyvim/plugins/extras/lang/nix.lua
@@ -4,6 +4,10 @@ return {
     root = "flake.nix",
   },
   {
+    "williamboman/mason.nvim",
+    opts = { ensure_installed = { "nixfmt" } },
+  },
+  {
     "nvim-treesitter/nvim-treesitter",
     opts = { ensure_installed = { "nix" } },
   },


### PR DESCRIPTION
## Description

`nixfmt` will soon be used to format Nixpkgs. It is also already configured to be used with conform.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
