### PR TITLE
fix(lang/haskell): better way to disable nvim-lspconfig

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/haskell.lua
+++ b/lua/lazyvim/plugins/extras/lang/haskell.lua
@@ -139,11 +139,7 @@ return {
   {
     "neovim/nvim-lspconfig",
     opts = {
-      setup = {
-        hls = function()
-          return true
-        end,
-      },
+      servers = { hls = { enabled = false } },
     },
   },
 }


### PR DESCRIPTION
## Description

Starting with v6.2.1 haskell-tools.nvim had issues to calculate the correct count of attached clients (result was always 0). This broke the state machine which decides which commands to allow (`Hls start` vs. `Hls restart` and `Hls stop`).

This is fixed by disabling the HLS server setup in nvim-lspconfig. Morally, the intention of the code hasn't changed. However, this way of disabling HLS solves the mentioned issue.

This way to disable LSP servers is not new. It's already used e.g. here:
- https://github.com/LazyVim/LazyVim/blob/c64a61734fc9d45470a72603395c02137802bc6f/lua/lazyvim/plugins/extras/ai/copilot.lua#L34
- https://github.com/LazyVim/LazyVim/blob/c64a61734fc9d45470a72603395c02137802bc6f/lua/lazyvim/plugins/extras/lang/typescript.lua#L25

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
