### PR TITLE
fix(terminal): partially revert previous mappings

### DIFF
--- a/lua/lazyvim/plugins/util.lua
+++ b/lua/lazyvim/plugins/util.lua
@@ -23,8 +23,6 @@ return {
             nav_j = { "<C-j>", term_nav("j"), desc = "Go to Lower Window", expr = true, mode = "t" },
             nav_k = { "<C-k>", term_nav("k"), desc = "Go to Upper Window", expr = true, mode = "t" },
             nav_l = { "<C-l>", term_nav("l"), desc = "Go to Right Window", expr = true, mode = "t" },
-            hide_slash = { "<C-/>", "hide", desc = "Hide Terminal", mode = { "t", "n" } },
-            hide_underscore = { "<c-_>", "hide", desc = "which_key_ignore", mode = { "t", "n" } },
           },
         },
       },


### PR DESCRIPTION
## Description
Commit 4efd0e2bea2a387d6fcdea8cf36a62049e8bafed introduced some changes to terminal mappings. I tested in a new LazyVim installation and `sidekick.nvim` is not affected by `<C-/>` any more.

The mappings `hide_underscore` and `hide_slash` don't let user to create new terminals with `2<C-/>`, `3<C-/>` and so on. Instead they hide the terminal and user can't open split terminals next to each other any more.

Therefore, I believe it would be a better default to revert these 2 mappings explicitly.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
