### PR TITLE
fix(ai.extras.copilot): update status retrieval for lualine

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/copilot.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot.lua
@@ -51,7 +51,7 @@ return {
         LazyVim.lualine.status(LazyVim.config.icons.kinds.Copilot, function()
           local clients = package.loaded["copilot"] and LazyVim.lsp.get_clients({ name = "copilot", bufnr = 0 }) or {}
           if #clients > 0 then
-            local status = require("copilot.api").status.data.status
+            local status = require("copilot.status").data.status
             return (status == "InProgress" and "pending") or (status == "Warning" and "error") or "ok"
           end
         end)


### PR DESCRIPTION
## Description

Following copilot.lua refactoring in https://github.com/zbirenbaum/copilot.lua/pull/431, lualine is unable to refresh.

We face the following error

```
  Error  15:55:22 msg_show.lua_error Error executing vim.schedule lua callback: ...share/nvim/lazy/lualine.nvim/lua/lualine/utils/utils.lua:211: lualine: Failed to refresh statusline:
.../.local/share/nvim/lazy/lualine.nvim/lua/lualine.lua:415: Error executing lua: ...m/lazy/LazyVim/lua/lazyvim/plugins/extras/ai/copilot.lua:54: attempt to index field 'status' (a nil value)
stack traceback:
	...m/lazy/LazyVim/lua/lazyvim/plugins/extras/ai/copilot.lua:54: in function 'status'
	...cal/share/nvim/lazy/LazyVim/lua/lazyvim/util/lualine.lua:17: in function 'cond'
	...l/share/nvim/lazy/lualine.nvim/lua/lualine/component.lua:275: in function 'draw'
	...are/nvim/lazy/lualine.nvim/lua/lualine/utils/section.lua:26: in function 'draw_section'
	.../.local/share/nvim/lazy/lualine.nvim/lua/lualine.lua:167: in function 'statusline'
	.../.local/share/nvim/lazy/lualine.nvim/lua/lualine.lua:309: in function <...gaze/.local/share/nvim/lazy/lualine.nvim/lua/lualine.lua:290>
	[C]: in function 'nvim_win_call'
	.../.local/share/nvim/lazy/lualine.nvim/lua/lualine.lua:415: in function 'refresh'
	.../.local/share/nvim/lazy/lualine.nvim/lua/lualine.lua:491: in function <.../.local/share/nvim/lazy/lualine.nvim/lua/lualine.lua:490>
	[C]: in function 'pcall'
	...share/nvim/lazy/lualine.nvim/lua/lualine/utils/utils.lua:214: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```

## Related Issue(s)

#5899 

## Screenshots

![Screenshot 2025-04-05 at 16 16 56](https://github.com/user-attachments/assets/3dc28dc6-1622-41ef-9e70-380a37064da4)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
