### PR TITLE
feat(leap): add `o` to labeled_modes for delete operator

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/leap.lua
+++ b/lua/lazyvim/plugins/extras/editor/leap.lua
@@ -14,7 +14,7 @@ return {
       end
       return ret
     end,
-    opts = { labeled_modes = "nx" },
+    opts = { labeled_modes = "nxo" },
   },
   {
     "ggandor/leap.nvim",
@@ -41,17 +41,17 @@ return {
     optional = true,
     opts = {
       mappings = {
-        add = "gza", -- Add surrounding in Normal and Visual modes
-        delete = "gzd", -- Delete surrounding
-        find = "gzf", -- Find surrounding (to the right)
-        find_left = "gzF", -- Find surrounding (to the left)
-        highlight = "gzh", -- Highlight surrounding
-        replace = "gzr", -- Replace surrounding
-        update_n_lines = "gzn", -- Update `n_lines`
+        add = "gaa", -- Add surrounding in Normal and Visual modes
+        delete = "gad", -- Delete surrounding
+        find = "gaf", -- Find surrounding (to the right)
+        find_left = "gaF", -- Find surrounding (to the left)
+        highlight = "gah", -- Highlight surrounding
+        replace = "gar", -- Replace surrounding
+        update_n_lines = "gan", -- Update `n_lines`
       },
     },
     keys = {
-      { "gz", "", desc = "+surround" },
+      { "ga", "", desc = "+surround" },
     },
   },
 


### PR DESCRIPTION
Also change alternative leap mappings from `gz` to more convenient `ga`

## Description

Default configuration of `flit.nvim` does not currently include `labeled_mode = "o"` by default.
This creates weird discrepancy beween usage of plain `f/F/t/T`, visual `v f/F/t/T` and delete `d f/F/t/T`.
(`flit.nvim` does not work in delete mode with these settings).  

Also, an alternative remap of `leap` is now set to `ga..` instead of `gz..`, which looks a bit more ergonomic on qwerty keyboard.

## Related Issue(s)

https://github.com/LazyVim/LazyVim/discussions/6037

## Screenshots

![image](https://github.com/user-attachments/assets/40d45931-a1b3-4048-9a57-f6b64a3d3ef8)
![image](https://github.com/user-attachments/assets/8aee8137-3ece-4c16-826f-1b008c6d5ba8)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
