### PR TITLE
feat(neotest): extra keymap to attach to a test

### DIFF
--- a/lua/lazyvim/plugins/extras/test/core.lua
+++ b/lua/lazyvim/plugins/extras/test/core.lua
@@ -106,6 +106,7 @@ return {
     -- stylua: ignore
     keys = {
       {"<leader>t", "", desc = "+test"},
+      { "<leader>ta", function() require("neotest").run.attach() end, desc = "Attach to Test (Neotest)" },
       { "<leader>tt", function() require("neotest").run.run(vim.fn.expand("%")) end, desc = "Run File (Neotest)" },
       { "<leader>tT", function() require("neotest").run.run(vim.uv.cwd()) end, desc = "Run All Test Files (Neotest)" },
       { "<leader>tr", function() require("neotest").run.run() end, desc = "Run Nearest (Neotest)" },


### PR DESCRIPTION
## Description

An extra keymap useful when running tests to attach to the test.

## Related Issue(s)

N/A

## Screenshots

N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
