### PR TITLE
docs(ui): fix typo - `s/inent/indent/`

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/mini-indentscope.lua
+++ b/lua/lazyvim/plugins/extras/ui/mini-indentscope.lua
@@ -44,7 +44,7 @@ return {
     end,
   },
 
-  -- disable inent-blankline scope when mini-indentscope is enabled
+  -- disable indent-blankline scope when mini-indentscope is enabled
   {
     "lukas-reineke/indent-blankline.nvim",
     optional = true,


### PR DESCRIPTION
## Description

This fixes a typo I noticed in the docs.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
