### PR TITLE
fix(config): update to mason v2

### DIFF
--- a/lua/lazyvim/plugins/extras/formatting/black.lua
+++ b/lua/lazyvim/plugins/extras/formatting/black.lua
@@ -1,6 +1,6 @@
 return {
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = function(_, opts)
       table.insert(opts.ensure_installed, "black")
     end,

--- a/lua/lazyvim/plugins/extras/formatting/prettier.lua
+++ b/lua/lazyvim/plugins/extras/formatting/prettier.lua
@@ -58,7 +58,7 @@ M.has_parser = LazyVim.memoize(M.has_parser)
 
 return {
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "prettier" } },
   },
 

--- a/lua/lazyvim/plugins/extras/lang/ansible.lua
+++ b/lua/lazyvim/plugins/extras/lang/ansible.lua
@@ -6,7 +6,7 @@ return {
     })
   end,
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "ansible-lint" } },
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -114,7 +114,7 @@ return {
     optional = true,
     dependencies = {
       -- Ensure C/C++ debugger is installed
-      "williamboman/mason.nvim",
+      "mason-org/mason.nvim",
       optional = true,
       opts = { ensure_installed = { "codelldb" } },
     },

--- a/lua/lazyvim/plugins/extras/lang/elm.lua
+++ b/lua/lazyvim/plugins/extras/lang/elm.lua
@@ -10,7 +10,7 @@ return {
   },
 
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "elm-format" } },
   },
 

--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -76,7 +76,7 @@ return {
   },
   -- Ensure Go tools are installed
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "goimports", "gofumpt" } },
   },
   {
@@ -84,7 +84,7 @@ return {
     optional = true,
     dependencies = {
       {
-        "williamboman/mason.nvim",
+        "mason-org/mason.nvim",
         opts = { ensure_installed = { "gomodifytags", "impl" } },
       },
     },
@@ -112,7 +112,7 @@ return {
     optional = true,
     dependencies = {
       {
-        "williamboman/mason.nvim",
+        "mason-org/mason.nvim",
         opts = { ensure_installed = { "delve" } },
       },
       {

--- a/lua/lazyvim/plugins/extras/lang/haskell.lua
+++ b/lua/lazyvim/plugins/extras/lang/haskell.lua
@@ -28,7 +28,7 @@ return {
   },
 
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "haskell-language-server" } },
   },
 
@@ -37,7 +37,7 @@ return {
     optional = true,
     dependencies = {
       {
-        "williamboman/mason.nvim",
+        "mason-org/mason.nvim",
         opts = { ensure_installed = { "haskell-debug-adapter" } },
       },
     },

--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -42,7 +42,7 @@ return {
     optional = true,
     dependencies = {
       {
-        "williamboman/mason.nvim",
+        "mason-org/mason.nvim",
         opts = { ensure_installed = { "java-debug-adapter", "java-test" } },
       },
     },

--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -71,8 +71,7 @@ return {
     dependencies = { "folke/which-key.nvim" },
     ft = java_filetypes,
     opts = function()
-      local mason_registry = require("mason-registry")
-      local lombok_jar = mason_registry.get_package("jdtls"):get_install_path() .. "/lombok.jar"
+      local lombok_jar = vim.fn.exepath("jdtls") .. "/lombok.jar"
       return {
         -- How to find the root dir for a given filename. The default comes from
         -- lspconfig which provides a function specifically for java projects.
@@ -135,14 +134,14 @@ return {
       local bundles = {} ---@type string[]
       if opts.dap and LazyVim.has("nvim-dap") and mason_registry.is_installed("java-debug-adapter") then
         local java_dbg_pkg = mason_registry.get_package("java-debug-adapter")
-        local java_dbg_path = java_dbg_pkg:get_install_path()
+        local java_dbg_path = vim.fn.expand(java_dbg_pkg)
         local jar_patterns = {
           java_dbg_path .. "/extension/server/com.microsoft.java.debug.plugin-*.jar",
         }
         -- java-test also depends on java-debug-adapter.
         if opts.test and mason_registry.is_installed("java-test") then
           local java_test_pkg = mason_registry.get_package("java-test")
-          local java_test_path = java_test_pkg:get_install_path()
+          local java_test_path = vim.fn.expand(java_test_pkg)
           vim.list_extend(jar_patterns, {
             java_test_path .. "/extension/server/*.jar",
           })

--- a/lua/lazyvim/plugins/extras/lang/kotlin.lua
+++ b/lua/lazyvim/plugins/extras/lang/kotlin.lua
@@ -14,7 +14,7 @@ return {
   end,
   -- Add packages(linting, debug adapter)
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "ktlint" } },
   },
   -- Add syntax highlighting
@@ -35,7 +35,7 @@ return {
   {
     "mfussenegger/nvim-lint",
     optional = true,
-    dependencies = "williamboman/mason.nvim",
+    dependencies = "mason-org/mason.nvim",
     opts = {
       linters_by_ft = { kotlin = { "ktlint" } },
     },
@@ -64,7 +64,7 @@ return {
   {
     "mfussenegger/nvim-dap",
     optional = true,
-    dependencies = "williamboman/mason.nvim",
+    dependencies = "mason-org/mason.nvim",
     opts = function()
       local dap = require("dap")
       if not dap.adapters.kotlin then

--- a/lua/lazyvim/plugins/extras/lang/markdown.lua
+++ b/lua/lazyvim/plugins/extras/lang/markdown.lua
@@ -40,7 +40,7 @@ return {
     },
   },
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "markdownlint-cli2", "markdown-toc" } },
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/omnisharp.lua
+++ b/lua/lazyvim/plugins/extras/lang/omnisharp.lua
@@ -36,7 +36,7 @@ return {
     },
   },
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "csharpier", "netcoredbg" } },
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/php.lua
+++ b/lua/lazyvim/plugins/extras/lang/php.lua
@@ -35,7 +35,7 @@ return {
   },
 
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = {
       ensure_installed = {
         "phpcs",

--- a/lua/lazyvim/plugins/extras/lang/php.lua
+++ b/lua/lazyvim/plugins/extras/lang/php.lua
@@ -48,7 +48,7 @@ return {
     optional = true,
     opts = function()
       local dap = require("dap")
-      local path = require("mason-registry").get_package("php-debug-adapter"):get_install_path()
+      local path = vim.fn.exepath("php-debug-adapter")
       dap.adapters.php = {
         type = "executable",
         command = "node",

--- a/lua/lazyvim/plugins/extras/lang/ruby.lua
+++ b/lua/lazyvim/plugins/extras/lang/ruby.lua
@@ -45,7 +45,7 @@ return {
     },
   },
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "erb-formatter", "erb-lint" } },
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -33,7 +33,7 @@ return {
 
   -- Ensure Rust debugger is installed
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     optional = true,
     opts = { ensure_installed = { "codelldb" } },
   },

--- a/lua/lazyvim/plugins/extras/lang/sql.lua
+++ b/lua/lazyvim/plugins/extras/lang/sql.lua
@@ -124,7 +124,7 @@ return {
 
   -- Linters & formatters
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "sqlfluff" } },
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/terraform.lua
+++ b/lua/lazyvim/plugins/extras/lang/terraform.lua
@@ -20,7 +20,7 @@ return {
   },
   -- ensure terraform tools are installed
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "tflint" } },
   },
   {

--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -193,7 +193,7 @@ return {
     optional = true,
     dependencies = {
       {
-        "williamboman/mason.nvim",
+        "mason-org/mason.nvim",
         opts = function(_, opts)
           opts.ensure_installed = opts.ensure_installed or {}
           table.insert(opts.ensure_installed, "js-debug-adapter")

--- a/lua/lazyvim/plugins/extras/util/dot.lua
+++ b/lua/lazyvim/plugins/extras/util/dot.lua
@@ -18,7 +18,7 @@ return {
     },
   },
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "shellcheck" } },
   },
   -- add some stuff to treesitter

