### PR TITLE
fix(snacks_picker): merge user config with call options

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/snacks_picker.lua
+++ b/lua/lazyvim/plugins/extras/editor/snacks_picker.lua
@@ -18,6 +18,7 @@ local picker = {
   ---@param source string
   ---@param opts? snacks.picker.Config
   open = function(source, opts)
+    opts = vim.tbl_deep_extend("force", opts or {}, Snacks.config.picker[source] or {})
     return Snacks.picker.pick(source, opts)
   end,
 }


### PR DESCRIPTION
## Description

User configuration for snacks picker may not be applied when called via `LazyVim.pick()`. The picker.open() function currently only passes call-specific options to Snacks.picker.pick(), without explicitly merging user configuration from Snacks.config.picker[source].

For example, this configuration might be ignored:

```lua
return {
  "folke/snacks.nvim",
  opts = {
    picker = {
      grep = {
        regex = false,
      },
    },
  },
}
```

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.