### PR TITLE
fix(util.project): Change project key from 'P' to 'p' in dashboard

### DIFF
--- a/lua/lazyvim/plugins/extras/util/project.lua
+++ b/lua/lazyvim/plugins/extras/util/project.lua
@@ -126,7 +126,7 @@ return {
     "goolord/alpha-nvim",
     optional = true,
     opts = function(_, dashboard)
-      local button = dashboard.button("P", " " .. " Projects (util.project)", pick)
+      local button = dashboard.button("p", " " .. " Projects (util.project)", pick)
       button.opts.hl = "AlphaButtons"
       button.opts.hl_shortcut = "AlphaShortcut"
       table.insert(dashboard.section.buttons.val, 4, button)
@@ -159,7 +159,7 @@ return {
         action = pick,
         desc = " Projects (util.project)",
         icon = " ",
-        key = "P",
+        key = "p",
       }
 
       projects.desc = projects.desc .. string.rep(" ", 43 - #projects.desc)
@@ -177,7 +177,7 @@ return {
         action = pick,
         desc = "Projects (util.project)",
         icon = " ",
-        key = "P",
+        key = "p",
       })
     end,
   },


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Change project key from 'P' to 'p' in dashboard.

I agree to make a distinction between snack/project and utils/project, but we should not modify the shortcut keys.

It is almost impossible to use both of them simultaneously.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

https://github.com/LazyVim/LazyVim/pull/5737

## Screenshots

<img width="862" height="220" alt="image" src="https://github.com/user-attachments/assets/e97ce595-7247-4a93-8731-905f0bc940e9" />


<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
