### PR TITLE
Improve comment in `keymaps.lua` on how to add keymap in lazyvim style

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -3,7 +3,7 @@
 -- DO NOT USE `LazyVim.safe_keymap_set` IN YOUR OWN CONFIG!!
 -- use `vim.keymap.set` instead
 -- or use local `wk = require("which-key")` and `wk.add`, to utilise the popup from the which-key plugin.
--- for more information, go to https://github.com/folke/which-key.nvim
+-- For more information, go to https://github.com/folke/which-key.nvim
 local map = LazyVim.safe_keymap_set
 
 -- better up/down

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -2,6 +2,8 @@
 
 -- DO NOT USE `LazyVim.safe_keymap_set` IN YOUR OWN CONFIG!!
 -- use `vim.keymap.set` instead
+-- or use local `wk = require("which-key")` and `wk.add`, to utilise the popup from the which-key plugin.
+-- for more information, go to https://github.com/folke/which-key.nvim
 local map = LazyVim.safe_keymap_set
 
 -- better up/down


### PR DESCRIPTION
## Description
This is the file that users are directed to in `lua/config/keymaps.lua`.
```
-- Keymaps are automatically loaded on the VeryLazy event
-- Default keymaps that are always set:
https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/keymaps.lua
-- Add any additional keymaps here
```
So it would be much better to explicitly guide them to use the which-key API.

Besides, the [documentation](https://www.lazyvim.org/configuration/keymaps) on keymaps might also be improved by instructing how to use which-key to add keymaps. As anyone who uses Lazyvim would like to add their keymaps with proper description to share the joy of which-key.