### PR TITLE
fix(avante): unset default keymaps

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/avante.lua
+++ b/lua/lazyvim/plugins/extras/ai/avante.lua
@@ -11,6 +11,9 @@ return {
       selection = {
         hint_display = "none",
       },
+      behaviour = {
+        auto_set_keymaps = false,
+      },
     },
     cmd = {
       "AvanteAsk",


### PR DESCRIPTION
## Description

The extras spec includes its own keymaps for the most common commands now so these are redundant and causing duplicate entries in which-key.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
