### PR TITLE
feat(extras): ai: add `claudecode.nvim`

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/claudecode.lua
+++ b/lua/lazyvim/plugins/extras/ai/claudecode.lua
@@ -1,0 +1,23 @@
+return {
+  "coder/claudecode.nvim",
+  dependencies = { "folke/snacks.nvim" },
+  config = true,
+  keys = {
+    { "<leader>a", "", desc = "+ai", mode = { "n", "v" } },
+    { "<leader>ac", "<cmd>ClaudeCode<cr>", desc = "Toggle Claude" },
+    { "<leader>af", "<cmd>ClaudeCodeFocus<cr>", desc = "Focus Claude" },
+    { "<leader>ar", "<cmd>ClaudeCode --resume<cr>", desc = "Resume Claude" },
+    { "<leader>aC", "<cmd>ClaudeCode --continue<cr>", desc = "Continue Claude" },
+    { "<leader>ab", "<cmd>ClaudeCodeAdd %<cr>", desc = "Add current buffer" },
+    { "<leader>as", "<cmd>ClaudeCodeSend<cr>", mode = "v", desc = "Send to Claude" },
+    {
+      "<leader>as",
+      "<cmd>ClaudeCodeTreeAdd<cr>",
+      desc = "Add file",
+      ft = { "NvimTree", "neo-tree", "oil" },
+    },
+    -- Diff management
+    { "<leader>aa", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff" },
+    { "<leader>ad", "<cmd>ClaudeCodeDiffDeny<cr>", desc = "Deny diff" },
+  },
+}


### PR DESCRIPTION
## Description

Adds [`claudecode.nvim`](https://github.com/coder/claudecode.nvim) which integrates Claude Code into NeoVim using snacks terminal.

I've been using this config for a while now and I think it's time to upstream to LazyVim. The configurations are the recommended ones from the plugin's README.

## Related Issue(s)

None

## Screenshots

![CleanShot 2025-07-05 at 06 58 15@2x](https://github.com/user-attachments/assets/23f8de5c-654e-470d-b814-0bf318ceb2b2)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
