### PR TITLE
fix(rust): disable proc-macro-disabled diagnostic

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -83,6 +83,9 @@ return {
             -- Enable diagnostics if using rust-analyzer
             diagnostics = {
               enable = diagnostics == "rust-analyzer",
+              disabled = {
+                "proc-macro-disabled",
+              },
             },
             procMacro = {
               enable = true,


### PR DESCRIPTION

## Description

The default Rust config disables a bunch of proc macros, but that causes a huge diagnostic to be shown by default for those proc macros. This disables that diagnostic by default.

## Related Issue(s)

- Related to https://github.com/rust-lang/rust-analyzer/issues/18414
- Fixes https://github.com/mrcjkb/rustaceanvim/discussions/482
- Fixes https://github.com/LazyVim/LazyVim/discussions/5638

## Screenshots

See screenshots in the linked issues above

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
