### PR TITLE
docs(mini-snippets): fix typo in the documentation

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/mini-snippets.lua
+++ b/lua/lazyvim/plugins/extras/coding/mini-snippets.lua
@@ -1,6 +1,6 @@
 if lazyvim_docs then
   -- Set to `false` to prevent "non-lsp snippets"" from appearing inside completion windows
-  -- Motivation: Less clutter in completion windows and a more direct usage of snippits
+  -- Motivation: Less clutter in completion windows and a more direct usage of snippets
   vim.g.lazyvim_mini_snippets_in_completion = true
 
   -- NOTE: Please also read:


### PR DESCRIPTION
typo `snippits`

## Description

Just a fix for the typo `snippits`

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
