### PR TITLE
fix(markdown): enable config file discovery for markdownlint-cli2

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/markdown.lua
+++ b/lua/lazyvim/plugins/extras/lang/markdown.lua
@@ -56,11 +56,23 @@ return {
   {
     "mfussenegger/nvim-lint",
     optional = true,
-    opts = {
-      linters_by_ft = {
-        markdown = { "markdownlint-cli2" },
-      },
-    },
+    opts = function(_, opts)
+      opts.linters_by_ft = opts.linters_by_ft or {}
+      opts.linters_by_ft.markdown = { "markdownlint-cli2" }
+
+      opts.linters = opts.linters or {}
+      opts.linters["markdownlint-cli2"] = {
+        -- Disable stdin to enable config file discovery.
+        -- markdownlint-cli2 traverses directories to find .markdownlint.json,
+        -- .markdownlint-cli2.jsonc, etc., but this only works with file paths.
+        stdin = false,
+        args = {},
+        parser = require("lint.parser").from_errorformat("%f:%l:%c %m,%f:%l %m", {
+          source = "markdownlint",
+          severity = vim.diagnostic.severity.WARN,
+        }),
+      }
+    end,
   },
   {
     "neovim/nvim-lspconfig",


### PR DESCRIPTION
## Summary

This PR fixes markdownlint-cli2 config file discovery in nvim-lint by disabling stdin mode.

## Problem

PR #3843 switched LazyVim from `markdownlint-cli` to `markdownlint-cli2`, citing "more flexible configuration through files in the whole directory tree" as a key benefit. However, nvim-lint's default `markdownlint-cli2` linter uses `stdin = true` with `args = { "-" }`, which pipes content via stdin.

**The issue**: When using stdin, markdownlint-cli2 doesn't know the file path and cannot traverse directories to find `.markdownlint.json`, `.markdownlint-cli2.jsonc`, or other config files. This defeats the primary reason for choosing markdownlint-cli2.

**Symptoms**:
- Local `.markdownlint.json` configs are ignored in Neovim
- CLI works fine: `markdownlint-cli2 file.md` respects configs
- Multiple users have reported this: #4695, discussions #4094, #2268, #2367

## Solution

Override nvim-lint's defaults to:
1. Set `stdin = false` so markdownlint-cli2 receives the actual file path
2. Set `args = {}` to remove the `-` (stdin indicator)
3. Update the error format parser to handle filename output instead of "stdin:"

## Testing

Verified locally that `.markdownlint.json` configs are now respected when linting markdown files in Neovim.

## Related

- Closes workaround from #4695
- Implements the config discovery promised by #3843