### PR TITLE
fix(lsp): use `supports_method` method instead of field on Neovim >=0.11

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/navic.lua
+++ b/lua/lazyvim/plugins/extras/editor/navic.lua
@@ -8,7 +8,10 @@ return {
     init = function()
       vim.g.navic_silence = true
       LazyVim.lsp.on_attach(function(client, buffer)
-        if client.supports_method("textDocument/documentSymbol") then
+        if
+          vim.fn.has("nvim-0.11") == 0 and client.supports_method("textDocument/documentSymbol")
+          or client:supports_method("textDocument/documentSymbol")
+        then
           require("nvim-navic").attach(client, buffer)
         end
       end)

--- a/lua/lazyvim/plugins/lsp/keymaps.lua
+++ b/lua/lazyvim/plugins/lsp/keymaps.lua
@@ -54,7 +54,7 @@ function M.has(buffer, method)
   method = method:find("/") and method or "textDocument/" .. method
   local clients = LazyVim.lsp.get_clients({ bufnr = buffer })
   for _, client in ipairs(clients) do
-    if client.supports_method(method) then
+    if vim.fn.has("nvim-0.11") == 0 and client.supports_method(method) or client:supports_method(method) then
       return true
     end
   end

--- a/lua/lazyvim/util/lsp.lua
+++ b/lua/lazyvim/util/lsp.lua
@@ -5,10 +5,12 @@ local M = {}
 ---@param method string
 ---@param bufnr? integer
 local function supports_method(client, method, bufnr)
-  if vim.fn.has("nvim-0.11") == 0 then
+  return client:supports_method(method, bufnr)
+end
+if vim.fn.has("nvim-0.11") == 0 then
+  function supports_method(client, method, bufnr)
     return client.supports_method and client.supports_method(method, { bufnr = bufnr })
   end
-  return client:supports_method(method, bufnr) and client:supports_method(method, bufnr)
 end
 
 ---@alias lsp.Client.filter {id?: number, bufnr?: number, name?: string, method?: string, filter?:fun(client: lsp.Client):boolean}


### PR DESCRIPTION
## Description
From Neovim 0.11 onwards `client.supports_method` was changed into a method `client:supports_method`. Hope I didn't forget any occurences where this has to be changed.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #5861 hopefully
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
