### PR TITLE
feat(chezmoi.nvim): use upstream pickers and add `<leader>sZ` keymap for neovim config files

### DIFF
--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -13,12 +13,16 @@ return {
     keys = {
       {
         "<leader>sz",
-        function() require("chezmoi.pick")[LazyVim.pick.picker.name]() end ,
+        function()
+          require("chezmoi.pick")[LazyVim.pick.picker.name]()
+        end,
         desc = "Chezmoi",
       },
       {
         "<leader>sZ",
-        function() require("chezmoi.pick")[LazyVim.pick.picker.name](vim.fn.stdpath("config")) end ,
+        function()
+          require("chezmoi.pick")[LazyVim.pick.picker.name](vim.fn.stdpath("config"))
+        end,
         desc = "Chezmoi",
       },
     },
@@ -51,7 +55,9 @@ return {
     optional = true,
     opts = function(_, opts)
       local projects = {
-        action = pick_chezmoi,
+        action = function()
+          require("chezmoi.pick")[LazyVim.pick.picker.name]()
+        end,
         desc = "  Config",
         icon = "",
         key = "c",
@@ -78,7 +84,9 @@ return {
         icon = " ",
         key = "c",
         desc = "Config",
-        action = pick_chezmoi,
+        action = function()
+          require("chezmoi.pick")[LazyVim.pick.picker.name]()
+        end,
       }
       local config_index
       for i = #opts.dashboard.preset.keys, 1, -1 do


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

I recently opened a PR to support multiple pickers upstream in xvzc/chezmoi.nvim#42 (telescope, snacks, fzf and mini.pick). The snacks and fzf functions were taken from LazyVim, telescope was already supported, and I implemented one for mini.pick. Having this functionality upstreams makes it easier for users to customize picker keymap and behaviour without having to copy code from LazyVim to their config. It also makes the pickers available outside of LazyVim. Switching to using those upstream pickers in LazyVim would also remove the burden of maintaining them here.

The upstream pickers also support `targets` and `args` arguments to customize the chezmoi command. I added a `<leader>sZ` keymap to search only neovim config files with chezmoi. I did not override the default `<leader>fc` keymap as this change was declined in #4151.

The PR as not been merged yet, so I'm making this a draft. Will mark for review if/when the pickers are merged upstream. Otherwise I will close. I just wanted to put it here because I had time this weekend, and in case anyone had early feedback to give.

Thanks!

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
