### PR TITLE
fix(dart): add file name to formatter

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/dart.lua
+++ b/lua/lazyvim/plugins/extras/lang/dart.lua
@@ -22,7 +22,7 @@ return {
     opts = {
       formatters = {
         dart_format = {
-          args = { "format", "--line-length", "120" },
+          args = { "format", "--line-length", "120", "$FILENAME" },
         },
       },
       formatters_by_ft = {


### PR DESCRIPTION
Fix dart_format failing to format because there wasn't a file name included.

## Description

I noticed the dart formatter wasn't working when installing the lang.dart extra without adding any of my own configuration. I tested this in a Docker container with a new install of LazyVim and lang.dart as well and the problem happens there as well.
The problem originates from the $FILENAME not being included in the dart format command, this PR adds that and thus fixes the formatting for dart.

## Related Issue(s)

-

## Screenshots

-

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
