### PR TITLE
fix(lsp): add missing automatic_enable field to mason-lspconfig settings

### DIFF
--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -237,6 +237,7 @@ return {
             ensure_installed,
             LazyVim.opts("mason-lspconfig.nvim").ensure_installed or {}
           ),
+          automatic_enable = true,
           handlers = { setup },
         })
       end


### PR DESCRIPTION
## Description

Add `automatic_enable = true` to the mason-lspconfig setup to satisfy the expected config schema in LazyVim,  
and ensure correct runtime behavior even if upstream plugins modify settings.

Without this field, Mason may fail to auto-enable LSP servers, which can indirectly break dependent plugins that assume active language servers, such as null-ls, formatter integrations, and Treesitter-LSP features.

## Related Issue(s)

N/A

## Screenshots

N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.