### PR TITLE
fix(mason): update org, use public mappings API

### DIFF
--- a/lua/lazyvim/plugins/extras/formatting/biome.lua
+++ b/lua/lazyvim/plugins/extras/formatting/biome.lua
@@ -24,7 +24,7 @@ local supported = {
 
 return {
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "biome" } },
   },
 

--- a/lua/lazyvim/plugins/extras/formatting/black.lua
+++ b/lua/lazyvim/plugins/extras/formatting/black.lua
@@ -1,6 +1,6 @@
 return {
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = function(_, opts)
       table.insert(opts.ensure_installed, "black")
     end,

--- a/lua/lazyvim/plugins/extras/formatting/prettier.lua
+++ b/lua/lazyvim/plugins/extras/formatting/prettier.lua
@@ -58,7 +58,7 @@ M.has_parser = LazyVim.memoize(M.has_parser)
 
 return {
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "prettier" } },
   },
 

--- a/lua/lazyvim/plugins/extras/lang/ansible.lua
+++ b/lua/lazyvim/plugins/extras/lang/ansible.lua
@@ -6,7 +6,7 @@ return {
     })
   end,
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "ansible-lint" } },
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -117,7 +117,7 @@ return {
     optional = true,
     dependencies = {
       -- Ensure C/C++ debugger is installed
-      "williamboman/mason.nvim",
+      "mason-org/mason.nvim",
       optional = true,
       opts = { ensure_installed = { "codelldb" } },
     },

--- a/lua/lazyvim/plugins/extras/lang/elm.lua
+++ b/lua/lazyvim/plugins/extras/lang/elm.lua
@@ -10,7 +10,7 @@ return {
   },
 
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "elm-format" } },
   },
 

--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -75,7 +75,7 @@ return {
   },
   -- Ensure Go tools are installed
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "goimports", "gofumpt" } },
   },
   {
@@ -83,7 +83,7 @@ return {
     optional = true,
     dependencies = {
       {
-        "williamboman/mason.nvim",
+        "mason-org/mason.nvim",
         opts = { ensure_installed = { "gomodifytags", "impl" } },
       },
     },
@@ -111,7 +111,7 @@ return {
     optional = true,
     dependencies = {
       {
-        "williamboman/mason.nvim",
+        "mason-org/mason.nvim",
         opts = { ensure_installed = { "delve" } },
       },
       {

--- a/lua/lazyvim/plugins/extras/lang/haskell.lua
+++ b/lua/lazyvim/plugins/extras/lang/haskell.lua
@@ -28,7 +28,7 @@ return {
   },
 
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "haskell-language-server" } },
   },
 
@@ -37,7 +37,7 @@ return {
     optional = true,
     dependencies = {
       {
-        "williamboman/mason.nvim",
+        "mason-org/mason.nvim",
         opts = { ensure_installed = { "haskell-debug-adapter" } },
       },
     },

--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -56,7 +56,7 @@ return {
     end,
     dependencies = {
       {
-        "williamboman/mason.nvim",
+        "mason-org/mason.nvim",
         opts = { ensure_installed = { "java-debug-adapter", "java-test" } },
       },
     },

--- a/lua/lazyvim/plugins/extras/lang/kotlin.lua
+++ b/lua/lazyvim/plugins/extras/lang/kotlin.lua
@@ -14,7 +14,7 @@ return {
   end,
   -- Add packages(linting, debug adapter)
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "ktlint" } },
   },
   -- Add syntax highlighting
@@ -35,7 +35,7 @@ return {
   {
     "mfussenegger/nvim-lint",
     optional = true,
-    dependencies = "williamboman/mason.nvim",
+    dependencies = "mason-org/mason.nvim",
     opts = {
       linters_by_ft = { kotlin = { "ktlint" } },
     },
@@ -64,7 +64,7 @@ return {
   {
     "mfussenegger/nvim-dap",
     optional = true,
-    dependencies = "williamboman/mason.nvim",
+    dependencies = "mason-org/mason.nvim",
     opts = function()
       local dap = require("dap")
       if not dap.adapters.kotlin then

--- a/lua/lazyvim/plugins/extras/lang/markdown.lua
+++ b/lua/lazyvim/plugins/extras/lang/markdown.lua
@@ -40,7 +40,7 @@ return {
     },
   },
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "markdownlint-cli2", "markdown-toc" } },
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/omnisharp.lua
+++ b/lua/lazyvim/plugins/extras/lang/omnisharp.lua
@@ -36,7 +36,7 @@ return {
     },
   },
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "csharpier", "netcoredbg" } },
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/php.lua
+++ b/lua/lazyvim/plugins/extras/lang/php.lua
@@ -35,7 +35,7 @@ return {
   },
 
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = {
       ensure_installed = {
         "phpcs",

--- a/lua/lazyvim/plugins/extras/lang/ruby.lua
+++ b/lua/lazyvim/plugins/extras/lang/ruby.lua
@@ -48,7 +48,7 @@ return {
     },
   },
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "erb-formatter", "erb-lint" } },
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -43,7 +43,7 @@ return {
 
   -- Ensure Rust debugger is installed
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     optional = true,
     opts = function(_, opts)
       opts.ensure_installed = opts.ensure_installed or {}

--- a/lua/lazyvim/plugins/extras/lang/sql.lua
+++ b/lua/lazyvim/plugins/extras/lang/sql.lua
@@ -143,7 +143,7 @@ return {
 
   -- Linters & formatters
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "sqlfluff" } },
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/terraform.lua
+++ b/lua/lazyvim/plugins/extras/lang/terraform.lua
@@ -20,7 +20,7 @@ return {
   },
   -- ensure terraform tools are installed
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "tflint" } },
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -194,7 +194,7 @@ return {
     optional = true,
     dependencies = {
       {
-        "williamboman/mason.nvim",
+        "mason-org/mason.nvim",
         opts = function(_, opts)
           opts.ensure_installed = opts.ensure_installed or {}
           table.insert(opts.ensure_installed, "js-debug-adapter")

--- a/lua/lazyvim/plugins/extras/util/dot.lua
+++ b/lua/lazyvim/plugins/extras/util/dot.lua
@@ -18,7 +18,7 @@ return {
     },
   },
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "shellcheck" } },
   },
   -- add some stuff to treesitter