--- a/lua/lazyvim/plugins/extras/util/gitui.lua
+++ b/lua/lazyvim/plugins/extras/util/gitui.lua
@@ -2,7 +2,7 @@ return {
 
   -- Ensure GitUI tool is installed
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     opts = { ensure_installed = { "gitui" } },
     keys = {
       {

--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -5,7 +5,7 @@ return {
     event = "LazyFile",
     dependencies = {
       "mason.nvim",
-      { "williamboman/mason-lspconfig.nvim", config = function() end },
+      { "mason-org/mason-lspconfig.nvim", config = function() end },
     },
     opts = function()
       ---@class PluginLspOpts
@@ -263,7 +263,7 @@ return {
   -- cmdline tools and lsp servers
   {
 
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     cmd = "Mason",
     keys = { { "<leader>cm", "<cmd>Mason<cr>", desc = "Mason" } },
     build = ":MasonUpdate",

--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -218,7 +218,7 @@ return {
       local have_mason, mlsp = pcall(require, "mason-lspconfig")
       local all_mslp_servers = {}
       if have_mason then
-        all_mslp_servers = vim.tbl_keys(require("mason-lspconfig.mappings.server").lspconfig_to_package)
+        all_mslp_servers = vim.tbl_keys(require("mason-lspconfig").get_mappings().lspconfig_to_package)
       end
 
       local ensure_installed = {} ---@type string[]

--- a/tests/extras/extra_spec.lua
+++ b/tests/extras/extra_spec.lua
@@ -44,7 +44,7 @@ describe("Extra", function()
         local mod = require(extra.modname)
         assert.is_not_nil(mod)
         local spec = Plugin.Spec.new({
-          { "williamboman/mason.nvim", opts = { ensure_installed = {} } },
+          { "mason-org/mason.nvim", opts = { ensure_installed = {} } },
           { "nvim-treesitter/nvim-treesitter", opts = { ensure_installed = {} } },
           mod,
         }, { optional = true })
@@ -60,7 +60,7 @@ describe("Extra", function()
 
       local mod = require(extra.modname)
       local spec = Plugin.Spec.new({
-        { "williamboman/mason.nvim", opts = { ensure_installed = {} } },
+        { "mason-org/mason.nvim", opts = { ensure_installed = {} } },
         { "nvim-treesitter/nvim-treesitter", opts = { ensure_installed = {} } },
         mod,
       }, { optional = true })

--- a/tests/minit.lua
+++ b/tests/minit.lua
@@ -8,8 +8,8 @@ require("lazy.minit").setup({
   spec = {
     { dir = vim.uv.cwd() },
     "LazyVim/starter",
-    "williamboman/mason-lspconfig.nvim",
-    "williamboman/mason.nvim",
+    "mason-org/mason-lspconfig.nvim",
+    "mason-org/mason.nvim",
     "nvim-treesitter/nvim-treesitter",
     { "echasnovski/mini.icons", opts = {} },
   },


### PR DESCRIPTION
## Description

- Updates all references to mason.nvim and mason-lspconfig.nvim
- Updates all config files to use the suggested vim APIs instead

## Related Issue(s)

- Fixes #6039

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
