### PR TITLE
fix(extras): adjust switch source/header shortcut

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -60,7 +60,7 @@ return {
         -- Ensure mason installs the server
         clangd = {
           keys = {
-            { "<leader>ch", "<cmd>ClangdSwitchSourceHeader<cr>", desc = "Switch Source/Header (C/C++)" },
+            { "<leader>ch", "<cmd>LspClangdSwitchSourceHeader<cr>", desc = "Switch Source/Header (C/C++)" },
           },
           root_markers = {
             "compile_commands.json",


### PR DESCRIPTION
The command to switch header and source is now called `:LspClangdSwitchSourceHeader` and no longer
`:ClangdSwitchSourceHeader`.

## Description

This is just a small fix due to a command that has been renamed.

## Related Issue(s)

I did not find any related issues.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
