### PR TITLE
feat(lang): add neotest config for PHP tests

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/php.lua
+++ b/lua/lazyvim/plugins/extras/lang/php.lua
@@ -84,4 +84,21 @@ return {
       },
     },
   },
+
+  {
+    "nvim-neotest/neotest",
+    optional = true,
+    dependencies = {
+      "V13Axel/neotest-pest",
+      "olimorris/neotest-phpunit",
+    },
+    opts = {
+      adapters = {
+        "neotest-pest",
+        ["neotest-phpunit"] = {
+          root_ignore_files = { "tests/Pest.php" },
+        },
+      },
+    },
+  },
 }


### PR DESCRIPTION
## Description

Similar to some other languages (this closely follows the Go lang extra), this adds neotest runners for the major PHP test runners: PHPUnit and Pest.

Both work together, trying to use Pest if available and falling back to PHPUnit which is a decent approach for the PHP ecosystem.

I read CONTRIBUTING.md which differs from the way the Go lang extra has implemented a neotest adapters and opted to follow that instead. Ie. adapters
have been added as dependencies instead of a separate spec with `lazy=true`. Let me know if you want that changed.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
