### PR TITLE
fix(typescript): support chrome, node and msedge dap adapters

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -315,6 +315,7 @@ return {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
     opts = {
+      -- chrome adapter is deprecated, use js-debug-adapter instead
       automatic_installation = { exclude = { "chrome" } },
     },
   },


### PR DESCRIPTION
## Description
Add support for `chrome`, `node` and `msedge` configs for dap typescript.

## Related Issue(s)
https://github.com/LazyVim/LazyVim/pull/6328

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
