### PR TITLE
fix(keymaps): terminal-toggle <C-/> should hide instead of re-evaluat…

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -189,8 +189,10 @@ map("n", "<leader>L", function() LazyVim.news.changelog() end, { desc = "LazyVim
 -- floating terminal
 map("n", "<leader>fT", function() Snacks.terminal() end, { desc = "Terminal (cwd)" })
 map("n", "<leader>ft", function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "Terminal (Root Dir)" })
-map({"n","t"}, "<c-/>",function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "Terminal (Root Dir)" })
-map({"n","t"}, "<c-_>",function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "which_key_ignore" })
+map("n", "<c-/>", function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "Terminal (Root Dir)" })
+map("t", "<c-/>", "<cmd>hide<cr>", { desc = "Hide Terminal" })
+map("n", "<c-_>", function() Snacks.terminal(nil, { cwd = LazyVim.root() }) end, { desc = "which_key_ignore" })
+map("t", "<c-_>", "<cmd>hide<cr>", { desc = "which_key_ignore" })
 
 -- windows
 map("n", "<leader>-", "<C-W>s", { desc = "Split Window Below", remap = true })


### PR DESCRIPTION
## Description

The terminal-mode `<C-/>` mapping currently calls `Snacks.terminal(nil, { cwd = LazyVim.root() })`, which re-evaluates the project root from within the terminal buffer. Since terminal buffers have no LSP and no file path, `LazyVim.root()` falls back to `cwd`, which can resolve to a different directory than the code buffer that originally opened the terminal.

This causes Snacks to compute a different terminal ID (since the ID is based on `cwd`), spawning a second terminal instead of toggling the first one closed.

The fix splits the `{"n","t"}` mapping so that:
- Normal mode still calls `Snacks.terminal(nil, { cwd = LazyVim.root() })` to open/toggle
- Terminal mode uses `<cmd>hide<cr>` to simply hide the window

This is consistent with Snacks' own built-in `q = "hide"` key for terminal windows (https://github.com/folke/snacks.nvim/blob/main/docs/terminal.md)

## Steps to reproduce

1. Open a project with nested directories (e.g. `~/projects/myapp/src/module`)
2. Press `<C-/>` from a code buffer, terminal opens correctly
3. Press `<C-/>` from inside the terminal, a second terminal spawns alongside the first

## Screenshots

Two terminal buffers spawned side by side after pressing `<C-/>` twice. 
Note the different working directories and PIDs:
![terminal-spawn-ids](https://github.com/user-attachments/assets/b4169826-a6a2-4c2f-bd96-349b237c6b78)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
