### PR TITLE
fix(python): remove the wrapping `settings` key from `setup()` options

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -120,10 +120,8 @@ return {
       return LazyVim.has("telescope.nvim")
     end,
     opts = {
-      settings = {
-        options = {
-          notify_user_on_venv_activation = true,
-        },
+      options = {
+        notify_user_on_venv_activation = true,
       },
     },
     --  Call config for python files and load the cached venv automatically


### PR DESCRIPTION
## Description

Remove the wrapping `settings` key from `setup()` options.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<img width="601" alt="image" src="https://github.com/user-attachments/assets/92f3fc5a-9497-40c2-bc83-2a216cccb2f2" />

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
