### PR TITLE
fix(mini.animate): schedule the toggle mapping to correctly take effect

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/mini-animate.lua
+++ b/lua/lazyvim/plugins/extras/ui/mini-animate.lua
@@ -32,15 +32,19 @@ return {
         end,
       })
 
-      Snacks.toggle({
-        name = "Mini Animate",
-        get = function()
-          return not vim.g.minianimate_disable
-        end,
-        set = function(state)
-          vim.g.minianimate_disable = not state
-        end,
-      }):map("<leader>ua")
+      -- schedule setting the mapping to override the default mapping from `keymaps.lua`
+      -- seems `keymaps.lua` is the last event to execute on `VeryLazy` and it overwrites it
+      vim.schedule(function()
+        Snacks.toggle({
+          name = "Mini Animate",
+          get = function()
+            return not vim.g.minianimate_disable
+          end,
+          set = function(state)
+            vim.g.minianimate_disable = not state
+          end,
+        }):map("<leader>ua")
+      end)
 
       local animate = require("mini.animate")
       return vim.tbl_deep_extend("force", opts, {


### PR DESCRIPTION
## Description
`mini.animate`'s toggle mapping didn't take effect, presumably because `keymaps.lua` is the last one to execute on `VeryLazy`. Schedule it to correctly overwrite the default from `keymaps.lua`.

I would also be interested if you don't mind to explain to me how can I find out the order of the events execution if there are multiple executions on the same event (i.e on `VeryLazy` what is the order of the execution? Is it arbitrary?)
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None. Saw a discussion on `snacks.nvim` and OP wanted to change the mapping and when I tested with `mini.animate` Extra I noticed that its mapping wasn't overriding the default one from `keymaps.lua`.
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
