### PR TITLE
fix(terminal): term toggle key `<c-/>` now only work for terminals opened by itself

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -85,8 +85,8 @@ map("x", "<", "<gv")
 map("x", ">", ">gv")
 
 -- commenting
-map("n", "gco", "o<esc>Vcx<esc><cmd>normal gcc<cr>fxa<bs>", { desc = "Add Comment Below" })
-map("n", "gcO", "O<esc>Vcx<esc><cmd>normal gcc<cr>fxa<bs>", { desc = "Add Comment Above" })
+map("n", "gco", 'o<esc>V"_cx<esc><cmd>normal gcc<cr>fxa<bs>', { desc = "Add Comment Below" })
+map("n", "gcO", 'O<esc>V"_cx<esc><cmd>normal gcc<cr>fxa<bs>', { desc = "Add Comment Above" })
 
 -- lazy
 map("n", "<leader>l", "<cmd>Lazy<cr>", { desc = "Lazy" })
@@ -189,8 +189,18 @@ map("n", "<leader>L", function() LazyVim.news.changelog() end, { desc = "LazyVim
 -- floating terminal
 map("n", "<leader>fT", function() Snacks.terminal() end, { desc = "Terminal (cwd)" })
 map("n", "<leader>ft", function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "Terminal (Root Dir)" })
-map({"n","t"}, "<c-/>",function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "Terminal (Root Dir)" })
-map({"n","t"}, "<c-_>",function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "which_key_ignore" })
+map({ "n", "t" }, "<c-/>", function()
+  Snacks.terminal(nil, {
+    cwd = LazyVim.root(),
+    win = { keys = { hide_slash = { "<c-/>", "hide", desc = "Hide Terminal", mode = "t" } } },
+  })
+end, { desc = "Terminal (Root Dir)" })
+map({ "n", "t" }, "<c-_>", function()
+  Snacks.terminal(nil, {
+    cwd = LazyVim.root(),
+    win = { keys = { hide_underscore = { "<c-_>", "hide", desc = "which_key_ignore", mode = "t" } } },
+  })
+end, { desc = "which_key_ignore" })
 
 -- windows
 map("n", "<leader>-", "<C-W>s", { desc = "Split Window Below", remap = true })


### PR DESCRIPTION
And `gco`/`gcO` keymaps now use blackhole register to avoid overwriting default register.

## Description

#6770 may affect users’ habits, I think this way of toggling terminals will have no side effects.

## Related Issue(s)

#6770 

## Screenshots

None.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
