### PR TITLE
fix(overseer): update commands and key mappings for v2

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/overseer.lua
+++ b/lua/lazyvim/plugins/extras/editor/overseer.lua
@@ -13,7 +13,8 @@ return {
       "OverseerClose",
       "OverseerToggle",
       "OverseerShell",
-      "OverseerRun"
+      "OverseerRun",
+      "OverseerTaskAction",
     },
     opts = {
       dap = false,


### PR DESCRIPTION

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Overseer [v2](https://github.com/stevearc/overseer.nvim/pull/448) introduced some breaking changes so this removes several Overseer commands and key mappings and adds `OverseerShell`.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
