### PR TITLE
Fix #6988: bug: kotlin_language_server is unable to detect gradle depen

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/kotlin.lua
+++ b/lua/lazyvim/plugins/extras/lang/kotlin.lua
@@ -27,7 +27,7 @@ return {
     "neovim/nvim-lspconfig",
     opts = {
       servers = {
-        kotlin_language_server = {},
+        kotlin_lsp = {},
       },
     },
   },


### PR DESCRIPTION
Fixes #6988

## Summary
This PR fixes: bug: kotlin_language_server is unable to detect gradle dependencies

## Changes
```
lua/lazyvim/plugins/extras/lang/kotlin.lua | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Haiku 4.5 by Anthropic | effort: high (extended thinking). Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).