### PR TITLE
Remove nvim-cmp plugin configuration (outdated?)

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/r.lua
+++ b/lua/lazyvim/plugins/extras/lang/r.lua
@@ -48,15 +48,6 @@ return {
     end,
   },
   {
-    "hrsh7th/nvim-cmp",
-    optional = true,
-    dependencies = { "R-nvim/cmp-r" },
-    opts = function(_, opts)
-      opts.sources = opts.sources or {}
-      table.insert(opts.sources, { name = "cmp_r" })
-    end,
-  },
-  {
     "nvim-treesitter/nvim-treesitter",
     opts = { ensure_installed = { "r", "rnoweb" } },
   },


### PR DESCRIPTION
## Description
When opening an R or Quarto file, I would see this message:

> "Please, uninstall cmp-r. It's no longer used."

So I have removed the optional nvim-cmp configuration for R.

This is my first time contributing a change, so I hope this is correct

So I deleted this part:

```
  {
    "hrsh7th/nvim-cmp",
    optional = true,
    dependencies = { "R-nvim/cmp-r" },
    opts = function(_, opts)
      opts.sources = opts.sources or {}
      table.insert(opts.sources, { name = "cmp_r" })
    end,
  },
```

## Related Issue(s)

  - Fixes #6849

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
