### PR TITLE
fix(json-load-migrate): prepend the extras module prefix if it's not already using that

### DIFF
--- a/lua/lazyvim/util/json.lua
+++ b/lua/lazyvim/util/json.lua
@@ -62,8 +62,9 @@ function M.migrate()
       ---@diagnostic disable-next-line: no-unknown
       json.data.hashes = nil
     end
+    -- prepend the extras module prefix if it's not yet using that
     json.data.extras = vim.tbl_map(function(extra)
-      return "lazyvim.plugins.extras." .. extra
+      return extra:match("^lazyvim%.plugins%.extras%.") and extra or "lazyvim.plugins.extras." .. extra
     end, json.data.extras or {})
   elseif json.data.version == 1 then
     json.data.extras = vim.tbl_map(function(extra)


### PR DESCRIPTION
## Description

As I was working on Omakub to toggle the extras modules based on the dev languages installed (see https://github.com/basecamp/omakub/pull/269), I noticed that LazyVIM was migrating the extras module names with the prefixes that were already added by us. That happens because the language might be installed before LazyVIM is booted for the first time, which would create the lazyvim.json with the correct version and all.

This should fix the issue there.

## Related Issue(s)

Didn't open an issue. Sorry.

## Screenshots

N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
