### PR TITLE
fix(typescript): DAP configuration for Typescript

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -247,6 +247,10 @@ return {
               name = "Launch file",
               program = "${file}",
               cwd = "${workspaceFolder}",
+              sourceMaps = true,
+              resolveSourceMapLocations = { "${workspaceFolder}/buid/**/*.js" },
+              skipFiles = { "<node_internals>/**", "node_modules/**" },
+              runtimeExecutable = "ts-node",
             },
             {
               type = "pwa-node",
@@ -254,6 +258,10 @@ return {
               name = "Attach",
               processId = require("dap.utils").pick_process,
               cwd = "${workspaceFolder}",
+              sourceMaps = true,
+              resolveSourceMapLocations = { "${workspaceFolder}/buid/**/*.js" },
+              skipFiles = { "<node_internals>/**", "node_modules/**" },
+              runtimeExecutable = "ts-node",
             },
           }
         end


### PR DESCRIPTION
## Description
DAP configuration for Typescript did not work right with imports as described in #6382 . Setting the `runtimeExecutable` to `ts-node` in the `Launch File` config fixes the issue. Additionally also set `sourceMaps`, because else the debugger complains that it can't read them. 

The `skipFiles` field is optional but I feel like it makes sense if I am already updating the debugger (it skips lib files). 

Added settings in `Attach` config might not be necessary (I have never used `Attach), but I'm assuming this makes sense?

## Related ~~Issue(s)~~ Discussion

https://github.com/LazyVim/LazyVim/discussions/6382#discussion-8826409



## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
