### PR TITLE
feat(dap): add a keymap to reset the dap ui

### DIFF
--- a/lua/lazyvim/plugins/extras/dap/core.lua
+++ b/lua/lazyvim/plugins/extras/dap/core.lua
@@ -47,6 +47,7 @@ return {
       { "<leader>dO", function() require("dap").step_over() end, desc = "Step Over" },
       { "<leader>dP", function() require("dap").pause() end, desc = "Pause" },
       { "<leader>dr", function() require("dap").repl.toggle() end, desc = "Toggle REPL" },
+      { "<leader>dR", function() require("dapui").open({ reset = true }) end, desc = "Reset UI" },
       { "<leader>ds", function() require("dap").session() end, desc = "Session" },
       { "<leader>dt", function() require("dap").terminate() end, desc = "Terminate" },
       { "<leader>dw", function() require("dap.ui.widgets").hover() end, desc = "Widgets" },


### PR DESCRIPTION
## Description

Add a new keymap to reset the DAP UI, this is useful when the size of the UI is modified by other splits

## Related Issue(s)

N/A

## Screenshots

N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
