### PR TITLE
fix(lang.haskell): prevent Haskell extras from installing telescope.nvim

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/haskell.lua
+++ b/lua/lazyvim/plugins/extras/lang/haskell.lua
@@ -70,7 +70,7 @@ return {
     "luc-tielen/telescope_hoogle",
     ft = { "haskell", "lhaskell", "cabal", "cabalproject" },
     dependencies = {
-      { "nvim-telescope/telescope.nvim" },
+      { "nvim-telescope/telescope.nvim", optional = true },
     },
     config = function()
       local ok, telescope = pcall(require, "telescope")


### PR DESCRIPTION

## Description
Installing the Haskell extras currently installs telescope.nvim as well,
since the dependency is not marked optional. This marks it optional so
telescope.nvim is no longer pulled in automatically.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
