### PR TITLE
fix(lsp): sort `opts.servers` before setting up keymaps

### DIFF
--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -155,7 +155,14 @@ return {
       LazyVim.format.register(LazyVim.lsp.formatter())
 
       -- setup keymaps
-      for server, server_opts in pairs(opts.servers) do
+      local keys = {}
+      for server in pairs(opts.servers) do
+        table.insert(keys, server)
+      end
+      table.sort(keys)
+
+      for _, server in ipairs(keys) do
+        local server_opts = opts.servers[server]
         if type(server_opts) == "table" and server_opts.keys then
           require("lazyvim.plugins.lsp.keymaps").set({ name = server ~= "*" and server or nil }, server_opts.keys)
         end


### PR DESCRIPTION
## Description
I noticed with Typescript Extra that some times `gD` was mapped to `vim.lsp.buf.declaration` and other times to `Go to Source Definition`. 

There was a race condition because `pairs(opts.servers)` doesn't guarantee the order in which servers will get evaluated for setting up keymaps. Some times `"*"` would get evaluated before `vtsls` and `Go to Source Definition` would take precedence and other times `"*"` would get evaluated after `vtsls` and thus resulting in `Goto Declaration` to take precedence. 

Solution: Put the keys of `opts.servers` into a list, sort the list and evaluate the servers based on the sorted list to setup keymaps. This way `"*"` server will always get evaluated first and other servers will be able to correctly overwrite keymaps that already exist.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
