### PR TITLE
fix(chezmoi): add `hidden=false` to fzf picker

### DIFF
--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -8,7 +8,7 @@ local pick_chezmoi = function()
         fzf_lua.actions.vimcmd_entry("ChezmoiEdit", selected, { cwd = os.getenv("HOME") })
       end,
     }
-    fzf_lua.files({ cmd = "chezmoi managed --include=files,symlinks", actions = actions })
+    fzf_lua.files({ cmd = "chezmoi managed --include=files,symlinks", actions = actions, hidden = false })
   elseif LazyVim.pick.picker.name == "snacks" then
     local results = require("chezmoi.commands").list({
       args = {


### PR DESCRIPTION
## Description
Since #5275, the fzf picker has changed to use the `files` picker instead of `fzf_exec` like before. 

That means it also inherits the options of `files` picker, where `hidden = true`. Just the command had been changed to use the `chezmoi` command, but it doesn't make sense to have `hidden = true`, since it just appends `--hidden` to the command which was supposed to be `fzf`, but now with `chezmoi` it's not recognized.

Add `hidden = false` to the `files` picker when the command is chezmoi.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #6094
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
