### PR TITLE
feat(extras.editor)!: update Leap configuration

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/leap.lua
+++ b/lua/lazyvim/plugins/extras/editor/leap.lua
@@ -1,37 +1,94 @@
+-- A helper function making it easier to set "clever-f" behavior
+-- (use f/F or t/T instead of ;/, - see the plugin clever-f.vim).
+local function clever(...)
+  return require("leap.user").with_traversal_keys(...)
+end
+
+local function ft(key_specific_args)
+  require("leap").leap(vim.tbl_deep_extend("keep", key_specific_args, {
+    inputlen = 1,
+    inclusive = true,
+    opts = {
+      labels = "",
+      safe_labels = vim.fn.mode(true):match("no?") and "" or nil,
+    },
+  }))
+end
+
 return {
   -- disable flash
   { "folke/flash.nvim", enabled = false, optional = true },
 
-  -- easily jump to any location and enhanced f/t motions for Leap
+  -- Leap provides improved vim-sneak-style navigation with live label
+  -- preview and multi-window scope, and also extra features like remote
+  -- operations and incremental treesitter node selection.
   {
     url = "https://codeberg.org/andyg/leap.nvim.git",
-    enabled = true,
-    keys = function()
-      ---@type LazyKeysSpec[]
-      local ret = {}
-      for _, key in ipairs({ "f", "F", "t", "T" }) do
-        ret[#ret + 1] = { key, mode = { "n", "x", "o" } }
-      end
-      return ret
-    end,
-    opts = { labeled_modes = "nx" },
-  },
-  {
-    url = "https://codeberg.org/andyg/leap.nvim.git",
-    enabled = true,
     keys = {
-      { "s", mode = { "n", "x", "o" }, desc = "Leap Forward to" },
-      { "S", mode = { "n", "x", "o" }, desc = "Leap Backward to" },
-      { "gs", mode = { "n", "x", "o" }, desc = "Leap from Windows" },
+      { "s", mode = { "n", "x", "o" }, "<Plug>(leap)", desc = "Leap" },
+      { "S", mode = { "n" }, "<Plug>(leap-from-window)", desc = "Leap from Window" },
+      -- Enhanced f/t motions.
+      -- To keep using `;`/`,` just set `opts = clever(";", ",")` everywhere.
+      {
+        "f",
+        mode = { "n", "x", "o" },
+        function()
+          ft({ opts = clever("f", "F") })
+        end,
+      },
+      {
+        "F",
+        mode = { "n", "x", "o" },
+        function()
+          ft({ backward = true, opts = clever("f", "F") })
+        end,
+      },
+      {
+        "t",
+        mode = { "n", "x", "o" },
+        function()
+          ft({ offset = -1, opts = clever("t", "T") })
+        end,
+      },
+      {
+        "T",
+        mode = { "n", "x", "o" },
+        function()
+          ft({ backward = true, offset = 1, opts = clever("t", "T") })
+        end,
+      },
+      -- See the documentation for extras, like setting up automatic
+      -- pasting after yank operations or defining remote text objects.
+      {
+        "gs",
+        mode = { "n", "o" },
+        function()
+          -- Automatically enter Visual mode when coming from Normal.
+          require("leap.remote").action({ input = vim.fn.mode(true):match("o") and "" or "v" })
+        end,
+        desc = "Remote Operation",
+      },
+      {
+        "R",
+        mode = { "x", "o" },
+        function()
+          require("leap.treesitter").select({ opts = clever("R", "r") })
+        end,
+        desc = "Leap Treesitter",
+      },
+    },
+    opts = {
+      -- Exclude whitespace and the middle of alphabetic words from preview.
+      preview = function(ch0, ch1, ch2)
+        return not (ch1:match("%s") or ch0:match("%a") and ch1:match("%a") and ch2:match("%a"))
+      end,
+      equivalence_classes = { " \t\n\r", "[({", "})]", "\"'`" },
     },
     config = function(_, opts)
       local leap = require("leap")
       for k, v in pairs(opts) do
         leap.opts[k] = v
       end
-      leap.add_default_mappings(true)
-      vim.keymap.del({ "x", "o" }, "x")
-      vim.keymap.del({ "x", "o" }, "X")
     end,
   },
 

--- a/lua/lazyvim/plugins/extras/editor/leap.lua
+++ b/lua/lazyvim/plugins/extras/editor/leap.lua
@@ -1,37 +1,79 @@
+-- A helper function making it easier to set "clever-f" behavior
+-- (use f/F or t/T instead of ;/, - see the plugin clever-f.vim).
+local function clever(...)
+  return require("leap.user").with_traversal_keys(...)
+end
+
+local function ft(key_specific_args)
+  require("leap").leap(vim.tbl_deep_extend("keep", key_specific_args, {
+    inputlen = 1,
+    inclusive = true,
+    opts = {
+      labels = "",
+      safe_labels = vim.fn.mode(true):match("no?") and "" or nil,
+    },
+  }))
+end
+
 return {
   -- disable flash
   { "folke/flash.nvim", enabled = false, optional = true },
 
-  -- easily jump to any location and enhanced f/t motions for Leap
+  -- Leap provides improved vim-sneak-style navigation with live label
+  -- preview and multi-window scope, and also extra features like remote
+  -- operations and incremental treesitter node selection.
   {
     url = "https://codeberg.org/andyg/leap.nvim.git",
-    enabled = true,
-    keys = function()
-      ---@type LazyKeysSpec[]
-      local ret = {}
-      for _, key in ipairs({ "f", "F", "t", "T" }) do
-        ret[#ret + 1] = { key, mode = { "n", "x", "o" } }
-      end
-      return ret
-    end,
-    opts = { labeled_modes = "nx" },
-  },
-  {
-    url = "https://codeberg.org/andyg/leap.nvim.git",
-    enabled = true,
     keys = {
-      { "s", mode = { "n", "x", "o" }, desc = "Leap Forward to" },
-      { "S", mode = { "n", "x", "o" }, desc = "Leap Backward to" },
-      { "gs", mode = { "n", "x", "o" }, desc = "Leap from Windows" },
+      { "s", mode = { "n", "x", "o" }, "<Plug>(leap)", desc = "Leap" },
+      { "S", mode = { "n" }, "<Plug>(leap-from-window)", desc = "Leap from Window" },
+      -- See the documentation for extras, like setting up automatic
+      -- pasting after yank operations or defining remote text objects.
+      { "gs", mode = { "n", "x", "o" }, "<Plug>(leap-visit)", desc = "Leap Visit" },
+      {
+        "an",
+        mode = { "x", "o" },
+        function()
+          require("leap.treesitter").select({ opts = clever("n", "N") })
+        end,
+        desc = "Leap Treesitter",
+      },
+      -- Enhanced f/t motions.
+      -- To keep using `;`/`,` just set `opts = clever(";", ",")` everywhere.
+      {
+        "f",
+        mode = { "n", "x", "o" },
+        function()
+          ft({ opts = clever("f", "F") })
+        end,
+      },
+      {
+        "F",
+        mode = { "n", "x", "o" },
+        function()
+          ft({ backward = true, opts = clever("f", "F") })
+        end,
+      },
+      {
+        "t",
+        mode = { "n", "x", "o" },
+        function()
+          ft({ offset = -1, opts = clever("t", "T") })
+        end,
+      },
+      {
+        "T",
+        mode = { "n", "x", "o" },
+        function()
+          ft({ backward = true, offset = 1, opts = clever("t", "T") })
+        end,
+      },
     },
     config = function(_, opts)
       local leap = require("leap")
       for k, v in pairs(opts) do
         leap.opts[k] = v
       end
-      leap.add_default_mappings(true)
-      vim.keymap.del({ "x", "o" }, "x")
-      vim.keymap.del({ "x", "o" }, "X")
     end,
   },
 


### PR DESCRIPTION
## Description

Leap's API has undergone significant changes in the meantime, and flit.nvim has been deprecated recently. The one in the PR is my suggested starter configuration now.

- `opts`: `preview` filter function, some more `equivalence_classes`
- replaced flit.nvim with simple `leap()` wrapper
- added mappings for treesitter node selection (`R` is used by flash's treesitter-search otherwise)
- added mappings for remote operations (`gs`)
- updated default mappings (bidirectional `s`) (breaking)

I'd be fine with keeping the current Sneak-like mappings for the default motions (`s`/`S`/`gs`), my only problem is that it's hard to find good mappings for remote then.

Feel free to discuss if you think you'd rather cherry-pick, but in any case, `add_default_mappings()` is deprecated, and I don't intend to maintain flit.nvim as a separate plugin anymore, at least those parts should be updated. Adding the treesitter mapping is also a no-brainer I guess.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
