### PR TITLE
fix(lang.clang): fix `clangd_extensions.nvim`

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/clangd.lua
+++ b/lua/lazyvim/plugins/extras/lang/clangd.lua
@@ -23,8 +23,7 @@ return {
 
   {
     "p00f/clangd_extensions.nvim",
-    lazy = true,
-    config = function() end,
+    ft = { "c", "cpp", "objc", "objcpp" },
     opts = {
       inlay_hints = {
         inline = false,
@@ -93,13 +92,6 @@ return {
             clangdFileStatus = true,
           },
         },
-      },
-      setup = {
-        clangd = function(_, opts)
-          local clangd_ext_opts = LazyVim.opts("clangd_extensions.nvim")
-          require("clangd_extensions").setup(vim.tbl_deep_extend("force", clangd_ext_opts or {}, { server = opts }))
-          return false
-        end,
       },
     },
   },


### PR DESCRIPTION
## Description
`clangd_extensions.nvim` does not seem to take `server` key any more, which was used to setup the plugin with clangd `cmd`, `init_options` etc. Instead you only need to configure the clangd server via lspconfig and the plugin separately according to my understanding.

Remove the unnecessary `opts.setup` which also requires the plugin itself and loads it and make the plugin lazy-loaded on c/c++ files only.

References:
- https://github.com/p00f/clangd_extensions.nvim#configuration
- https://github.com/p00f/clangd_extensions.nvim/issues/49#issuecomment-1719654413

PS: I don't do C/C++, so testers would be welcome.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #6800
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
