### PR TITLE
Fix #6900: bug: missing `lsp.execute()` error handling

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -72,6 +72,7 @@ return {
                 local win = vim.api.nvim_get_current_win()
                 local params = vim.lsp.util.make_position_params(win, "utf-16")
                 LazyVim.lsp.execute({
+                  filter = "vtsls",
                   command = "typescript.goToSourceDefinition",
                   arguments = { params.textDocument.uri, params.position },
                   open = true,
@@ -83,6 +84,7 @@ return {
               "gR",
               function()
                 LazyVim.lsp.execute({
+                  filter = "vtsls",
                   command = "typescript.findAllFileReferences",
                   arguments = { vim.uri_from_bufnr(0) },
                   open = true,

--- a/lua/lazyvim/util/lsp.lua
+++ b/lua/lazyvim/util/lsp.lua
@@ -76,7 +76,14 @@ function M.execute(opts)
   local buf = vim.api.nvim_get_current_buf()
 
   ---@cast filter vim.lsp.get_clients.Filter
-  local client = vim.lsp.get_clients(LazyVim.merge({}, filter, { bufnr = buf }))[1]
+  local clients = vim.lsp.get_clients(LazyVim.merge({}, filter, { bufnr = buf }))
+  local client = clients[1]
+
+  if not client then
+    local filter_name = type(opts.filter) == "string" and opts.filter or (filter.name or "any")
+    LazyVim.warn("No LSP client found for filter: " .. filter_name, { title = "LSP Execute" })
+    return
+  end
 
   local params = {
     command = opts.command,
@@ -89,7 +96,14 @@ function M.execute(opts)
     })
   else
     vim.list_extend(params, { title = opts.title })
-    return client:exec_cmd(params, { bufnr = buf }, opts.handler)
+    local ok, result = pcall(function()
+      return client:exec_cmd(params, { bufnr = buf }, opts.handler)
+    end)
+    if not ok then
+      LazyVim.warn("Failed to execute command '" .. opts.command .. "': " .. tostring(result), { title = "LSP Execute" })
+      return
+    end
+    return result
   end
 end
 


### PR DESCRIPTION
Fixes #6900

## Summary
This PR fixes: bug: missing `lsp.execute()` error handling

## Changes
```
lua/lazyvim/plugins/extras/lang/typescript.lua |  2 ++
 lua/lazyvim/util/lsp.lua                       | 18 ++++++++++++++++--
 2 files changed, 18 insertions(+), 2 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Haiku 4.5 by Anthropic | effort: high (extended thinking). Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).