### PR TITLE
fix(colorscheme): use get_theme() for catppuccin bufferline integration

### DIFF
--- a/lua/lazyvim/plugins/colorscheme.lua
+++ b/lua/lazyvim/plugins/colorscheme.lua
@@ -58,7 +58,7 @@ return {
         optional = true,
         opts = function(_, opts)
           if (vim.g.colors_name or ""):find("catppuccin") then
-            opts.highlights = require("catppuccin.groups.integrations.bufferline").get()
+            opts.highlights = require("catppuccin.groups.integrations.bufferline").get_theme()
           end
         end,
       },


### PR DESCRIPTION
catppuccin's bufferline integration no longer provides `get()`. Switch to `get_theme()` to avoid the error:

attempt to call field 'get' (a nil value)

## Description

This PR updates LazyVim's catppuccin integration with `bufferline.nvim` to use
`get_theme()` instead of the removed `get()` function. Without this change,
Neovim fails to start when using catppuccin as the colorscheme.

## Related Issue(s)

<!-- If there is a reported issue for this bug, link it here. -->
Fixes #<issue_number_if_exists>

## Screenshots

N/A — no visual change, only fixes a startup error.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
- [x] The change has been tested locally with catppuccin and bufferline installed.
- [x] No breaking changes for other colorschemes.