### PR TITLE
fix(jdtls): root_dir

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -91,6 +91,7 @@ return {
         table.insert(cmd, string.format("--jvm-arg=-javaagent:%s", lombok_jar))
       end
       return {
+        root_dir = require("lspconfig.util").root_pattern(vim.lsp.config.jdtls.root_markers),
 
         -- How to find the project name for a given root dir.
         project_name = function(root_dir)
@@ -164,10 +165,12 @@ return {
         end
       end
       local function attach_jdtls()
+        local fname = vim.api.nvim_buf_get_name(0)
+
         -- Configuration can be augmented and overridden by opts.jdtls
         local config = extend_or_override({
           cmd = opts.full_cmd(opts),
-          root_dir = vim.fs.root(0, vim.lsp.config.jdtls.root_markers),
+          root_dir = opts.root_dir(fname),
           init_options = {
             bundles = bundles,
           },


### PR DESCRIPTION
Fix:

```
Failed to run `config` for nvim-jdtls

...im/lazy/LazyVim/lua/lazyvim/plugins/extras/lang/java.lua:113: attempt to call field 'root_dir' (a nil value)

  - /LazyVim/lua/lazyvim/plugins/extras/lang/java.lua:113 _in_ **full_cmd**
  - /LazyVim/lua/lazyvim/plugins/extras/lang/java.lua:169 _in_ **attach_jdtls**
  - /LazyVim/lua/lazyvim/plugins/extras/lang/java.lua:286 _in_ **config**
  - ~/.local/share/bob/nightly/share/nvim/runtime/filetype.lua:36
  - vim/shared.lua:0
  - ~/.local/share/bob/nightly/share/nvim/runtime/filetype.lua:35
  - vim/_editor.lua:0 _in_ **cmd**
  - /persistence.nvim/lua/persistence/init.lua:88 _in_ **load**
  - lua:1
  - vim/_editor.lua:0 _in_ **action**
  - /snacks.nvim/lua/snacks/dashboard.lua:693
```

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
