### PR TITLE
fix(news): use $VIMRUNTIME for news.txt path

### DIFF
--- a/lua/lazyvim/util/news.lua
+++ b/lua/lazyvim/util/news.lua
@@ -51,7 +51,7 @@ function M.open(file, opts)
     end
     file = plugin.dir .. "/" .. file
   elseif opts.rtp then
-    file = vim.api.nvim_get_runtime_file(file, false)[1]
+    file = vim.fs.joinpath(vim.env.VIMRUNTIME, "doc", "news.txt")
   end
 
   if not file then


### PR DESCRIPTION


## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Use `vim.env.VIMRUNTIME` to resolve `news.txt` instead of `nvim_get_runtime_file()`, which can return a plugin's `news.txt` (e.g., rainbow-delimiters.nvim) instead of Neovim's bundled one.

I have tested this in macOS & Arch Linux, seems to be working in both.  
Let me know if this approach is not good, I have gone through `:h $VIMRUNTIME`, and it should work according to the doc. 

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

- Fixes #7019 

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
