### PR TITLE
fix(catppuccin): follow renamed integration (again)

### DIFF
--- a/lua/lazyvim/plugins/colorscheme.lua
+++ b/lua/lazyvim/plugins/colorscheme.lua
@@ -58,7 +58,7 @@ return {
         optional = true,
         opts = function(_, opts)
           if (vim.g.colors_name or ""):find("catppuccin") then
-            opts.highlights = require("catppuccin.groups.integrations.bufferline").get_theme()
+            opts.highlights = require("catppuccin.special.bufferline").get_theme()
           end
         end,
       },


### PR DESCRIPTION
"We have renamed the integration [again](https://github.com/catppuccin/nvim/commit/5af9374957a65be8770696da295dc9016b96f241), pray we do not rename it further"