### PR TITLE
feat(extras): added matlab support

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/matlab.lua
+++ b/lua/lazyvim/plugins/extras/lang/matlab.lua
@@ -21,7 +21,6 @@ return {
     "mason-org/mason.nvim",
     opts = function(_, opts)
       opts.ensure_installed = opts.ensure_installed or {}
-      vim.list_extend(opts.ensure_installed, { "matlab_language_server" })
       if formatter == "miss_hit" then
         vim.list_extend(opts.ensure_installed, { "miss_hit" })
       end


### PR DESCRIPTION
## Description

This PR adds a new extra for MATLAB support.

It includes the following components:
* **LSP:** Configures `matlab_ls` via `nvim-lspconfig` and installs it via `mason`.
* **Syntax Highlighting:** Ensures `matlab` treesitter parser is installed.
* **Execution & Debug:** Uses [`idossha/matlab.nvim`](https://github.com/idossha/matlab.nvim) for code evaluation and debug.
    * *Note: This plugin requires `tmux` to function correctly.*
* **Formatting:**
    * Defaults to using the LSP (`matlab_ls`).
    * Supports `miss_hit` (`mh_style`) as an alternative formatter via `conform.nvim`. This can be enabled by setting `vim.g.lazyvim_matlab_formatter = "miss_hit"`.

## Related Issue(s)

## Screenshots

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
