### PR TITLE
fix(terminal): terminal mappings again

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -189,8 +189,12 @@ map("n", "<leader>L", function() LazyVim.news.changelog() end, { desc = "LazyVim
 -- floating terminal
 map("n", "<leader>fT", function() Snacks.terminal() end, { desc = "Terminal (cwd)" })
 map("n", "<leader>ft", function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "Terminal (Root Dir)" })
-map({"n","t"}, "<c-/>",function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "Terminal (Root Dir)" })
-map({"n","t"}, "<c-_>",function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "which_key_ignore" })
+map("n", "<c-/>",      function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "Terminal (Root Dir)" })
+map("n", "<c-_>",      function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "which_key_ignore" })
+
+-- Terminal Mappings
+map("t", "<C-/>", "<cmd>close<cr>", { desc = "Hide Terminal" })
+map("t", "<c-_>", "<cmd>close<cr>", { desc = "which_key_ignore" })
 
 -- windows
 map("n", "<leader>-", "<C-W>s", { desc = "Split Window Below", remap = true })

--- a/lua/lazyvim/plugins/extras/ai/sidekick.lua
+++ b/lua/lazyvim/plugins/extras/ai/sidekick.lua
@@ -74,6 +74,18 @@ return {
           require("sidekick.nes").enable(state)
         end,
       }):map("<leader>uN")
+      local opts = {
+        cli = {
+          win = {
+            --stylua: ignore
+            keys = {
+              terminal_slash = { "<C-/>", function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, desc = "Terminal (Root Dir)", mode = "t" },
+              terminal_underscore = { "<C-_>", function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, desc = "which_key_ignore", mode = "t" },
+            },
+          },
+        },
+      }
+      return opts
     end,
     -- stylua: ignore
     keys = {


### PR DESCRIPTION
## Description
Previous change results in a weird behavior where you can indeed open multiple terminals vertically, but then whey you press `<C-/>` it always toggles the last terminal. After some discussion in #6773 as well, I guess this is a better compromise.

In my personal opinion, since all this stemmed from https://github.com/LazyVim/LazyVim/commit/4efd0e2bea2a387d6fcdea8cf36a62049e8bafed in order to resolve #6573, I believe it would be best to reinstate the former mappings (which undoubtedly provide a more intuitive overall behavior regarding terminals) and just create a buffer local mapping for Sidekick either in an autocommand as suggested also in #6573 or maybe Sidekick can handle this internally.

This is just my personal opinion though and you of course have the final decision. This PR still leaves some unintuitive behavior when in normal mode with the cursor focused in a terminal window, but it tries to operate based on the assumption that toggling off the terminal makes more sense when in terminal mode rather than normal mode. Of course there might be a better way I can't think of, in which case I'll gladly accept whatever else you come up with over everything I've mentioned above.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
