### PR TITLE
Added missing Mason LspconfigSettings field automatic_enable

### DIFF
--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -237,6 +237,7 @@ return {
             ensure_installed,
             LazyVim.opts("mason-lspconfig.nvim").ensure_installed or {}
           ),
+          automatic_enable = true,
           handlers = { setup },
         })
       end


### PR DESCRIPTION
## Description

This change does not introduce a new plugin or extra. It only updates an existing configuration to match the expected API of mason-lspconfig v2. No additional dependencies or language configurations are added.

Add `automatic_enable = true` to the mason-lspconfig setup to satisfy the expected config schema in LazyVim,  
and to ensure correct runtime behavior if any upstream plugin modifies this field.  
This prevents both a Neovim configuration validation warning and potential future server setup issues.

## Related Issue(s)

N/A

## Screenshots

N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
