### PR TITLE
fix(extras): ensure tex extra installs latex tree-sitter parser

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/tex.lua
+++ b/lua/lazyvim/plugins/extras/lang/tex.lua
@@ -12,7 +12,7 @@ return {
     opts = function(_, opts)
       opts.highlight = opts.highlight or {}
       if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "bibtex" })
+        vim.list_extend(opts.ensure_installed, { "bibtex", "latex" })
       end
       if type(opts.highlight.disable) == "table" then
         vim.list_extend(opts.highlight.disable, { "latex" })


### PR DESCRIPTION
## Description

Currently we don't ensure the latex treesitter is installed for latex. Although it is not used for highlighting, it is used by default plugins like flash, so this adds it to the list

## Related Issue(s)

https://github.com/LazyVim/LazyVim/pull/1156