### PR TITLE
fix(bufferline): fix the path to bufferline.lua in colorscheme.lua

### DIFF
--- a/lua/lazyvim/plugins/colorscheme.lua
+++ b/lua/lazyvim/plugins/colorscheme.lua
@@ -58,7 +58,7 @@ return {
         optional = true,
         opts = function(_, opts)
           if (vim.g.colors_name or ""):find("catppuccin") then
-            opts.highlights = require("catppuccin.groups.integrations.bufferline").get_theme()
+            opts.highlights = require("catppuccin.special.bufferline").get_theme()
           end
         end,
       },


### PR DESCRIPTION

## Description

- In catppuccin/nvim, the path for bufferline.lua had been changed from “lua/catppuccin/groups/integrations/” to “lua/catppuccin/special/”, causing a loading error each time Neovim was launched.
- The bug was fixed by correcting the path specification in the require statement within LazyVim's colorscheme.lua.

<img width="1299" height="452" alt="image" src="https://github.com/user-attachments/assets/39119d81-07a6-48c3-b02d-c9b6198a0962" />

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

- Fixes #6522 
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
