### PR TITLE
fix(util.project): migrate to maintained project.nvim fork

### DIFF
--- a/lua/lazyvim/plugins/extras/util/project.lua
+++ b/lua/lazyvim/plugins/extras/util/project.lua
@@ -5,8 +5,8 @@ pick = function()
     return vim.cmd("Telescope projects")
   elseif LazyVim.pick.picker.name == "fzf" then
     local fzf_lua = require("fzf-lua")
-    local project = require("project_nvim.project")
-    local history = require("project_nvim.utils.history")
+    local project = require("project.api")
+    local history = require("project.utils.history")
     local results = history.get_recent_projects()
     local utils = require("fzf-lua.utils")
 
@@ -84,14 +84,14 @@ end
 
 return {
   {
-    "ahmedkhalf/project.nvim",
+    "DrKJeff16/project.nvim",
     opts = {
       manual_mode = true,
     },
     event = "VeryLazy",
     config = function(_, opts)
-      require("project_nvim").setup(opts)
-      local history = require("project_nvim.utils.history")
+      require("project").setup(opts)
+      local history = require("project.utils.history")
       history.delete_project = function(project)
         for k, v in pairs(history.recent_projects) do
           if v == project.value then


### PR DESCRIPTION
## Summary
- Switch from unmaintained `ahmedkhalf/project.nvim` to actively maintained `DrKJeff16/project.nvim` fork
- Update require paths to match the new module structure

## Changes
The fork has reorganized module names:
| Old | New |
|-----|-----|
| `require("project_nvim")` | `require("project")` |
| `require("project_nvim.project")` | `require("project.api")` |
| `require("project_nvim.utils.history")` | `require("project.utils.history")` |

## Test plan
- [ ] Enable `util.project` extra
- [ ] Verify `:Lazy` shows `DrKJeff16/project.nvim` installed
- [ ] Test `<leader>fp` opens project picker
- [ ] Test project switching works with Telescope
- [ ] Test project switching works with fzf-lua

Closes #6867