### PR TITLE
fix(xtras): load `copilot-native` before `blink`

### DIFF
--- a/lua/lazyvim/plugins/xtras.lua
+++ b/lua/lazyvim/plugins/xtras.lua
@@ -5,8 +5,9 @@ local prios = {
   ["lazyvim.plugins.extras.coding.nvim-cmp"] = 2,
   ["lazyvim.plugins.extras.editor.neo-tree"] = 2,
   ["lazyvim.plugins.extras.ui.edgy"] = 3,
-  ["lazyvim.plugins.extras.lang.typescript"] = 5,
+  ["lazyvim.plugins.extras.ai.copilot-native"] = 4,
   ["lazyvim.plugins.extras.coding.blink"] = 5,
+  ["lazyvim.plugins.extras.lang.typescript"] = 5,
   ["lazyvim.plugins.extras.formatting.prettier"] = 10,
   -- default core extra priority is 20
   -- default priority is 50


### PR DESCRIPTION
## Description
`blink` Extra loads earlier than `copilot-native` Extra and that causes `ghost_text.enabled = vim.g.ai_cmp` to wrongly evaluate to `true` even though `copilot-native` explicitly sets `vim.g.ai_cmp = false`.

I also changed the order of `blink` and `typescript` so that `blink` comes logically right after `copilot-native`, hope that is not a problem. If it is, feel free to revert the order and just keep the change about `copilot-native`.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None, I was just trying to create a toggle mapping to disable/enable both NES and inline_completion and even  though they were disabled, I could see ghost_text from blink.
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