--- a/lua/lazyvim/plugins/extras/util/gitui.lua
+++ b/lua/lazyvim/plugins/extras/util/gitui.lua
@@ -2,7 +2,7 @@ return {
 
   -- Ensure GitUI tool is installed
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "gitui" } },
     keys = {
       {

--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -5,7 +5,7 @@ return {
     event = "LazyFile",
     dependencies = {
       "mason.nvim",
-      { "williamboman/mason-lspconfig.nvim", config = function() end },
+      { "mason-org/mason-lspconfig.nvim", config = function() end },
     },
     opts = function()
       ---@class PluginLspOpts
@@ -212,7 +212,7 @@ return {
       local have_mason, mlsp = pcall(require, "mason-lspconfig")
       local all_mslp_servers = {}
       if have_mason then
-        all_mslp_servers = vim.tbl_keys(require("mason-lspconfig.mappings.server").lspconfig_to_package)
+        all_mslp_servers = vim.tbl_keys(require("mason-lspconfig").get_mappings().lspconfig_to_package)
       end
 
       local ensure_installed = {} ---@type string[]
@@ -257,7 +257,7 @@ return {
   -- cmdline tools and lsp servers
   {
 
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     cmd = "Mason",
     keys = { { "<leader>cm", "<cmd>Mason<cr>", desc = "Mason" } },
     build = ":MasonUpdate",

--- a/tests/extras/extra_spec.lua
+++ b/tests/extras/extra_spec.lua
@@ -26,7 +26,7 @@ describe("Extra", function()
     return not vim.tbl_contains(ignore, extra.modname)
   end, extras)
 
-  local lsp_to_pkg = require("mason-lspconfig.mappings.server").lspconfig_to_package
+  local lsp_to_pkg = require("mason-lspconfig").get_mappings().lspconfig_to_package
 
   local tsspec = Plugin.Spec.new({
     import = "lazyvim.plugins.treesitter",
@@ -44,7 +44,7 @@ describe("Extra", function()
         local mod = require(extra.modname)
         assert.is_not_nil(mod)
         local spec = Plugin.Spec.new({
-          { "williamboman/mason.nvim", opts = { ensure_installed = {} } },
+          { "mason-org/mason.nvim", opts = { ensure_installed = {} } },
           { "nvim-treesitter/nvim-treesitter", opts = { ensure_installed = {} } },
           mod,
         }, { optional = true })
@@ -60,7 +60,7 @@ describe("Extra", function()
 
       local mod = require(extra.modname)
       local spec = Plugin.Spec.new({
-        { "williamboman/mason.nvim", opts = { ensure_installed = {} } },
+        { "mason-org/mason.nvim", opts = { ensure_installed = {} } },
         { "nvim-treesitter/nvim-treesitter", opts = { ensure_installed = {} } },
         mod,
       }, { optional = true })

--- a/tests/minit.lua
+++ b/tests/minit.lua
@@ -8,8 +8,8 @@ require("lazy.minit").setup({
   spec = {
     { dir = vim.uv.cwd() },
     "LazyVim/starter",
-    "williamboman/mason-lspconfig.nvim",
-    "williamboman/mason.nvim",
+    "mason-org/mason-lspconfig.nvim",
+    "mason-org/mason.nvim",
     "nvim-treesitter/nvim-treesitter",
     { "echasnovski/mini.icons", opts = {} },
   },


### PR DESCRIPTION
## Description

`mason.nvim` and `mason-lspconfig.nvim` have moved GitHub orgs, causing LazyVim to break. This PR updates all references with the new org, and uses the `mason-lspconfig` public `get_mappings()` API [as suggested](https://github.com/LazyVim/LazyVim/issues/6039#issuecomment-2856502153) by @williamboman himself.

## Related Issue(s)

- https://github.com/mason-org/mason.nvim/pull/1925
- Fixes #6039

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
