### PR TITLE
feat(dap): close dap-float window with `q`.

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -56,6 +56,7 @@ vim.api.nvim_create_autocmd("FileType", {
   pattern = {
     "PlenaryTestPopup",
     "checkhealth",
+    "dap-float",
     "dbout",
     "gitsigns-blame",
     "grug-far",


### PR DESCRIPTION


## Description

nvim-dap-ui's widget window to preview value of object under the cursor has ftype `dap-float`. Include it so it can be closed quickly like other popup windows.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
