### PR TITLE
fix(lang.vue): volar deprecated, switch to vue_ls

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/vue.lua
+++ b/lua/lazyvim/plugins/extras/lang/vue.lua
@@ -19,10 +19,10 @@ return {
     "neovim/nvim-lspconfig",
     opts = {
       servers = {
-        volar = {
+        vue_ls = {
           init_options = {
             vue = {
-              hybridMode = true,
+              hybridMode = false,
             },
           },
         },

--- a/lua/lazyvim/plugins/extras/lang/vue.lua
+++ b/lua/lazyvim/plugins/extras/lang/vue.lua
@@ -22,7 +22,7 @@ return {
         vue_ls = {
           init_options = {
             vue = {
-              hybridMode = false,
+              hybridMode = true,
             },
           },
         },


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Opening a `.vue` file you get the following warn: `volar is deprecated, use vue_ls instead.` This PR switches from `volar` to `vue_ls`.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
N/A

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
