### PR TITLE
feat(typescript): disable useAliasesForRenames

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -52,6 +52,9 @@ return {
             },
             typescript = {
               updateImportsOnFileMove = { enabled = "always" },
+              preferences = {
+                useAliasesForRenames = false,
+              },
               suggest = {
                 completeFunctionCalls = true,
               },


### PR DESCRIPTION
## Description
This allows the user the rename exported variables globally without the lsp using aliases for the renamed variable.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
n/a
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots
n/a
<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
