### PR TITLE
chore(render-markdown): use API to toggle

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/markdown.lua
+++ b/lua/lazyvim/plugins/extras/lang/markdown.lua
@@ -113,17 +113,8 @@ return {
       require("render-markdown").setup(opts)
       Snacks.toggle({
         name = "Render Markdown",
-        get = function()
-          return require("render-markdown.state").enabled
-        end,
-        set = function(enabled)
-          local m = require("render-markdown")
-          if enabled then
-            m.enable()
-          else
-            m.disable()
-          end
-        end,
+        get = require("render-markdown").get,
+        set = require("render-markdown").set,
       }):map("<leader>um")
     end,
   },


### PR DESCRIPTION
## Description

The `state` module in `render-markdown` is not expected to be accessed outside of the package and may be refactored in the future.

Prevent any breaking changes in LazyVim by using the public API which was updated here:
https://github.com/MeanderingProgrammer/render-markdown.nvim/commit/accaa600ba59022171275adf6640dda13004bd6f

## Related Issue(s)

None

## Screenshots

N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
