### PR TITLE
refactor(dial): use inbuilt augends

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/dial.lua
+++ b/lua/lazyvim/plugins/extras/editor/dial.lua
@@ -53,20 +53,6 @@ return {
       cyclic = true,
     })
 
-    local weekdays = augend.constant.new({
-      elements = {
-        "Monday",
-        "Tuesday",
-        "Wednesday",
-        "Thursday",
-        "Friday",
-        "Saturday",
-        "Sunday",
-      },
-      word = true,
-      cyclic = true,
-    })
-
     local months = augend.constant.new({
       elements = {
         "January",
@@ -81,15 +67,6 @@ return {
         "October",
         "November",
         "December",
-      },
-      word = true,
-      cyclic = true,
-    })
-
-    local capitalized_boolean = augend.constant.new({
-      elements = {
-        "True",
-        "False",
       },
       word = true,
       cyclic = true,
@@ -116,11 +93,12 @@ return {
           augend.integer.alias.decimal_int, -- nonnegative and negative decimal number
           augend.integer.alias.hex, -- nonnegative hex number  (0x01, 0x1a1f, etc.)
           augend.date.alias["%Y/%m/%d"], -- date (2022/02/19, etc.)
+          augend.constant.alias.en_weekday, -- Mon, Tue, ..., Sat, Sun
+          augend.constant.alias.en_weekday_full, -- Monday, Tuesday, ..., Saturday, Sunday
           ordinal_numbers,
-          weekdays,
           months,
-          capitalized_boolean,
           augend.constant.alias.bool, -- boolean value (true <-> false)
+          augend.constant.alias.Bool, -- boolean value (True <-> False)
           logical_alias,
         },
         vue = {


### PR DESCRIPTION
Dial now has built in augends for weekdays and Pythonic booleans

[monaqa/dial.nvim#augend-alias](https://github.com/monaqa/dial.nvim#augend-alias)

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
