### PR TITLE
feat(treesitter): support query table in treesitter-textobjects mappings

### DIFF
--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -171,8 +171,14 @@ return {
 
         for method, keymaps in pairs(moves) do
           for key, query in pairs(keymaps) do
-            local desc = query:gsub("@", ""):gsub("%..*", "")
-            desc = desc:sub(1, 1):upper() .. desc:sub(2)
+            local queries = type(query) == "table" and query or { query }
+            local parts = {}
+            for _, q in ipairs(queries) do
+              local part = q:gsub("@", ""):gsub("%..*", "")
+              part = part:sub(1, 1):upper() .. part:sub(2)
+              table.insert(parts, part)
+            end
+            local desc = table.concat(parts, " or ")
             desc = (key:sub(1, 1) == "[" and "Prev " or "Next ") .. desc
             desc = desc .. (key:sub(2, 2) == key:sub(2, 2):upper() and " End" or " Start")
             if not (vim.wo.diff and key:find("[cC]")) then


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

`treesitter-textobjects` mappings accept a table query (for the "move" mappings, at least, I haven't checked the others). Currently, in LazyVim, using a table causes an error due to the assumption that `query` is a string in the `config` function that creates the keymap description. This  PR adds a simple loop to gather the queries from a table and join them with "or" in the description.

Here is an example config and the resulting error. Everything works as expected with the PR and string (single) queries still behave as expected.

```lua
  {
    "nvim-treesitter/nvim-treesitter-textobjects",
    opts = {
      move = {
        keys = {
          goto_next_start = { ["]j"] = { "@function.outer", "@class.outer" } },
          goto_next_end = { ["]J"] = { "@function.outer", "@class.outer" } },
          goto_previous_start = { ["[j"] = { "@function.outer", "@class.outer" } },
          goto_previous_end = { ["[J"] = { "@function.outer", "@class.outer" } },
        },
      },
    },
  }
```

```lua
Failed to run `config` for nvim-treesitter-textobjects

...vim-local/opt/LazyVim/lua/lazyvim/plugins/treesitter.lua:174: attempt to call method 'gsub' (a nil value)

# stacktrace:
  - repos/nvim-local/opt/LazyVim/lua/lazyvim/plugins/treesitter.lua:174
  - vim/shared.lua:0 _in_ **tbl_map**
  - repos/nvim-local/opt/LazyVim/lua/lazyvim/plugins/treesitter.lua:197 _in_ **config**
```



## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
