### PR TITLE
fix(catppuccin): apply bufferline api change

### DIFF
--- a/lua/lazyvim/plugins/colorscheme.lua
+++ b/lua/lazyvim/plugins/colorscheme.lua
@@ -58,7 +58,7 @@ return {
         optional = true,
         opts = function(_, opts)
           if (vim.g.colors_name or ""):find("catppuccin") then
-            opts.highlights = require("catppuccin.groups.integrations.bufferline").get()
+            opts.highlights = require("catppuccin.groups.integrations.bufferline").get_theme()
           end
         end,
       },


### PR DESCRIPTION
## Description

bufferline changed it's api, so we need to patch colorscheme.lua

## Related Issue(s)

  - Fixes #6355

## Screenshots

-

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
