### PR TITLE
feat(extras): add buffer-jump extra for LunarVim-style buffer picker

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/buffer-jump.lua
+++ b/lua/lazyvim/plugins/extras/editor/buffer-jump.lua
@@ -1,4 +1,5 @@
 return {
+  desc = "LunarVim-style buffer picker with letter key navigation",
   "Masalale/buffer-jump.nvim",
   opts = {
     width = 55,


### PR DESCRIPTION
## Summary

Adds a new extra `editor.buffer-jump` that provides LunarVim-style buffer switching.

## Features

- Letter-key selection: Each buffer shows a highlighted letter - press it to jump instantly
- Visual indicators: Modified buffers show `•`, unloaded session buffers show `○`
- Number keys: Press 1-9 to jump to buffers by position
- Session aware: Shows all session-restored buffers, even if not yet loaded
- Configurable: Customize colors, dimensions, and border style

## Usage

Enable the extra:
```lua
{ import = "lazyvim.plugins.extras.editor.buffer-jump" }
```

Then use `<leader>bj` to open the buffer picker.

## Why This Extra?

LazyVim's default `<leader>,` uses fuzzy search which requires typing.
This extra provides **instant** buffer switching - see the letter, press it, done.

Inspired by LunarVim's buffer switcher UX.

## Plugin Repository

https://github.com/Masalale/buffer-jump.nvim