### PR TITLE
revert: "feat(extra): allow users to add custom bundles through opts.init_options.bundles to jdtls (#6265)"

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -157,16 +157,6 @@ return {
           end
         end
       end
-
-      -- Allow users to add custom bundles through opts.init_options.bundles and opts.jdtls.init_options.bundles
-      if opts.init_options and opts.init_options.bundles then
-        vim.list_extend(bundles, opts.init_options.bundles)
-      end
-      if opts.jdtls and opts.jdtls.init_options and opts.jdtls.init_options.bundles then
-        vim.list_extend(bundles, opts.jdtls.init_options.bundles)
-        opts.jdtls.init_options.bundles = nil
-      end
-
       local function attach_jdtls()
         local fname = vim.api.nvim_buf_get_name(0)
 


### PR DESCRIPTION
Fixes:

```
Failed to run `config` for nvim-jdtls

...im/lazy/LazyVim/lua/lazyvim/plugins/extras/lang/java.lua:165: attempt to index field 'jdtls' (a function value)

  - /LazyVim/lua/lazyvim/plugins/extras/lang/java.lua:165 _in_ **config**
  - ~/.local/share/bob/nightly/share/nvim/runtime/filetype.lua:36
  - vim/shared.lua:0
  - ~/.local/share/bob/nightly/share/nvim/runtime/filetype.lua:35
  - vim/_editor.lua:0 _in_ **cmd**
  - /snacks.nvim/lua/snacks/picker/actions.lua:115 _in_ **fn**
  - /snacks.nvim/lua/snacks/win.lua:339
```

`init_options.bundles` already can be overridden by `opts.jdtls`, see: https://github.com/LazyVim/LazyVim/pull/6265#issuecomment-3203831504 for example.

## Description

Reverts the commit, which breaks `opts.jdtls` defined here:

https://github.com/LazyVim/LazyVim/blob/faeb24ba956f103c5551bde11506991d8b594bc5/lua/lazyvim/plugins/extras/lang/java.lua#L185-L185

## Related Issue(s)

#6265 

## Screenshots

None.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
