### PR TITLE
clangd: improvements

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -9,6 +9,8 @@ return {
         "compile_commands.json",
         "compile_flags.txt",
         "configure.ac", -- AutoTools
+        "meson.build",
+        "build.ninja",
       },
     })
   end,

--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -63,9 +63,6 @@ return {
             { "<leader>ch", "<cmd>ClangdSwitchSourceHeader<cr>", desc = "Switch Source/Header (C/C++)" },
           },
           root_markers = {
-            ".clangd",
-            ".clang-tidy",
-            ".clang-format",
             "compile_commands.json",
             "compile_flags.txt",
             "configure.ac", -- AutoTools


### PR DESCRIPTION
## Description

As discussed in https://github.com/LazyVim/LazyVim/commit/23b9cdeb3471b655532e9884fa2dd36ee83062d5#r165937336, it'd be better to remove clang configuration files from influencing root dir detection. I've also added meson and ninja files to the extra's recommendation detection

## Related Issue(s)

## Screenshots

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
