### PR TITLE
feat(extra): add oxfmt formatter

### DIFF
--- a/lua/lazyvim/plugins/extras/formatting/oxfmt.lua
+++ b/lua/lazyvim/plugins/extras/formatting/oxfmt.lua
@@ -1,0 +1,60 @@
+---@diagnostic disable: inject-field
+if lazyvim_docs then
+  -- Enable the option to require an oxfmt config file.
+  -- If no oxfmt config file is found, the formatter will not be used.
+  -- Note: oxfmt is Prettier-compatible but uses its own config files
+  -- (.oxfmtrc.json or .oxfmtrc.jsonc), not Prettier configs.
+  vim.g.lazyvim_oxfmt_needs_config = false
+end
+
+-- https://oxc.rs/docs/guide/usage/formatter.html#supported-languages
+local supported = {
+  "css",
+  "graphql",
+  "handlebars",
+  "html",
+  "javascript",
+  "javascriptreact",
+  "json",
+  "jsonc",
+  "less",
+  "markdown",
+  "markdown.mdx",
+  "scss",
+  "typescript",
+  "typescriptreact",
+  "vue",
+  "yaml",
+}
+
+---@param ctx conform.Context
+local function has_config(ctx)
+  return vim.fs.find({ ".oxfmtrc.json", ".oxfmtrc.jsonc" }, { path = ctx.filename, upward = true })[1] ~= nil
+end
+
+return {
+  {
+    "mason-org/mason.nvim",
+    opts = { ensure_installed = { "oxfmt" } },
+  },
+
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    ---@param opts conform.setupOpts
+    opts = function(_, opts)
+      opts.formatters_by_ft = opts.formatters_by_ft or {}
+      for _, ft in ipairs(supported) do
+        opts.formatters_by_ft[ft] = opts.formatters_by_ft[ft] or {}
+        table.insert(opts.formatters_by_ft[ft], "oxfmt")
+      end
+
+      opts.formatters = opts.formatters or {}
+      opts.formatters.oxfmt = {
+        condition = function(_, ctx)
+          return vim.g.lazyvim_oxfmt_needs_config ~= true or has_config(ctx)
+        end,
+      }
+    end,
+  },
+}


### PR DESCRIPTION
## Description
Add [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) as a new formatter extra. Oxfmt is a high-performance, Prettier-compatible formatter for the JavaScript ecosystem built on the OXC compiler stack from the Void(0) team.

## Documentation
- [Oxfmt Overview](https://oxc.rs/docs/guide/usage/formatter.html)
- [Oxfmt Configuration](https://oxc.rs/docs/guide/usage/formatter/config.html)
- [Oxfmt Editor Setup](https://oxc.rs/docs/guide/usage/formatter/editors.html#neovim)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
