### PR TITLE
fix(mini.surround): manually define 'gsn' keymap to update n_lines configuration

### DIFF
--- a/lua/lazyvim/plugins/extras/coding/mini-surround.lua
+++ b/lua/lazyvim/plugins/extras/coding/mini-surround.lua
@@ -14,7 +14,11 @@ return {
       { opts.mappings.find_left, desc = "Find Left Surrounding" },
       { opts.mappings.highlight, desc = "Highlight Surrounding" },
       { opts.mappings.replace, desc = "Replace Surrounding" },
-      { opts.mappings.update_n_lines, desc = "Update `MiniSurround.config.n_lines`" },
+      {
+        opts.mappings.update_n_lines,
+        "<Cmd>lua MiniSurround.update_n_lines()<CR>",
+        desc = "Update `MiniSurround.config.n_lines`",
+      },
     }
     mappings = vim.tbl_filter(function(m)
       return m[1] and #m[1] > 0


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

The `mini.surround` plugin removed the `gsn` shortcut in commit [cd806144](https://github.com/nvim-mini/mini.nvim/commit/cd806144455f216cc670f7891e8473c1cc1ee49c), which the LazyVim "extra" relies on in its configuration. In its documentation, the plugin now recommends setting this keymap like so.

```lua
vim.keymap.set('n', 'sn', '<Cmd>lua MiniSurround.update_n_lines()<CR>')
```

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
