### PR TITLE
feat(php): add `php-debug-adapter` to mason

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/php.lua
+++ b/lua/lazyvim/plugins/extras/lang/php.lua
@@ -46,6 +46,16 @@ return {
   {
     "mfussenegger/nvim-dap",
     optional = true,
+    specs = {
+      {
+        "mason-org/mason.nvim",
+        opts = {
+          ensure_installed = {
+            "php-debug-adapter",
+          },
+        },
+      },
+    },
     opts = function()
       local dap = require("dap")
       local path = require("mason-registry").get_package("php-debug-adapter"):get_install_path()


### PR DESCRIPTION
## Description

While reviewing and contributing to #6053, I noticed that the PHP language extra doesn't include `php-debug-adapter` in mason's `ensure_installed`, even though it requires it.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
