### PR TITLE
fix(json,yaml): use `before_init` instead of `on_new_config`

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/json.lua
+++ b/lua/lazyvim/plugins/extras/lang/json.lua
@@ -27,7 +27,7 @@ return {
       servers = {
         jsonls = {
           -- lazy-load schemastore when needed
-          on_new_config = function(new_config)
+          before_init = function(_, new_config)
             new_config.settings.json.schemas = new_config.settings.json.schemas or {}
             vim.list_extend(new_config.settings.json.schemas, require("schemastore").json.schemas())
           end,

--- a/lua/lazyvim/plugins/extras/lang/yaml.lua
+++ b/lua/lazyvim/plugins/extras/lang/yaml.lua
@@ -29,7 +29,7 @@ return {
             },
           },
           -- lazy-load schemastore when needed
-          on_new_config = function(new_config)
+          before_init = function(_, new_config)
             new_config.settings.yaml.schemas = vim.tbl_deep_extend(
               "force",
               new_config.settings.yaml.schemas or {},


### PR DESCRIPTION
## Description

`vim.lsp.config` doesn't provide `on_new_config`, which is causing `b0o/SchemaStore.nvim` fail to load.
This PR replaces `on_new_config` with `before_init` fixing the issue.

## Checklist

- [ x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
