### PR TITLE
fix(catppuccin): bufferline integration

### DIFF
--- a/lua/lazyvim/plugins/colorscheme.lua
+++ b/lua/lazyvim/plugins/colorscheme.lua
@@ -58,7 +58,7 @@ return {
         optional = true,
         opts = function(_, opts)
           if (vim.g.colors_name or ""):find("catppuccin") then
-            opts.highlights = require("catppuccin.groups.integrations.bufferline").get()
+            opts.highlights = require("catppuccin.groups.integrations.bufferline").get_theme()
           end
         end,
       },


### PR DESCRIPTION
fix(catppuccin): bufferline integration


## Description

Hello! I noticed an error when using bufferline integration with catppuccin.
I checked the catppuccin bufferline [integrations](https://github.com/catppuccin/nvim?tab=readme-ov-file#integrations) and noticed the change to get_theme.


## Screenshots

<img width="700" height="274" alt="image" src="https://github.com/user-attachments/assets/9b589947-180b-4cd4-8f02-5b94db8bc224" />

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
