### PR TITLE
fix(vtsls): remove redundant deno logic, upstreamed in `nvim-lspconfig`

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -132,28 +132,6 @@ return {
           return true
         end,
         vtsls = function(_, opts)
-          if vim.lsp.config.denols and vim.lsp.config.vtsls then
-            ---@param server string
-            local resolve = function(server)
-              local markers, root_dir = vim.lsp.config[server].root_markers, vim.lsp.config[server].root_dir
-              vim.lsp.config(server, {
-                root_dir = function(bufnr, on_dir)
-                  local is_deno = vim.fs.root(bufnr, { "deno.json", "deno.jsonc" }) ~= nil
-                  if is_deno == (server == "denols") then
-                    if root_dir then
-                      return root_dir(bufnr, on_dir)
-                    elseif type(markers) == "table" then
-                      local root = vim.fs.root(bufnr, markers)
-                      return root and on_dir(root)
-                    end
-                  end
-                end,
-              })
-            end
-            resolve("denols")
-            resolve("vtsls")
-          end
-
           Snacks.util.lsp.on({ name = "vtsls" }, function(buffer, client)
             client.commands["_typescript.moveToFileRefactoring"] = function(command, ctx)
               ---@type string, string, lsp.Range


### PR DESCRIPTION
## Description
Since https://github.com/neovim/nvim-lspconfig/pull/4304 `nvim-lspconfig` has inherent deno logic to disambiguate between deno/non-deno projects. 

I believe it'd be better to remove the logic from LazyVim, since it might lead to issues because of different behavior compared to `nvim-lspconfig` defaults (whose logic doesn't only rely on the existence of `deno/json`, but also looks for lock files and takes into account which is the largest path with regards to the found pattern files). It'd be better for users to change `root_dir` themselves if they don't agree with the inherent logic.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
