### PR TITLE
feat(bufferline): add <leader>bj keymap for BufferLinePick

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -15,6 +15,7 @@ return {
       { "]b", "<cmd>BufferLineCycleNext<cr>", desc = "Next Buffer" },
       { "[B", "<cmd>BufferLineMovePrev<cr>", desc = "Move buffer prev" },
       { "]B", "<cmd>BufferLineMoveNext<cr>", desc = "Move buffer next" },
+      { "<leader>bj", "<cmd>BufferLinePick<cr>", desc = "Pick Buffer" },
     },
     opts = {
       options = {


### PR DESCRIPTION
## Summary
- Adds `<leader>bj` keymap to quickly pick a buffer using BufferLinePick

## Motivation
BufferLinePick provides a great UX for quickly jumping to buffers by letter key, similar to LunarVim's buffer picker. This keymap makes it easily discoverable.

## Changes
- Added `<leader>bj` → `:BufferLinePick` in bufferline plugin config

## Testing
- Tested locally with multiple buffers open
- Press `<Space>bj`, letter labels appear on tabs, press letter to jump