### PR TITLE
fix(leap): use new Codeberg repository

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/leap.lua
+++ b/lua/lazyvim/plugins/extras/editor/leap.lua
@@ -17,7 +17,7 @@ return {
     opts = { labeled_modes = "nx" },
   },
   {
-    "ggandor/leap.nvim",
+    "https://codeberg.org/andyg/leap.nvim",
     enabled = true,
     keys = {
       { "s", mode = { "n", "x", "o" }, desc = "Leap Forward to" },


### PR DESCRIPTION
Leap.nvim moved to Codeberg and the GitHub repo is no longer maintained.

## Description

This PR updates the `leap.nvim` extra to install from the actively maintained Codeberg repository instead of the deprecated GitHub mirror.
- Changes the plugin spec in `lua/lazyvim/plugins/extras/editor/leap.lua` from `ggandor/leap.nvim` to `https://codeberg.org/andyg/leap.nvim`.
- Keeps the existing configuration, keymaps, and lazy-loading behavior unchanged.
- Aligns LazyVim with the upstream recommendation that the GitHub repository is no longer maintained or mirrored.

## Related Issue(s)

#6958

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [ x]  I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
