### PR TITLE
fix(extras/rust): show Rust impl blocks in outline

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -154,4 +154,17 @@ return {
       },
     },
   },
+
+  -- Show `impl` blocks in outline.nvim
+  {
+    "hedyhli/outline.nvim",
+    optional = true,
+    opts = {
+      symbols = {
+        filter = {
+          rust = vim.list_extend(vim.deepcopy(LazyVim.config.kind_filter["default"]), { "Object" }),
+        },
+      },
+    },
+  },
 }


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Hi!

By default, when using the Rust extra, [functions inside impl blocks](https://doc.rust-lang.org/std/keyword.impl.html#implementing-functionality-for-a-type) don't show up in [outline](https://www.lazyvim.org/extras/editor/outline), making the outline largely pointless in my experience.

The problem is that `impl` blocks are `Objects`, which are not included [lazyvim's default kind filter](https://github.com/LazyVim/LazyVim/blob/25abbf546d564dc484cf903804661ba12de45507/lua/lazyvim/config/init.lua#L102).

## Related Issue(s)

 - no issue in lazyvim repo
 - related issue from outline repo: https://github.com/hedyhli/outline.nvim/issues/81

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

Before:

![20250519_11h04m53s_grim](https://github.com/user-attachments/assets/2bed393c-9d32-4817-ab78-fb50d0a3739a)

After:

![20250519_11h05m25s_grim](https://github.com/user-attachments/assets/27085b8f-276e-4e51-a53f-7d4222fe471d)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
