### PR TITLE
fix(haskell): execute all command keymap

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/haskell.lua
+++ b/lua/lazyvim/plugins/extras/lang/haskell.lua
@@ -19,7 +19,9 @@ return {
     keys = {
       {
         "<localleader>e",
-        "<cmd>HlsEvalAll<cr>",
+        function()
+          require("haskell-tools").lsp.buf_eval_all()
+        end,
         ft = "haskell",
         desc = "Evaluate All",
       },


### PR DESCRIPTION
## Description

`HslExecuteAll` is not a valid command.

`ht.lsp.buf_eval_all()` is what matches the [documentation](https://github.com/mrcjkb/haskell-tools.nvim?tab=readme-ov-file#available-functions-and-commands) and better matches the other keymaps

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
