### PR TITLE
fix(editor): calculate the height passed to the prompt of fzf-lua properly

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/fzf.lua
+++ b/lua/lazyvim/plugins/extras/editor/fzf.lua
@@ -120,7 +120,7 @@ return {
             winopts = {
               layout = "vertical",
               -- height is number of items minus 15 lines for the preview, with a max of 80% screen height
-              height = math.floor(math.min(vim.o.lines * 0.8 - 16, #items + 2) + 0.5) + 16,
+              height = math.floor(math.min(vim.o.lines * 0.8 - 16, #items + 4) + 0.5) + 16,
               width = 0.5,
               preview = not vim.tbl_isempty(vim.lsp.get_clients({ bufnr = 0, name = "vtsls" })) and {
                 layout = "vertical",
@@ -135,7 +135,7 @@ return {
             winopts = {
               width = 0.5,
               -- height is number of items, with a max of 80% screen height
-              height = math.floor(math.min(vim.o.lines * 0.8, #items + 2) + 0.5),
+              height = math.floor(math.min(vim.o.lines * 0.8, #items + 4) + 0.5),
             },
           })
         end,


### PR DESCRIPTION
## Description

add two lines more to the height of prompt window.

## Related Issue(s)

  - Fixes #6480


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
