### PR TITLE
Change  Copilot-native's "<M-[>" description to "Prev Suggestion"

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/copilot-native.lua
+++ b/lua/lazyvim/plugins/extras/ai/copilot-native.lua
@@ -37,7 +37,7 @@ return {
             {
               "<M-[>",
               function() vim.lsp.inline_completion.select({ count = -1 }) end,
-              desc = "Next Copilot Suggestion",
+              desc = "Prev Copilot Suggestion",
               mode = { "i", "n" },
             },
           },


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
The description for both `<M-]>` and `<M-[>` in the `copilot-native` extra are described as `Next Copilot Suggestion`. The PR changes the description of `<M-[>` to be `Prev Copilot Suggestion`

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
