### PR TITLE
fix(bufferline): bufferline use catppuccin API get_theme()

### DIFF
--- a/lua/lazyvim/plugins/colorscheme.lua
+++ b/lua/lazyvim/plugins/colorscheme.lua
@@ -58,7 +58,7 @@ return {
         optional = true,
         opts = function(_, opts)
           if (vim.g.colors_name or ""):find("catppuccin") then
-            opts.highlights = require("catppuccin.groups.integrations.bufferline").get()
+            opts.highlights = require("catppuccin.groups.integrations.bufferline").get_theme()
           end
         end,
       },


### PR DESCRIPTION
## Description

I see catppuccin should use now API get_theme(), does NOT get().

the below is error detail

   Error  11:33:38 notify.error lazy.nvim Failed to run `config` for bufferline.nvim

...re/nvim/lazy/LazyVim/lua/lazyvim/plugins/colorscheme.lua:61: attempt to call field 'get' (a nil value)

# stacktrace:
  - /LazyVim/lua/lazyvim/plugins/colorscheme.lua:61 _in_ **values**


## Related Issue(s)

nop

## Screenshots
<img width="768" height="160" alt="image" src="https://github.com/user-attachments/assets/3e7b3911-5442-44b4-a1bd-8d7165e806f4" />


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
