### PR TITLE
Use debugpy-adapter executable for nvim-dap-python

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -103,11 +103,7 @@ return {
         { "<leader>dPc", function() require('dap-python').test_class() end, desc = "Debug Class", ft = "python" },
       },
       config = function()
-        if vim.fn.has("win32") == 1 then
-          require("dap-python").setup(LazyVim.get_pkg_path("debugpy", "/venv/Scripts/pythonw.exe"))
-        else
-          require("dap-python").setup(LazyVim.get_pkg_path("debugpy", "/venv/bin/python"))
-        end
+        require("dap-python").setup("debugpy-adapter")
       end,
     },
   },


### PR DESCRIPTION
## Description

Uses a less hacky and now officially-supported way of getting the debugpy DAP adapter path for nvim-dap-python.

Since https://github.com/mfussenegger/nvim-dap-python/pull/184, nvim-dap-python can start the debugpy adapter using the `debugpy-adapter` executable. Since [Mason](https://github.com/mason-org/mason-registry/blob/f7c1c2fde2d1c79f8892dafc9528da1b78b56b25/packages/debugpy/package.yaml#L17) and [now debugpy itself](https://github.com/microsoft/debugpy/pull/1870) provide this executable, there's no need to get the `python` executable from debugpy's venv.

I've gone with just `"debugpy-adapter"` rather than `LazyVim.get_pkg_path("debugpy", "debugpy-adapter")` so that a system-wide installation of debugpy can also be used.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
