### PR TITLE
fix(extras/prettier): run "prettier" command in a shell

### DIFF
--- a/lua/lazyvim/plugins/extras/formatting/prettier.lua
+++ b/lua/lazyvim/plugins/extras/formatting/prettier.lua
@@ -30,13 +30,10 @@ local supported = {
 --- Checks if a Prettier config file exists for the given context
 ---@param ctx ConformCtx
 function M.has_config(ctx)
-  local res = vim
-    .system({
-      vim.o.sh,
-      vim.o.shcf,
-      "prettier --find-config-path " .. vim.fn.shellescape(ctx.filename),
-    }, { text = true })
-    :wait()
+  local args = { vim.o.sh }
+  vim.list_extend(args, vim.split(vim.o.shcf, " ", { trimempty = true }))
+  table.insert(args, "prettier --find-config-path " .. vim.fn.shellescape(ctx.filename))
+  local res = vim.system(args, { text = true }):wait()
   return res.code == 0
 end
 
@@ -51,13 +48,10 @@ function M.has_parser(ctx)
     return true
   end
   -- otherwise, check if a parser can be inferred
-  local ret = vim
-    .system({
-      vim.o.sh,
-      vim.o.shcf,
-      "prettier --file-info " .. vim.fn.shellescape(ctx.filename),
-    }, { text = true })
-    :wait().stdout
+  local args = { vim.o.sh }
+  vim.list_extend(args, vim.split(vim.o.shcf, " ", { trimempty = true }))
+  table.insert(args, "prettier --file-info " .. vim.fn.shellescape(ctx.filename))
+  local ret = vim.system(args, { text = true }):wait().stdout
   ---@type boolean, string?
   local ok, parser = pcall(function()
     return vim.fn.json_decode(ret).inferredParser


### PR DESCRIPTION
Try to run `prettier` as a command in `shell` instead of running it directly, which fails for installations where `prettier` is a shell script (and not an executable).

(in fact, afaik there are no binaries for prettier... so how has this ever worked correctly?)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
