### PR TITLE
Fix VS Code terminal integration and unify calls to extension API

### DIFF
--- a/lua/lazyvim/plugins/extras/vscode.lua
+++ b/lua/lazyvim/plugins/extras/vscode.lua
@@ -37,8 +37,12 @@ vim.api.nvim_create_autocmd("User", {
   callback = function()
     -- VSCode-specific keymaps for search and navigation
     vim.keymap.set("n", "<leader><space>", "<cmd>Find<cr>")
-    vim.keymap.set("n", "<leader>/", [[<cmd>lua require('vscode').action('workbench.action.findInFiles')<cr>]])
-    vim.keymap.set("n", "<leader>ss", [[<cmd>lua require('vscode').action('workbench.action.gotoSymbol')<cr>]])
+    vim.keymap.set("n", "<leader>/", function()
+      vscode.call("workbench.action.findInFiles")
+    end)
+    vim.keymap.set("n", "<leader>ss", function()
+      vscode.call("workbench.action.gotoSymbol")
+    end)
 
     -- Toggle VS Code integrated terminal
     for _, lhs in ipairs({ "<leader>ft", "<leader>fT", "<c-/>" }) do
@@ -48,12 +52,20 @@ vim.api.nvim_create_autocmd("User", {
     end
 
     -- Keep undo/redo lists in sync with VsCode
-    vim.keymap.set("n", "u", "<Cmd>call VSCodeNotify('undo')<CR>")
-    vim.keymap.set("n", "<C-r>", "<Cmd>call VSCodeNotify('redo')<CR>")
+    vim.keymap.set("n", "u", function()
+      vscode.call("undo")
+    end)
+    vim.keymap.set("n", "<C-r>", function()
+      vscode.call("redo")
+    end)
 
     -- Navigate VSCode tabs like lazyvim buffers
-    vim.keymap.set("n", "<S-h>", "<Cmd>call VSCodeNotify('workbench.action.previousEditor')<CR>")
-    vim.keymap.set("n", "<S-l>", "<Cmd>call VSCodeNotify('workbench.action.nextEditor')<CR>")
+    vim.keymap.set("n", "<S-h>", function()
+      vscode.call("workbench.action.previousEditor")
+    end)
+    vim.keymap.set("n", "<S-l>", function()
+      vscode.call("workbench.action.nextEditor")
+    end)
   end,
 })
 

--- a/lua/lazyvim/plugins/extras/vscode.lua
+++ b/lua/lazyvim/plugins/extras/vscode.lua
@@ -23,6 +23,7 @@ local enabled = {
 }
 
 local Config = require("lazy.core.config")
+local vscode = require("vscode")
 Config.options.checker.enabled = false
 Config.options.change_detection.enabled = false
 Config.options.defaults.cond = function(plugin)
@@ -39,6 +40,13 @@ vim.api.nvim_create_autocmd("User", {
     vim.keymap.set("n", "<leader>/", [[<cmd>lua require('vscode').action('workbench.action.findInFiles')<cr>]])
     vim.keymap.set("n", "<leader>ss", [[<cmd>lua require('vscode').action('workbench.action.gotoSymbol')<cr>]])
 
+    -- Toggle VS Code integrated terminal
+    for _, lhs in ipairs({ "<leader>ft", "<leader>fT", "<c-/>" }) do
+      vim.keymap.set("n", lhs, function()
+        vscode.call("workbench.action.terminal.toggleTerminal")
+      end)
+    end
+
     -- Keep undo/redo lists in sync with VsCode
     vim.keymap.set("n", "u", "<Cmd>call VSCodeNotify('undo')<CR>")
     vim.keymap.set("n", "<C-r>", "<Cmd>call VSCodeNotify('redo')<CR>")
@@ -48,10 +56,6 @@ vim.api.nvim_create_autocmd("User", {
     vim.keymap.set("n", "<S-l>", "<Cmd>call VSCodeNotify('workbench.action.nextEditor')<CR>")
   end,
 })
-
-function LazyVim.terminal()
-  require("vscode").action("workbench.action.terminal.toggleTerminal")
-end
 
 return {
   {


### PR DESCRIPTION
## Description

This PR proposes the following changes to the VS Code extra:
- Re-implement the VS Code terminal integration (broken since [`2f46974`](https://github.com/LazyVim/LazyVim/commit/2f4697443c0186663ba4421bd4b856e36c3bd7cc#diff-f878104b5415a79ed4bb9036974722cad911327fdd46994e04f5065ff90e9a55), see comment referenced below)
- Unifiy calls to the [extension API](https://github.com/vscode-neovim/vscode-neovim/tree/v1.18.21?tab=readme-ov-file#%EF%B8%8F-api)
  - Fully adopt the Lua API in favour of the deprecated Vim script functions (see [deprecation notice](https://github.com/vscode-neovim/vscode-neovim/tree/v1.18.21?tab=readme-ov-file#vimscript))
  - Centralise `require("vscode")` calls

## Related Issue(s)

- Fixes https://github.com/LazyVim/LazyVim/pull/4392#issuecomment-2881395017

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
