### PR TITLE
fix(venv-selector): incorrect configuration

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -120,10 +120,8 @@ return {
       return LazyVim.has("telescope.nvim")
     end,
     opts = {
-      settings = {
-        options = {
-          notify_user_on_venv_activation = true,
-        },
+      options = {
+        notify_user_on_venv_activation = true,
       },
     },
     --  Call config for python files and load the cached venv automatically


### PR DESCRIPTION
## Description

lazyextra `lang.python` incorrectly configured `venv-selector`, which cause it can't parse `opts` after merging config with user's custom config. Now I fix it.

## Screenshots

<img width="2350" height="1225" alt="image" src="https://github.com/user-attachments/assets/82b443a4-742f-49c8-bee2-438c97ea5d18" />

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
