### PR TITLE
refactor(dial): use inbuilt augends

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/dial.lua
+++ b/lua/lazyvim/plugins/extras/editor/dial.lua
@@ -53,7 +53,6 @@ return {
       cyclic = true,
     })
 
-
     local months = augend.constant.new({
       elements = {
         "January",
@@ -72,7 +71,6 @@ return {
       word = true,
       cyclic = true,
     })
-
 
     return {
       dials_by_ft = {
@@ -95,7 +93,7 @@ return {
           augend.integer.alias.decimal_int, -- nonnegative and negative decimal number
           augend.integer.alias.hex, -- nonnegative hex number  (0x01, 0x1a1f, etc.)
           augend.date.alias["%Y/%m/%d"], -- date (2022/02/19, etc.)
-          augend.alias.en_weekday,       -- Mon, Tue, ..., Sat, Sun
+          augend.constant.alias.en_weekday, -- Mon, Tue, ..., Sat, Sun
           augend.constant.alias.en_weekday_full, -- Monday, Tuesday, ..., Saturday, Sunday
           ordinal_numbers,
           months,


### PR DESCRIPTION
## Description

Dial now has built in augends for weekdays and Pythonic booleans

https://github.com/monaqa/dial.nvim#augend-alias

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
