### PR TITLE
fix(util): Add some kulala keymaps back to global

### DIFF
--- a/lua/lazyvim/plugins/extras/util/rest.lua
+++ b/lua/lazyvim/plugins/extras/util/rest.lua
@@ -8,8 +8,8 @@ return {
     "mistweaverco/kulala.nvim",
     ft = "http",
     keys = {
-      { "<leader>R", "", desc = "+Rest", ft = "http" },
-      { "<leader>Rb", "<cmd>lua require('kulala').scratchpad()<cr>", desc = "Open scratchpad", ft = "http" },
+      { "<leader>R", "", desc = "+Rest" },
+      { "<leader>Rb", "<cmd>lua require('kulala').scratchpad()<cr>", desc = "Open scratchpad" },
       { "<leader>Rc", "<cmd>lua require('kulala').copy()<cr>", desc = "Copy as cURL", ft = "http" },
       { "<leader>RC", "<cmd>lua require('kulala').from_curl()<cr>", desc = "Paste from curl", ft = "http" },
       {
@@ -22,7 +22,7 @@ return {
       { "<leader>Rn", "<cmd>lua require('kulala').jump_next()<cr>", desc = "Jump to next request", ft = "http" },
       { "<leader>Rp", "<cmd>lua require('kulala').jump_prev()<cr>", desc = "Jump to previous request", ft = "http" },
       { "<leader>Rq", "<cmd>lua require('kulala').close()<cr>", desc = "Close window", ft = "http" },
-      { "<leader>Rr", "<cmd>lua require('kulala').replay()<cr>", desc = "Replay the last request", ft = "http" },
+      { "<leader>Rr", "<cmd>lua require('kulala').replay()<cr>", desc = "Replay the last request" },
       { "<leader>Rs", "<cmd>lua require('kulala').run()<cr>", desc = "Send the request", ft = "http" },
       { "<leader>RS", "<cmd>lua require('kulala').show_stats()<cr>", desc = "Show stats", ft = "http" },
       { "<leader>Rt", "<cmd>lua require('kulala').toggle_view()<cr>", desc = "Toggle headers/body", ft = "http" },


### PR DESCRIPTION
## Description

Some kulala keymaps are useful to access globally, such as the scratchpad. However, #4467 #4574 added all of them to http filetypes only

This adds the scratchpad and replay last to global keymaps

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
