### PR TITLE
fix(keymaps): disable `scroll` for search mappings which use `zv`

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -62,10 +62,34 @@ map(
 )
 
 -- https://github.com/mhinz/vim-galore#saner-behavior-of-n-and-n
-map("n", "n", "'Nn'[v:searchforward].'zv'", { expr = true, desc = "Next Search Result" })
+map("n", "n", function()
+  local old = vim.g.snacks_scroll
+  vim.g.snacks_scroll = false
+
+  local key = (vim.v.searchforward and "n" or "N") .. "zv"
+
+  -- without `vim.schedule`, the mapping did not behave consistently, sometimes opening
+  -- the fold and highlighting the word and sometimes not
+  vim.schedule(function()
+    vim.g.snacks_scroll = old
+  end)
+
+  return key
+end, { expr = true, desc = "Next Search Result" })
 map("x", "n", "'Nn'[v:searchforward]", { expr = true, desc = "Next Search Result" })
 map("o", "n", "'Nn'[v:searchforward]", { expr = true, desc = "Next Search Result" })
-map("n", "N", "'nN'[v:searchforward].'zv'", { expr = true, desc = "Prev Search Result" })
+map("n", "N", function()
+  local old = vim.g.snacks_scroll
+  vim.g.snacks_scroll = false
+
+  local key = (vim.v.searchforward and "n" or "N") .. "zv"
+
+  vim.schedule(function()
+    vim.g.snacks_scroll = old
+  end)
+
+  return key
+end, { expr = true, desc = "Prev Search Result" })
 map("x", "N", "'nN'[v:searchforward]", { expr = true, desc = "Prev Search Result" })
 map("o", "N", "'nN'[v:searchforward]", { expr = true, desc = "Prev Search Result" })
 


### PR DESCRIPTION
## Description
As per https://github.com/folke/snacks.nvim/discussions/1030#discussioncomment-12109404 `Snacks.scroll` is not able to detect `z*` motions. Disable `snacks_scroll` in mappings `n`/`N` that use `zv`.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #7022
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
