### PR TITLE
feat(extras): add snacks picker to octo extra

### DIFF
--- a/lua/lazyvim/plugins/extras/util/octo.lua
+++ b/lua/lazyvim/plugins/extras/util/octo.lua
@@ -47,7 +47,7 @@ return {
       elseif LazyVim.has("fzf-lua") then
         opts.picker = "fzf-lua"
       else
-        LazyVim.error("`octo.nvim` requires `telescope.nvim` or `fzf-lua`")
+        opts.picker = "snacks"
       end
 
       -- Keep some empty windows in sessions


### PR DESCRIPTION
## Description

Hi! This is a tiny pr that adds support for snacks picker to octo.nvim. It is [already supported](https://github.com/pwntester/octo.nvim/pull/858) by octo, so I just needed to set it in the extra in case snacks picker is used

## Screenshots

![CleanShot 2025-04-06 at 10 42 21@2x](https://github.com/user-attachments/assets/bbfe974f-7920-4040-8c41-5fea6f23b3d2)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
