### PR TITLE
fix(util.lsp): `LazyVim.lsp.execute` only request single client

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/elixir.lua
+++ b/lua/lazyvim/plugins/extras/lang/elixir.lua
@@ -16,6 +16,8 @@ return {
               function()
                 local params = vim.lsp.util.make_position_params()
                 LazyVim.lsp.execute({
+                  title = "toPipe",
+                  filter = "elixirls",
                   command = "manipulatePipes:serverid",
                   arguments = { "toPipe", params.textDocument.uri, params.position.line, params.position.character },
                 })
@@ -27,6 +29,8 @@ return {
               function()
                 local params = vim.lsp.util.make_position_params()
                 LazyVim.lsp.execute({
+                  title = "fromPipe",
+                  filter = "elixirls",
                   command = "manipulatePipes:serverid",
                   arguments = { "fromPipe", params.textDocument.uri, params.position.line, params.position.character },
                 })

--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -113,7 +113,11 @@ return {
             {
               "<leader>cV",
               function()
-                LazyVim.lsp.execute({ command = "typescript.selectTypeScriptVersion" })
+                LazyVim.lsp.execute({
+                  title = "Select TypeScript Version",
+                  filter = "vtsls",
+                  command = "typescript.selectTypeScriptVersion",
+                })
               end,
               desc = "Select TS workspace version",
             },

--- a/lua/lazyvim/plugins/extras/lang/typst.lua
+++ b/lua/lazyvim/plugins/extras/lang/typst.lua
@@ -24,6 +24,8 @@ return {
                 local buf_name = vim.api.nvim_buf_get_name(0)
                 local file_name = vim.fn.fnamemodify(buf_name, ":t")
                 LazyVim.lsp.execute({
+                  title = "Pin Main",
+                  filter = "tinymist",
                   command = "tinymist.pinMain",
                   arguments = { buf_name },
                 })


### PR DESCRIPTION
## Description
`LazyVim.lsp.execute` uses `vim.lsp.buf_request` which sends the request to all attached clients. 

`LazyVim.lsp.execute` seems to me to be the equivalent of [vim.lsp.buf.execute_command](https://github.com/neovim/neovim/blob/922816877febf397fe854f01d8013a510d73f1d2/runtime/lua/vim/lsp/buf.lua#L1366-L1376), but adds the option to also open in Trouble. Otherwise the request is being made the same way. This command will be deprecated in 0.12 and it's advised to use `client:exec_cmd` instead.

Since LazyVim supports Neovim >=0.11.2, it makes sense to refactor the corresponding codeblock and use `client:cmd_exec` instead (it's already available in Neovim 0.11).

I only changed the necessary parts where `vim.lsp.buf_request` was being used and not Trouble (when `opts.open = true`), since I'm not familiar with its codebase. That's also why I went for extending `params` in the `else` branch instead of adding `title` into original `params`, since I didn't know how Trouble will react to this change. Not sure if maybe there also needs to be some change there.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #6900
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
