### PR TITLE
fix(lang): support indirect tailwindcss for lsp detection

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/tailwind.lua
+++ b/lua/lazyvim/plugins/extras/lang/tailwind.lua
@@ -24,6 +24,14 @@ return {
           filetypes_include = {},
           -- to fully override the default_config, change the below
           -- filetypes = {}
+          root_dir = function(fname)
+            local node_modules = vim.fs.dirname(vim.fs.find("node_modules", { path = fname, upward = true })[1])
+            if not node_modules then
+              return nil
+            else
+              return node_modules
+            end
+          end,
         },
       },
       setup = {


### PR DESCRIPTION
## Description

I'm working with Nuxt project that requires Nuxt UI. The tailwindcss lib is part of Nuxt UI's dependencies. And the new tailwindcss v4 allow us to not having any configuration files such as tailwind config or postcss config files. The problem is on the tailwind language server detection done by `nvim-lspconfig`, it detects the file we open is using tailwind lsp by checking whether the project root is having related config files as I mentioned before (which might not be the case for tailwindcss v4) and checking tailwindcss is installed in package.json, see L128 in link below.

https://github.com/neovim/nvim-lspconfig/blob/master/lsp/tailwindcss.lua#L109-L130

It seems correct but the project might has indirect dependency like Nuxt UI with tailwindcss out of the box. So, the fix is just to check if it's a javascript/typescript project by checking node_modules path. 

I guess this issue was address by someone here, but it was closed with dissatisfaction :')
https://github.com/neovim/nvim-lspconfig/issues/3448

Let me know if you guys have any better idea to solve this issue.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
