### PR TITLE
feat(lang.nix): Use `alejandra` formatter instead of `nixfmt`

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/nix.lua
+++ b/lua/lazyvim/plugins/extras/lang/nix.lua
@@ -20,7 +20,7 @@ return {
     optional = true,
     opts = {
       formatters_by_ft = {
-        nix = { "nixfmt" },
+        nix = { "alejandra" },
       },
     },
   },


### PR DESCRIPTION
## Description
This pr change `conform.nvim` formatter to [Alejandra]( https://github.com/kamadorueda/alejandra) because It's faster and prettier

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
