### PR TITLE
fix(clangd): rewrite the root_dir function

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -60,18 +60,27 @@ return {
           keys = {
             { "<leader>ch", "<cmd>ClangdSwitchSourceHeader<cr>", desc = "Switch Source/Header (C/C++)" },
           },
-          root_dir = function(fname)
-            return require("lspconfig.util").root_pattern(
-              "Makefile",
-              "configure.ac",
-              "configure.in",
-              "config.h.in",
-              "meson.build",
-              "meson_options.txt",
-              "build.ninja"
-            )(fname) or require("lspconfig.util").root_pattern("compile_commands.json", "compile_flags.txt")(
-              fname
-            ) or require("lspconfig.util").find_git_ancestor(fname)
+          root_dir = function(bufnr, ondir)
+            local root_directory = function(fname)
+              return require("lspconfig.util").root_pattern(
+                "Makefile",
+                "configure.ac",
+                "configure.in",
+                "config.h.in",
+                "meson.build",
+                "meson_options.txt",
+                "build.ninja"
+              )(fname) or require("lspconfig.util").root_pattern(
+                "compile_commands.json",
+                "compile_flags.txt"
+              )(fname) or require("lspconfig.util").find_git_ancestor(fname)
+            end
+            if type(bufnr) == "string" then
+              return root_directory(bufnr)
+            else
+              local fname = vim.api.nvim_buf_get_name(bufnr)
+              ondir(root_directory(fname))
+            end
           end,
           capabilities = {
             offsetEncoding = { "utf-16" },


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Nvim 0.11 had some breaking changes in lsp related parts. And one of them is that if the root_dir field of lsp config is a function, the bufnr and a function would be passed instead of the file name in nvim 0.10. As a result, the configurations of extra.lang.clangd broke.

I rewrite the root_dir function and make it work both on 0.11 and 0.10.

It would check whether the first argument is a string to decide whether to adapt the new interface.

## Checklist

- [ x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
