### PR TITLE
this fix #6155

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/omnisharp.lua
+++ b/lua/lazyvim/plugins/extras/lang/omnisharp.lua
@@ -29,8 +29,8 @@ return {
       },
       formatters = {
         csharpier = {
-          command = "dotnet-csharpier",
-          args = { "--write-stdout" },
+          command = "csharpier",
+          args = { "format", "--write-stdout" },
         },
       },
     },


### PR DESCRIPTION
## Description
This PR updates the CSharpier integration in LazyVim to reflect changes in how Mason installs the formatter.

Previously, Mason installed CSharpier as the `dotnet-csharpier` binary, which allowed running it without additional arguments. Now, Mason installs it simply as `csharpier`, requiring the explicit format argument for it to work correctly.

This change updates the formatter command and arguments accordingly to ensure compatibility with the latest Mason installation and CSharpier CLI behavior.

## Changes
Replaced `dotnet-csharpier` with `csharpier` as the executable command.

Added the required `format` argument to the command invocation.

## Related Issue(s)
Fixes #6155

## Checklist
 I have read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.