### PR TITLE
fix(editor.overseer): migrate to v2

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/overseer.lua
+++ b/lua/lazyvim/plugins/extras/editor/overseer.lua
@@ -8,37 +8,23 @@ return {
   },
   {
     "stevearc/overseer.nvim",
+    lazy = false, -- plugin is self-lazy-loading
     cmd = {
       "OverseerOpen",
       "OverseerClose",
       "OverseerToggle",
-      "OverseerSaveBundle",
-      "OverseerLoadBundle",
-      "OverseerDeleteBundle",
-      "OverseerRunCmd",
       "OverseerRun",
-      "OverseerInfo",
-      "OverseerBuild",
-      "OverseerQuickAction",
       "OverseerTaskAction",
-      "OverseerClearCache",
     },
     opts = {
       dap = false,
       task_list = {
-        bindings = {
-          ["<C-h>"] = false,
+        keymaps = {
           ["<C-j>"] = false,
           ["<C-k>"] = false,
-          ["<C-l>"] = false,
         },
       },
       form = {
-        win_opts = {
-          winblend = 0,
-        },
-      },
-      confirm = {
         win_opts = {
           winblend = 0,
         },
@@ -51,13 +37,9 @@ return {
     },
     -- stylua: ignore
     keys = {
-      { "<leader>ow", "<cmd>OverseerToggle<cr>",      desc = "Task list" },
-      { "<leader>oo", "<cmd>OverseerRun<cr>",         desc = "Run task" },
-      { "<leader>oq", "<cmd>OverseerQuickAction<cr>", desc = "Action recent task" },
-      { "<leader>oi", "<cmd>OverseerInfo<cr>",        desc = "Overseer Info" },
-      { "<leader>ob", "<cmd>OverseerBuild<cr>",       desc = "Task builder" },
-      { "<leader>ot", "<cmd>OverseerTaskAction<cr>",  desc = "Task action" },
-      { "<leader>oc", "<cmd>OverseerClearCache<cr>",  desc = "Clear cache" },
+      { "<leader>ow", "<cmd>OverseerToggle!<cr>",    desc = "Task list" },
+      { "<leader>oo", "<cmd>OverseerRun<cr>",        desc = "Run task" },
+      { "<leader>ot", "<cmd>OverseerTaskAction<cr>", desc = "Task action" },
     },
   },
   {


### PR DESCRIPTION

## Description

Overseer.nvim recently-ish released v2.  
This PR updates the extras config according to the breaking changes.

A few commands were removed and the `bindings` config key was renamed to `keymaps`.

I've also taken the liberty of marking the plugin as not lazy since it lazy-loads itself.
The impact on startup is ~<1ms, which I think is acceptable over lazy.nvim command/keymap listener overhead, but this is open to discussion :shrug:  

## Related Issue(s)

fixes #6876 

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
