### PR TITLE
fix(treesitter): remove deleted jsonc parser

### DIFF
--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -37,7 +37,6 @@ return {
         "javascript",
         "jsdoc",
         "json",
-        "jsonc",
         "lua",
         "luadoc",
         "luap",


### PR DESCRIPTION
## Description
https://github.com/nvim-treesitter/nvim-treesitter/commit/d2350758b39dce3593ffa8b058f863ea4cfa5b0e removed parsers not hosted on Github, `jsonc` among them. Remove it from LazyVim as well. On a fresh new installation, there's no problem and it doesn't even install, but on existing installation you get an error when updating about parser not available.

<img width="2559" height="313" alt="2025-12-07_11-24" src="https://github.com/user-attachments/assets/99802b66-ff39-4631-89c6-ee4f2516acf1" />

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
