### PR TITLE
fix(ocaml): use `root_dir` instead of `root_markers` for globs support

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/ocaml.lua
+++ b/lua/lazyvim/plugins/extras/lang/ocaml.lua
@@ -26,15 +26,12 @@ return {
             "reason",
             "dune",
           },
-          root_markers = {
-            "*.opam",
-            "esy.json",
-            "package.json",
-            ".git",
-            "dune-project",
-            "dune-workspace",
-            "*.ml",
-          },
+          root_dir = function(bufnr, on_dir)
+            local util = require("lspconfig.util")
+            local fname = vim.api.nvim_buf_get_name(bufnr)
+            --stylua: ignore
+            on_dir(util.root_pattern("*.opam", "esy.json", "package.json", ".git", "dune-project", "dune-workspace", "*.ml")( fname))
+          end,
         },
       },
     },


### PR DESCRIPTION
## Description
As per [comment](https://github.com/LazyVim/LazyVim/commit/23b9cdeb3471b655532e9884fa2dd36ee83062d5#r165830889), use `root_dir` with `util.root_pattern` instead of `root_markers` for globs support.

I don't actually do Ocaml to thoroughly test it, but it should work in theory :stuck_out_tongue: 
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
