### PR TITLE
fix(typescript): add support for chrome debugger

### DIFF
--- a/lua/lazyvim/plugins/extras/dap/core.lua
+++ b/lua/lazyvim/plugins/extras/dap/core.lua
@@ -67,13 +67,6 @@ return {
           { text = sign[1], texthl = sign[2] or "DiagnosticInfo", linehl = sign[3], numhl = sign[3] }
         )
       end
-
-      -- setup dap config by VsCode launch.json file
-      local vscode = require("dap.ext.vscode")
-      local json = require("plenary.json")
-      vscode.json_decode = function(str)
-        return vim.json.decode(json.json_strip_comments(str))
-      end
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -234,10 +234,6 @@ return {
 
       local js_filetypes = { "typescript", "javascript", "typescriptreact", "javascriptreact" }
 
-      local vscode = require("dap.ext.vscode")
-      vscode.type_to_filetypes["node"] = js_filetypes
-      vscode.type_to_filetypes["pwa-node"] = js_filetypes
-
       for _, language in ipairs(js_filetypes) do
         if not dap.configurations[language] then
           dap.configurations[language] = {

--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -257,6 +257,14 @@ return {
     end,
   },
 
+  {
+    "jay-babu/mason-nvim-dap.nvim",
+    optional = true,
+    opts = {
+      automatic_installation = { exclude = { "chrome" } },
+    },
+  },
+
   -- Filetype icons
   {
     "echasnovski/mini.icons",

--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -203,31 +203,34 @@ return {
     },
     opts = function()
       local dap = require("dap")
-      if not dap.adapters["pwa-node"] then
-        require("dap").adapters["pwa-node"] = {
-          type = "server",
-          host = "localhost",
-          port = "${port}",
-          executable = {
-            command = "node",
-            -- 💀 Make sure to update this path to point to your installation
-            args = {
-              LazyVim.get_pkg_path("js-debug-adapter", "/js-debug/src/dapDebugServer.js"),
-              "${port}",
+
+      for _, adapterType in ipairs({ "node", "chrome", "msedge" }) do
+        local pwaType = "pwa-" .. adapterType
+
+        if not dap.adapters[pwaType] then
+          dap.adapters[pwaType] = {
+            type = "server",
+            host = "localhost",
+            port = "${port}",
+            executable = {
+              command = "js-debug-adapter",
+              args = { "${port}" },
             },
-          },
-        }
-      end
-      if not dap.adapters["node"] then
-        dap.adapters["node"] = function(cb, config)
-          if config.type == "node" then
-            config.type = "pwa-node"
-          end
-          local nativeAdapter = dap.adapters["pwa-node"]
-          if type(nativeAdapter) == "function" then
-            nativeAdapter(cb, config)
-          else
-            cb(nativeAdapter)
+          }
+        end
+
+        -- Define adapters without the "pwa-" prefix for VSCode compatibility
+        if not dap.adapters[adapterType] then
+          dap.adapters[adapterType] = function(cb, config)
+            local nativeAdapter = dap.adapters[pwaType]
+
+            config.type = pwaType
+
+            if type(nativeAdapter) == "function" then
+              nativeAdapter(cb, config)
+            else
+              cb(nativeAdapter)
+            end
           end
         end
       end


### PR DESCRIPTION
## Align debugger configuration with VSCode

Added `chrome` and `msedge` to the list of pre-defined adapters. It brings the list of supported providers to:
`node`, `pwa-node`, `chrome`, `pwa-chrome`, `msedge`, `pwa-msedge`. Note that `pwa-*` prefix is deprecated in VSCode but required for `js-debug-adapter`. This PR mitigates this discrepancy by supporting both variants.

Removed deprecated `dap.ext.vscode`, the launch.json is [automatically loaded](https://github.com/mfussenegger/nvim-dap/blob/master/doc/dap.txt#L329) by dap.

Disable installing of deprecated `chrome-debug-adapter`. `js-debug-adapter` supports both node and browser debuggers.

## How to debug a web application in the browser
1. create `.vscode/launch.json` in the project root

```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "type": "chrome",
      "request": "launch",
      "name": "Open in Google Chrome",
      "url": "http://localhost:3000"
    }
  ]
}
```
2. make sure the app is running on `localhost:3000`
3. set breakpoints and run the debugger 


