### PR TITLE
fix(vscode): don't sync undo/redo with vscode

### DIFF
--- a/lua/lazyvim/plugins/extras/vscode.lua
+++ b/lua/lazyvim/plugins/extras/vscode.lua
@@ -39,10 +39,6 @@ vim.api.nvim_create_autocmd("User", {
     vim.keymap.set("n", "<leader>/", [[<cmd>lua require('vscode').action('workbench.action.findInFiles')<cr>]])
     vim.keymap.set("n", "<leader>ss", [[<cmd>lua require('vscode').action('workbench.action.gotoSymbol')<cr>]])
 
-    -- Keep undo/redo lists in sync with VsCode
-    vim.keymap.set("n", "u", "<Cmd>call VSCodeNotify('undo')<CR>")
-    vim.keymap.set("n", "<C-r>", "<Cmd>call VSCodeNotify('redo')<CR>")
-
     -- Navigate VSCode tabs like lazyvim buffers
     vim.keymap.set("n", "<S-h>", "<Cmd>call VSCodeNotify('workbench.action.previousEditor')<CR>")
     vim.keymap.set("n", "<S-l>", "<Cmd>call VSCodeNotify('workbench.action.nextEditor')<CR>")


### PR DESCRIPTION
## Description

Vscode-neovim maintainer here, https://github.com/LazyVim/LazyVim/pull/4983 should not have been merged, it creates more problems than it 
solves. For the longest time I was trying to figure out why undo is broken on my machine, didn't notice this slipped in.

The fundamental issue is that vscode's undo points are based on a time-based heuristic, wheras neovim's undo points are based on atomic actions (delete, insert, etc). Vscode doesn't understand the context of what the user is doing, it just receives a stream of edits from neovim. 

Ultimately this results in multiple unrelated edits being undone with a single press of the u key, resulting in very confusing behavior. 

## Related Issue(s)

https://github.com/LazyVim/LazyVim/pull/4983

## Screenshots

Current

https://github.com/user-attachments/assets/5ca33b0d-fe2e-49f9-aa17-66f3c42c0966

Expected

https://github.com/user-attachments/assets/d577a1f3-efb2-4725-be50-bd0cf691252d



## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
