### PR TITLE
fix(mason): only don't install servers with `enabled=false`

### DIFF
--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -215,7 +215,7 @@ return {
       if have_mason then
         require("mason-lspconfig").setup({
           ensure_installed = vim.tbl_filter(function(server)
-            return not vim.tbl_contains(exclude, server)
+            return opts.servers[server].enabled ~= false
           end, vim.list_extend(servers, LazyVim.opts("mason-lspconfig.nvim").ensure_installed or {})),
           automatic_enable = { exclude = exclude },
         })


### PR DESCRIPTION
## Description
I don't believe we should filter out servers from `exclude` table from installing via Mason (which is the current behavior).

I believe servers should not be installed only when `enabled = false`. 

You might also want to take a look at the comments in #6498 and might revert that commit as it seems to break the Java Extra. See [comment here](https://github.com/LazyVim/LazyVim/pull/6498#issuecomment-3322117658). I don't do Java to thoroughly test.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None. Just the comment I linked above for the Java Extra PR, which prompted me to test again the current code.
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
