### PR TITLE
fix(lualine): increase placeholder width for better rendering

### DIFF
--- a/lua/lazyvim/util/lualine.lua
+++ b/lua/lazyvim/util/lualine.lua
@@ -124,7 +124,7 @@ function M.pretty_path(opts)
     if opts.length == 0 then
       parts = parts
     elseif #parts > opts.length then
-      parts = { parts[1], "…", unpack(parts, #parts - opts.length + 2, #parts) }
+      parts = { parts[1], "… ", unpack(parts, #parts - opts.length + 2, #parts) }
     end
 
     if opts.modified_hl and vim.bo.modified then


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

In the pretty path lualine helper, the ellipsis is being cut off. In order to fix that, I've added an extra space of padding in order for things to visually line up correctly again.

I'm using Iosevka as my font and am seeing this in both Wezterm and Ghostty. It could potentially be a font problem, but in case it's not, I decided to submit a potential fix.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

Before:
<img width="1280" height="720" alt="Screenshot showing the problem" src="https://github.com/user-attachments/assets/2e74e720-31e9-4538-8d80-69b0430b4bfc" />

Notice the ellipsis being cut off in the statusline.

After:

<img width="1280" height="720" alt="Screenshot with the problem fixed" src="https://github.com/user-attachments/assets/354e7ac0-acc8-4456-bc48-3c39eed0b2ca" />

No more cut off!

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
