### PR TITLE
fix(fzf): correct git_diff description from 'hunks' to 'files'

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/fzf.lua
+++ b/lua/lazyvim/plugins/extras/editor/fzf.lua
@@ -227,7 +227,7 @@ return {
       { "<leader>fR", LazyVim.pick("oldfiles", { cwd = vim.uv.cwd() }), desc = "Recent (cwd)" },
       -- git
       { "<leader>gc", "<cmd>FzfLua git_commits<CR>", desc = "Commits" },
-      { "<leader>gd", "<cmd>FzfLua git_diff<cr>", desc = "Git Diff (hunks)" },
+      { "<leader>gd", "<cmd>FzfLua git_diff<cr>", desc = "Git Diff (files)" },
       { "<leader>gl", "<cmd>FzfLua git_commits<CR>", desc = "Commits" },
       { "<leader>gs", "<cmd>FzfLua git_status<CR>", desc = "Status" },
       { "<leader>gS", "<cmd>FzfLua git_stash<cr>", desc = "Git Stash" },


### PR DESCRIPTION
Fixes #6960

`FzfLua git_diff` runs `git diff --name-only` which lists changed **files**, not hunks.

Updated the description from `"Git Diff (hunks)"` to `"Git Diff (files)"` to accurately reflect the command behavior.