### PR TITLE
fix(leap): "default mappings are deprecated" warning from leap

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/leap.lua
+++ b/lua/lazyvim/plugins/extras/editor/leap.lua
@@ -29,9 +29,9 @@ return {
       for k, v in pairs(opts) do
         leap.opts[k] = v
       end
-      leap.add_default_mappings(true)
-      vim.keymap.del({ "x", "o" }, "x")
-      vim.keymap.del({ "x", "o" }, "X")
+      vim.keymap.set({ "n", "x", "o" }, "s", "<Plug>(leap-forward)")
+      vim.keymap.set({ "n", "x", "o" }, "S", "<Plug>(leap-backward)")
+      vim.keymap.set("n", "gs", "<Plug>(leap-from-window)")
     end,
   },
 


### PR DESCRIPTION
## Description

The first use of Leap anywhere generates a popup warning that
the default mappings are deprecated.

PR replaces the call to `leap.add_default_mappings` with the
part of the default mappings that wasn't immediately
deleted afterwards.
