### PR TITLE
fix(terminal): add -NoProfile to powershell shellcmdflag

### DIFF
--- a/lua/lazyvim/util/terminal.lua
+++ b/lua/lazyvim/util/terminal.lua
@@ -18,7 +18,7 @@ function M.setup(shell)
 
     -- Setting shell command flags
     vim.o.shellcmdflag =
-      "-NoLogo -NonInteractive -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues['Out-File:Encoding']='utf8';$PSStyle.OutputRendering='plaintext';Remove-Alias -Force -ErrorAction SilentlyContinue tee;"
+      "-NoProfile -NoLogo -NonInteractive -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues['Out-File:Encoding']='utf8';$PSStyle.OutputRendering='plaintext';Remove-Alias -Force -ErrorAction SilentlyContinue tee;"
 
     -- Setting shell redirection
     vim.o.shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'


### PR DESCRIPTION
## Description

changing the PowerShell profile might accidentally cause errors in Neovim (see [issue](https://github.com/LazyVim/LazyVim/issues/4805)), which is a subtle bug. Add the `-NoProfile` flag to ensure Neovim is not affected by profile. 

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
