### PR TITLE
feat(config): dynamically determine LazyVim origin spec

### DIFF
--- a/lua/lazyvim/plugins/init.lua
+++ b/lua/lazyvim/plugins/init.lua
@@ -10,9 +10,24 @@ end
 
 require("lazyvim.config").init()
 
+local Git = require("lazy.manage.git")
+local Util = require("lazy.core.util")
+
+local function find_actual_origin_spec()
+  local current_dir = vim.fn.fnamemodify(Util.get_source(), ":h")
+  return {
+    url = Git.get_origin(Util.find_git_root(current_dir)),
+    priority = 10000,
+    lazy = false,
+    opts = {},
+    cond = true,
+    version = "*",
+  }
+end
+
 return {
   { "folke/lazy.nvim", version = "*" },
-  { "LazyVim/LazyVim", priority = 10000, lazy = false, opts = {}, cond = true, version = "*" },
+  find_actual_origin_spec(),
   {
     "folke/snacks.nvim",
     priority = 1000,


### PR DESCRIPTION

## Description

Replace hardcoded repository reference with dynamic origin detection to support different LazyVim forks automatically.

This only works with https://github.com/folke/lazy.nvim/pull/2016.

## Related Issue(s)

None

## Screenshots

![image](https://github.com/user-attachments/assets/0030fad7-7c7b-4d46-be0c-913705ae22c0)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
