### PR TITLE
FIX: Mason LSP

### DIFF
--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -211,8 +211,9 @@ return {
       -- get all the servers that are available through mason-lspconfig
       local have_mason, mlsp = pcall(require, "mason-lspconfig")
       local all_mslp_servers = {}
+
       if have_mason then
-        all_mslp_servers = vim.tbl_keys(require("mason-lspconfig.mappings.server").lspconfig_to_package)
+        all_mslp_servers = mlsp.get_available_servers()
       end
 
       local ensure_installed = {} ---@type string[]


### PR DESCRIPTION
## Description

FIX:

Failed to run `config` for nvim-lspconfig

...share/nvim/lazy/LazyVim/lua/lazyvim/plugins/lsp/init.lua:215: module 'mason-lspconfig.mappings.server' not found:
	no field package.preload['mason-lspconfig.mappings.server']
	cache_loader: module 'mason-lspconfig.mappings.server' not found
	cache_loader_lib: module 'mason-lspconfig.mappings.server' not found
	no file './mason-lspconfig/mappings/server.lua'
	no file '/usr/local/share/luajit-2.1/mason-lspconfig/mappings/server.lua'
	no file '/usr/local/share/lua/5.1/mason-lspconfig/mappings/server.lua'
	no file '/usr/local/share/lua/5.1/mason-lspconfig/mappings/server/init.lua'
	no file './mason-lspconfig/mappings/server.so'
	no file '/usr/local/lib/lua/5.1/mason-lspconfig/mappings/server.so'
	no file '/usr/local/lib/lua/5.1/loadall.so'
	no file './mason-lspconfig.so'
	no file '/usr/local/lib/lua/5.1/mason-lspconfig.so'
	no file '/usr/local/lib/lua/5.1/loadall.so'

# stacktrace:
  - /LazyVim/lua/lazyvim/plugins/lsp/init.lua:215 _in_ **config**


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

![Uploading image.png…]()

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
