### PR TITLE
fix(chezmoi): handle `.chezmoiroot` in `source_dir_path`

### DIFF
--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -55,7 +55,18 @@ return {
     "alker0/chezmoi.vim",
     init = function()
       vim.g["chezmoi#use_tmp_buffer"] = 1
-      vim.g["chezmoi#source_dir_path"] = vim.env.HOME .. "/.local/share/chezmoi"
+      -- Handle .chezmoiroot for users who organize source files in subdirectories
+      local source = vim.env.HOME .. "/.local/share/chezmoi"
+      local root_file = source .. "/.chezmoiroot"
+      local f = io.open(root_file, "r")
+      if f then
+        local root = f:read("*l")
+        f:close()
+        if root and root ~= "" then
+          source = source .. "/" .. vim.trim(root)
+        end
+      end
+      vim.g["chezmoi#source_dir_path"] = source
     end,
   },
   {

--- a/lua/lazyvim/plugins/extras/util/chezmoi.lua
+++ b/lua/lazyvim/plugins/extras/util/chezmoi.lua
@@ -1,3 +1,24 @@
+-- Resolve source path, respecting .chezmoiroot
+local source_dir = (function()
+  local out = vim.fn.system("chezmoi source-path")
+  if vim.v.shell_error == 0 then
+    return vim.trim(out)
+  end
+  local base = vim.env.HOME .. "/.local/share/chezmoi"
+  local f = io.open(base .. "/.chezmoiroot", "r")
+  if f then
+    local root = f:read("*l")
+    f:close()
+    if root then
+      root = vim.fs.normalize(vim.trim(root), { expand_env = false })
+      if root ~= "" and not root:find("..", 1, true) then
+        return vim.fs.joinpath(base, root)
+      end
+    end
+  end
+  return base
+end)()
+
 local pick_chezmoi = function()
   if LazyVim.pick.picker.name == "telescope" then
     require("telescope").extensions.chezmoi.find_files()
@@ -55,18 +76,7 @@ return {
     "alker0/chezmoi.vim",
     init = function()
       vim.g["chezmoi#use_tmp_buffer"] = 1
-      -- Handle .chezmoiroot for users who organize source files in subdirectories
-      local source = vim.env.HOME .. "/.local/share/chezmoi"
-      local root_file = source .. "/.chezmoiroot"
-      local f = io.open(root_file, "r")
-      if f then
-        local root = f:read("*l")
-        f:close()
-        if root and root ~= "" then
-          source = source .. "/" .. vim.trim(root)
-        end
-      end
-      vim.g["chezmoi#source_dir_path"] = source
+      vim.g["chezmoi#source_dir_path"] = source_dir
     end,
   },
   {
@@ -96,7 +106,7 @@ return {
     init = function()
       -- run chezmoi edit on file enter
       vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
-        pattern = { vim.env.HOME .. "/.local/share/chezmoi/*" },
+        pattern = { source_dir .. "/*" },
         callback = function()
           vim.schedule(require("chezmoi.commands.__edit").watch)
         end,


### PR DESCRIPTION
## Description

Add support for `.chezmoiroot` to configure source directory.

## Related Issue(s)

  When users have a `.chezmoiroot` file in their chezmoi source directory, the current `chezmoi#source_dir_path` setting doesn't include the root subdirectory. This causes chezmoi.vim's filetype detection to fail for files in `.chezmoiscripts/` and other special directories.

  For example, with `.chezmoiroot` containing `home`:
  - Current: `~/.local/share/chezmoi`
  - Expected: `~/.local/share/chezmoi/home`

### Solution

  Read `.chezmoiroot` file if it exists and append its content to the source path, matching chezmoi.vim's built-in detection behavior.

### Testing

  Verified with:
  - `.chezmoiscripts/run_once_before_*.sh.tmpl` → sh.chezmoitmpl 
  - `dot_config/fish/config.fish.tmpl` → fish.chezmoitmpl

## Screenshots

### Before this patch `~/.local/share/chezmoi/home/.chezmoiscripts/run_once_before_1-install-lazyvim.sh.tmpl`
<img width="798" height="355" alt="image" src="https://github.com/user-attachments/assets/3deeaf72-71a0-4dd9-b761-a18a7eafa9c5" />

### After this patch `~/.local/share/chezmoi/home/.chezmoiscripts/run_once_before_1-install-lazyvim.sh.tmpl`
<img width="771" height="385" alt="image" src="https://github.com/user-attachments/assets/cd733134-ee2b-40df-9e17-e5a5f0418f58" />


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
