### PR TITLE
fix(copilot-chat): use up to date config for chat headers

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/copilot-chat.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot-chat.lua
@@ -8,8 +8,11 @@ return {
       user = user:sub(1, 1):upper() .. user:sub(2)
       return {
         auto_insert_mode = true,
-        question_header = "  " .. user .. " ",
-        answer_header = "  Copilot ",
+        headers = {
+          user = "  " .. user .. " ",
+          assistant = "  Copilot ",
+          tool = "󰊳  Tool ",
+        },
         window = {
           width = 0.4,
         },


### PR DESCRIPTION
The config format changed a while ago due to function calling support