### PR TITLE
fix(extras.lang): use 'nvim-paredit' instead 'nvim-treesitter-sexp' as clojure S-exp Plugin

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/clojure.lua
+++ b/lua/lazyvim/plugins/extras/lang/clojure.lua
@@ -27,7 +27,7 @@ return {
   },
 
   -- Add s-exp mappings
-  { "PaterJason/nvim-treesitter-sexp", opts = {}, event = "LazyFile" },
+  { "julienvincent/nvim-paredit", opts = {}, event = "LazyFile" },
 
   -- Colorize the output of the log buffer
   {


### PR DESCRIPTION
## Description

On [this bug](https://github.com/LazyVim/LazyVim/issues/5866) I told about a plugin that was falty on clojure lang extra, with the goal to have him removed but @mitchelkuijpers suggested a new one that I implemented on this PR.

[The plugin](https://github.com/julienvincent/nvim-paredit) is 1:1 with the keymaps of the older one.

## Related Issue(s)

https://github.com/LazyVim/LazyVim/issues/5866

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
