### PR TITLE
feat(sidekick): add open terminal from sidekick

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/sidekick.lua
+++ b/lua/lazyvim/plugins/extras/ai/sidekick.lua
@@ -65,6 +65,26 @@ return {
           return true
         end
       end
+
+      return {
+        cli = {
+          win = {
+            keys = {
+              open_terminal = {
+                "<C-/>",
+                function(_)
+                  vim.cmd.stopinsert()
+                  vim.schedule(function()
+                    Snacks.terminal(nil, { cwd = LazyVim.root() })
+                  end)
+                end,
+                mode = "nt",
+                desc = "Terminal (Root Dir)",
+              },
+            },
+          },
+        },
+      }
     end,
     -- stylua: ignore
     keys = {


### PR DESCRIPTION
## Description

When using sidekick AI CLI it's really common to hopping back and froth between the terminal (e.g. to run commands suggested by the LLM) and the AI CLI pane.

The current keymap configuration require to enter NORMAL mode with `<C-q>` and then spawn a terminal with `<C-/>`. If the terminal is already open, you can also navigate to it with <C-h|j|k|l>` (but I still prefer a single keymap "open and jump to my terminal").

Adding `<C-/>` to sidekick keymaps enable to open and jump to terminal also from the TERMINAL mode of sidekick_terminal.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
