### PR TITLE
fix(util.lsp): pass `formatters_by_ft` to `opts`

### DIFF
--- a/lua/lazyvim/util/lsp.lua
+++ b/lua/lazyvim/util/lsp.lua
@@ -35,18 +35,14 @@ end
 
 ---@param opts? lsp.Client.format
 function M.format(opts)
-  opts = vim.tbl_deep_extend(
-    "force",
-    {},
-    opts or {},
-    LazyVim.opts("nvim-lspconfig").format or {},
-    LazyVim.opts("conform.nvim").format or {}
-  )
+  opts = vim.tbl_deep_extend("force", {}, opts or {}, LazyVim.opts("nvim-lspconfig").format or {})
   local ok, conform = pcall(require, "conform")
   -- use conform for formatting with LSP when available,
   -- since it has better format diffing
   if ok then
-    opts.formatters = {}
+    -- It should be `nil`, otherwise it doesn't fetch options from `formatters_by_ft`,
+    -- see https://github.com/stevearc/conform.nvim/blob/5420c4b5ea0aeb99c09cfbd4fd0b70d257b44f25/lua/conform/init.lua#L417-L418
+    opts.formatters = nil
     conform.format(opts)
   else
     vim.lsp.buf.format(opts)


### PR DESCRIPTION
## Description
Here https://github.com/LazyVim/LazyVim/blob/c64a61734fc9d45470a72603395c02137802bc6f/lua/lazyvim/util/lsp.lua#L50 we call directly `conform.format` with our specific options. 

`conform.nvim` also allows passing options such as `lsp_format` directly to `formatter_by_ft` as also can be seen [here](https://github.com/stevearc/conform.nvim/blob/5420c4b5ea0aeb99c09cfbd4fd0b70d257b44f25/doc/conform.txt#L20-L21). Those options are not passed when we call `conform.format(opts)` in the LSP formatter.

So, we add these options. Also, fix the correct name for general format options, since it had been changed at some time in `conform.nvim` and that change made it to the plugin spec, but not here.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #6893
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
