### PR TITLE
fix(treesitter): removes 'jsonc' from Treesitter languages

### DIFF
--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -37,7 +37,6 @@ return {
         "javascript",
         "jsdoc",
         "json",
-        "jsonc",
         "lua",
         "luadoc",
         "luap",


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

It seems jsonc is [not supported](https://github.com/nvim-treesitter/nvim-treesitter/issues/1997#issuecomment-3657115364) by tresitter-nvim anymore, and it breaks when trying to install, with:

```
:TSInstallSync jsonc
Downloading tree-sitter-jsonc...
Creating temporary directory
Extracting tree-sitter-jsonc...

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now

Error during tarball extraction.
Failed to execute the following command:
{
  cmd = "tar",
  err = "Error during tarball extraction.",
  info = "Extracting tree-sitter-jsonc...",
  opts = {
    args = { "-xvzf", "tree-sitter-jsonc.tar.gz", "-C", "tree-sitter-jsonc-tmp" },
    cwd = "/home/guel/.local/share/nvim"
  }
}
Press ENTER or type command to continue
```

So I think it should be removed from the "ensure installed", so that it doesn't try to install it by default on LazyVim installations.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

- Fixes #6518

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [ X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
