### PR TITLE
fix(copilot.lua): changed endpoint for lualine status

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/copilot.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot.lua
@@ -51,7 +51,7 @@ return {
         LazyVim.lualine.status(LazyVim.config.icons.kinds.Copilot, function()
           local clients = package.loaded["copilot"] and LazyVim.lsp.get_clients({ name = "copilot", bufnr = 0 }) or {}
           if #clients > 0 then
-            local status = require("copilot.api").status.data.status
+            local status = require("copilot.status").data.status
             return (status == "InProgress" and "pending") or (status == "Warning" and "error") or "ok"
           end
         end)


### PR DESCRIPTION
## Description

I have refactor a lot of code in copilot.lua so the endpoint for the status has changed.
A few users have created bug reports on the project reporting this.
Warning! I have not tested the change as I do not use LazyVim.

## Related Issue(s)

https://github.com/zbirenbaum/copilot.lua/issues/432
https://github.com/zbirenbaum/copilot.lua/issues/437

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
