### PR TITLE
Associate 'Containerfile' with 'dockerfile' filetype

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/docker.lua
+++ b/lua/lazyvim/plugins/extras/lang/docker.lua
@@ -2,7 +2,7 @@ return {
   recommended = function()
     return LazyVim.extras.wants({
       ft = "dockerfile",
-      root = { "Dockerfile", "docker-compose.yml", "compose.yml", "docker-compose.yaml", "compose.yaml" },
+      root = { "Dockerfile", "Containerfile", "docker-compose.yml", "compose.yml", "docker-compose.yaml", "compose.yaml" },
     })
   end,
   {


### PR DESCRIPTION
## Description

'Containerfile' [1] is a supported alternative name for container build definitions. It is recognized by Docker and other container tools, and can help clarify intent in multi-container repositories or non-Docker-specific setups.

[1]: https://github.com/containers/common/blob/main/docs/Containerfile.5.md

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
