### PR TITLE
fix(python): set venv-selector.nvim override_notify = false

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/python.lua
+++ b/lua/lazyvim/plugins/extras/lang/python.lua
@@ -114,6 +114,7 @@ return {
     opts = {
       options = {
         notify_user_on_venv_activation = true,
+        override_notify = false,
       },
     },
     --  Call config for Python files and load the cached venv automatically


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
This is a new option in venv-selector.nvim which stops it from
overriding vim.notify, so that it no longer interferes with noice.nvim.
See also [1].

[1] https://github.com/linux-cultist/venv-selector.nvim/issues/240

<!-- === GH HISTORY FENCE === -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
N/A

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
