### PR TITLE
feat(extras.lang): add java dependencies sidebar to java extra

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/java.lua
+++ b/lua/lazyvim/plugins/extras/lang/java.lua
@@ -79,6 +79,20 @@ return {
     },
   },
 
+  -- Opens up a sidebar with all the project's java dependencies
+  -- similar functionality to vscode's: https://github.com/microsoft/vscode-java-dependency
+  {
+    "g0ne150/java-deps.nvim",
+    dependencies = {
+      "folke/snacks.nvim",
+      {
+        "mason-org/mason.nvim",
+        opts = { ensure_installed = { "vscode-java-dependency" } },
+      },
+    },
+    config = function() end,
+  },
+
   -- Set up nvim-jdtls to attach to java files.
   {
     "mfussenegger/nvim-jdtls",
@@ -155,6 +169,13 @@ return {
           if opts.test and mason_registry.is_installed("java-test") then
             vim.list_extend(bundles, vim.fn.glob("$MASON/share/java-test/*.jar", false, true))
           end
+        end
+
+        if mason_registry.is_installed("vscode-java-dependency") then
+          vim.list_extend(
+            bundles,
+            vim.fn.glob("$MASON/share/vscode-java-dependency/com.microsoft.jdtls.ext.core-*.jar", false, true)
+          )
         end
       end
       local function attach_jdtls()


### PR DESCRIPTION
## Description

This PR adds support for displaying a list of java dependencies in a sidebar through the [java-deps.nvim](https://github.com/g0ne150/java-deps.nvim) plugin. 

## Related Issue(s)

If the inclusion of this plugin should be avoided for whatever reason (keep the extra simple with the current plugins only for example), we should figure out a way to configure the list of bundles that we pass to jdtls, so that the user of this extra handles this scenario locally.
Other than that, I believe this is a good addition since it enhances the java experience significantly.

## Screenshots

<img width="1391" height="904" alt="image" src="https://github.com/user-attachments/assets/94bcc685-c70f-4cb9-8955-3ca7fdec7ffa" />
<img width="1460" height="854" alt="image" src="https://github.com/user-attachments/assets/3133bc83-0a52-46fd-a61d-8884b48a8423" />
<img width="1723" height="904" alt="image" src="https://github.com/user-attachments/assets/13a506a7-afa3-4e9e-8bad-390814dcd19d" />


## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
