### PR TITLE
fix(treesitter): don't lazy-load textobjects when open file from command line

### DIFF
--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -141,6 +141,7 @@ return {
     "nvim-treesitter/nvim-treesitter-textobjects",
     branch = "main",
     event = "VeryLazy",
+    lazy = vim.fn.argc(-1) == 0, -- load treesitter-textobjects early when opening a file from the cmdline
     opts = {
       move = {
         enable = true,


### PR DESCRIPTION
## Description
`nvim-treesitter-textobjects` don't create keymaps when opening file directly from command line. 

Follow same logic as loading `nvim-treesitter` with regards to lazy-loading
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #6639
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
