### PR TITLE
feat(lang.python): supprot loading python path configured in neoconf

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -105,9 +105,19 @@ return {
       config = function()
         if vim.fn.has("win32") == 1 then
           require("dap-python").setup(LazyVim.get_pkg_path("debugpy", "/venv/Scripts/pythonw.exe"))
-        else
-          require("dap-python").setup(LazyVim.get_pkg_path("debugpy", "/venv/bin/python"))
+          return
         end
+        -- try loading python path configured in neoconf (pyright)
+        if LazyVim.has("neoconf.nvim") and LazyVim.is_loaded("neoconf.nvim") then
+          local ncf = require("neoconf").get()
+          local pypath = ((ncf.lspconfig or {}).pyright or {})["python.pythonPath"]
+          if pypath ~= nil then
+            pypath = vim.fn.expand(pypath)
+            require('dap-python').setup(nil, { pythonPath = pypath })
+            return
+          end
+        end
+        require("dap-python").setup(LazyVim.get_pkg_path("debugpy", "/venv/bin/python"))
       end,
     },
   },


### PR DESCRIPTION
## Description

Currently, `nvim-dap-python` resolve python interpreter through [debugpy](https://github.com/microsoft/debugpy), while `lspconfig` support `neoconf`. In most case, it's not necessary to setup two different interpreter for a simple project.

`linux-cultist/venv-selector.nvim` is disabled after `telescope` removed by default, this commit add a support for loading python interpreter path configured in neoconf.

## Related Issue(s)

  - related #5829

## Screenshots

...

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
