### PR TITLE
feat(lang): add opentofu support

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/opentofu.lua
+++ b/lua/lazyvim/plugins/extras/lang/opentofu.lua
@@ -1,0 +1,57 @@
+vim.filetype.add({
+  extension = {
+    tofu = "opentofu",
+  },
+})
+
+return {
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = function(_, opts)
+      opts.ensure_installed = opts.ensure_installed or {}
+      vim.list_extend(opts.ensure_installed, { "terraform", "hcl" })
+      vim.treesitter.language.register("opentofu", "hcl")
+    end,
+  },
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        tofu_ls = {},
+      },
+    },
+  },
+  {
+    "mason-org/mason.nvim",
+    opts = { ensure_installed = { "tofu-ls" } },
+  },
+  {
+    "nvimtools/none-ls.nvim",
+    optional = true,
+    opts = function(_, opts)
+      local null_ls = require("null-ls")
+      opts.sources = vim.list_extend(opts.sources or {}, {
+        null_ls.builtins.formatting.opentofu_fmt,
+        null_ls.builtins.diagnostics.opentofu_validate,
+      })
+    end,
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        opentofu = { "tofu" },
+      },
+    },
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        opentofu = { "tofu_fmt" },
+      },
+    },
+  },
+}

--- a/lua/lazyvim/plugins/extras/lang/opentofu.lua
+++ b/lua/lazyvim/plugins/extras/lang/opentofu.lua
@@ -5,6 +5,13 @@ vim.filetype.add({
 })
 
 return {
+  recommended = function()
+    return LazyVim.extras.wants({
+      ft = "hcl",
+      root = ".tofu",
+    })
+  end,
+
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
@@ -20,10 +27,6 @@ return {
         tofu_ls = {},
       },
     },
-  },
-  {
-    "mason-org/mason.nvim",
-    opts = { ensure_installed = { "tofu-ls" } },
   },
   {
     "nvimtools/none-ls.nvim",


### PR DESCRIPTION
## Description

I would like to add support for opentofu (using the `.tofu` extension). OpenTofu is a drop-in replacement for Terraform (with some enhancements and changes). OpenTofu can work with its own extensions `.tofu` or uses the Terraform extension `.tf`.

I would be very grateful if you guide me on this pull request, as I'm not an expert in lua neither in LazyVim, but happily using LazyVim and learning every day how to make it even more useful.

## Related Issue(s)

See discussions #6280 and #6270.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
