### PR TITLE
fix(jdtls): allow mason jdtls installation

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -71,11 +71,6 @@ return {
       servers = {
         jdtls = {},
       },
-      setup = {
-        jdtls = function()
-          return true -- avoid duplicate servers
-        end,
-      },
     },
   },
 


### PR DESCRIPTION
Bug fix jdtls config for compatibility with last lsp refactor.
