### PR TITLE
feat: add a hook for user to enable extras in lua config with correct order

### DIFF
--- a/lua/lazyvim/plugins/xtras.lua
+++ b/lua/lazyvim/plugins/xtras.lua
@@ -59,9 +59,9 @@ for name, extra in pairs(defaults) do
   end
 end
 
--- Add user defined extras via `vim.g.lazyvim_user_extras`
-local user_defined_extras = vim.g.lazyvim_user_extras or {}
-for k, v in pairs(user_defined_extras) do
+-- Add user enabled extras via `vim.g.lazyvim_user_extras`
+local user_enabled_extras = vim.g.lazyvim_user_extras or {}
+for k, v in pairs(user_enabled_extras) do
   local is_atomic_value = type(k) == "number"
   local name = is_atomic_value and v or k
   local priority = is_atomic_value and default_prio or v


### PR DESCRIPTION
## Description

This PR adds a `vim.g.lazyvim_user_extras` hook to address the pain point that user currently does not have a way to enable extras in lua config that respects LazyVim's plugin/extras loading order and predefined priorities. It is a table whose elements can be either an extras name (i.e. `lazyvim.plugins.extras.*`, using default priority of 50), or a kv pair of `["lazyvim.plugins.extras.<name>"] = <custom priority>`. This table is **merged and sorted together** with extras enabled in `lazyvim.json` and default core extras. It also detects and disallows user from overriding priority of default core extras and extras enabled via `lazyvim.json`. 

## Motivation

Currently, the user has two ways of enabling extras:
1. updating `lazyvim.json`: this can be done by either updating the file directly or via `:LazyExtras`
2. add `{ import = "lazyvim.plugins.extras.<name>" }` to a plugin spec, which usually stays under `lua/plugins` directory.

The two approaches serve different use cases and user preferences. However, the second approach has the downside that LazyVim would warn about plugins not loaded in the correct order: all extras should be loaded before user plugins, which is not possible if user "import" it in `lua/plugins`. The user could modify `lua/config/lazy.lua` to something like:
```
require("lazy").setup({
  spec = {
    -- add LazyVim and import its plugins
    { "LazyVim/LazyVim", import = "lazyvim.plugins" },
    -- import user-enabled extras
    {import = "extras"},
    -- import/override with your plugins
    { import = "plugins" },
  },
  ...
}
```

However, this means that all extras are loaded after those enabled via  `lazyvim.json`. 
With this PR, user now has the ability to precisely control the order in which extras are enabled, whilst keeping the declarations in lua land.

## Related Issue(s)

Addresses https://github.com/LazyVim/LazyVim/issues/5854 in an alternative way.

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
