### PR TITLE
chore(toml): change the language server from taplo to tombi

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/toml.lua
+++ b/lua/lazyvim/plugins/extras/lang/toml.lua
@@ -8,7 +8,7 @@ return {
   "neovim/nvim-lspconfig",
   opts = {
     servers = {
-      taplo = {},
+      tombi = {},
     },
   },
 }


### PR DESCRIPTION
## Description

The Taplo language server is no longer maintained: https://github.com/tamasfe/taplo/issues/715#issue-2751689713. The only alternative I could find was [Tombi](https://github.com/tombi-toml/tombi).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
