### PR TITLE
feat(ai.coding.yanky): Use default highlight group for yanked region

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/yanky.lua
+++ b/lua/lazyvim/plugins/extras/coding/yanky.lua
@@ -7,6 +7,10 @@ return {
   opts = {
     highlight = { timer = 150 },
   },
+  init = function(_)
+    vim.api.nvim_set_hl(0, "YankyYanked", { link = "IncSearch" })
+    vim.api.nvim_set_hl(0, "YankyPut", { link = "IncSearch" })
+  end,
   keys = {
     {
       "<leader>p",


### PR DESCRIPTION
Set yanky.nvim's highlight groups, YankyPut and YankyYanked, to use vim.hl.on_yank()'s default highlight group for yanked region, IncSearch.

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Without yanky.nvim extra installed, yanking will use the default highlight group, IncSearch.

Reference from LazyVim's Documentation,

[link](https://www.lazyvim.org/configuration/general)

Autocommand:
```lua
-- Highlight on yank
vim.api.nvim_create_autocmd("TextYankPost", {
  group = augroup("highlight_yank"),
  callback = function()
    (vim.hl or vim.highlight).on_yank()
  end,
})
```

Reference from NeoVim's Documentation,

[link](https://neovim.io/doc/user/lua.html#vim.hl.on_yank())

documentation states that vim.hl.on_yank() uses the default highlight group for yanked region as IncSearch.

> {opts} (table?) Optional parameters
> higroup highlight group for yanked region (default "IncSearch")

However, when you install yank.nvim extra, yank.nvim's two highlight groups, YankyPut and YankyYanked, is linked to Search highlight group by default ([link](https://github.com/gbprod/yanky.nvim?tab=readme-ov-file#-colors)).

This can be puzzling for users, at least for me, because I previously had colors when I yank, but after installing yank.nvim, the colors are gone.

This PR links yank.nvim's two highlight groups, YankyPut and YankyYanked, to the default highlight group, IncSearch, used by vim.hl.on_yanked().

As a result, after installing yank.nvim extra, user should still see colors when they yank, just as expected. 


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
