### PR TITLE
fix(clipboad): connecting via vscpde's remote-ssh extension causes severe lag during yank and copy operations. 

### DIFF
--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -54,7 +54,7 @@ local opt = vim.opt
 opt.autowrite = true -- Enable auto write
 -- only set clipboard if not in ssh, to make sure the OSC 52
 -- integration works automatically.
-opt.clipboard = vim.env.SSH_TTY and "" or "unnamedplus" -- Sync with system clipboard
+opt.clipboard = vim.env.SSH_CONNECTION and "" or "unnamedplus" -- Sync with system clipboard
 opt.completeopt = "menu,menuone,noselect"
 opt.conceallevel = 2 -- Hide * markup for bold and italic, but not markers with substitutions
 opt.confirm = true -- Confirm to save changes before exiting modified buffer

--- a/lua/lazyvim/plugins/extras/coding/yanky.lua
+++ b/lua/lazyvim/plugins/extras/coding/yanky.lua
@@ -5,6 +5,9 @@ return {
   desc = "Better Yank/Paste",
   event = "LazyFile",
   opts = {
+    system_clipboard = {
+      sync_with_ring = not vim.env.SSH_CONNECTION,
+    },
     highlight = { timer = 150 },
   },
   keys = {


### PR DESCRIPTION
## Description

When connecting to a remote server via VSCode's Remote-SSH extension, the `SSH_TTY` environment variable is not set. Consequently, both the `vscode-neovim` extension (when using the remote Neovim instance) and Neovim launched from VSCode's integrated terminal use the system clipboard, resulting in severe lag.

Additionally, the `yanky.nvim` plugin synchronizes with the system clipboard by default, regardless of whether the `clipboard` option is set to an empty string (`""`). This causes similar performance issues as described above.

Using the `SSH_CONNECTION` environment variable instead of `SSH_TTY` can effectively resolve this issue.



## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
