### PR TITLE
fix(alpha): pick config files

### DIFF
--- a/lua/lazyvim/plugins/extras/ui/alpha.lua
+++ b/lua/lazyvim/plugins/extras/ui/alpha.lua
@@ -26,7 +26,7 @@ return {
         dashboard.button("n", " " .. " New file",        [[<cmd> ene <BAR> startinsert <cr>]]),
         dashboard.button("r", " " .. " Recent files",    [[<cmd> lua LazyVim.pick("oldfiles")() <cr>]]),
         dashboard.button("g", " " .. " Find text",       [[<cmd> lua LazyVim.pick("live_grep")() <cr>]]),
-        dashboard.button("c", " " .. " Config",          "<cmd> lua LazyVim.pick.config_files()() <cr>"),
+        dashboard.button("c", " " .. " Config",          [[<cmd> lua LazyVim.pick.config_files()() <cr>]]),
         dashboard.button("s", " " .. " Restore Session", [[<cmd> lua require("persistence").load() <cr>]]),
         dashboard.button("x", " " .. " Lazy Extras",     "<cmd> LazyExtras <cr>"),
         dashboard.button("l", "󰒲 " .. " Lazy",            "<cmd> Lazy <cr>"),


### PR DESCRIPTION
## Description

The `alpha` dashboard fails to open a picker for config files selection.

## Related Issue(s)

None

## Screenshots

None

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
