### PR TITLE
Fix #7008: bug: Shortcuts to mason.nvim not working in lazy menu

### DIFF
--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -267,7 +267,27 @@ return {
 
     "mason-org/mason.nvim",
     cmd = "Mason",
-    keys = { { "<leader>cm", "<cmd>Mason<cr>", desc = "Mason" } },
+    keys = {
+      {
+        "<leader>cm",
+        function()
+          -- Close any floating windows that might be the lazy menu
+          for _, win in ipairs(vim.api.nvim_list_wins()) do
+            local config = vim.api.nvim_win_get_config(win)
+            if config.relative ~= "" then
+              local buf = vim.api.nvim_win_get_buf(win)
+              local bufname = vim.api.nvim_buf_get_name(buf)
+              -- Close floating windows that are likely from lazy.nvim
+              if bufname:find("lazy", 1, true) or vim.bo[buf].filetype == "lazy" then
+                vim.api.nvim_win_close(win, false)
+              end
+            end
+          end
+          vim.cmd("Mason")
+        end,
+        desc = "Mason",
+      },
+    },
     build = ":MasonUpdate",
     opts_extend = { "ensure_installed" },
     opts = {


### PR DESCRIPTION
Fixes #7008

## Summary
This PR fixes: bug: Shortcuts to mason.nvim not working in lazy menu

## Changes
```
lua/lazyvim/plugins/lsp/init.lua | 22 +++++++++++++++++++++-
 1 file changed, 21 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Haiku 4.5 by Anthropic | effort: high (extended thinking). Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).