### PR TITLE
Fix #6876: bug: Update Overseer config to 2.0.0

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/overseer.lua
+++ b/lua/lazyvim/plugins/extras/editor/overseer.lua
@@ -14,6 +14,7 @@ return {
       "OverseerClose",
       "OverseerToggle",
       "OverseerRun",
+      "OverseerShell",
       "OverseerTaskAction",
     },
     opts = {
@@ -40,6 +41,7 @@ return {
       { "<leader>ow", "<cmd>OverseerToggle!<cr>",    desc = "Task list" },
       { "<leader>oo", "<cmd>OverseerRun<cr>",        desc = "Run task" },
       { "<leader>ot", "<cmd>OverseerTaskAction<cr>", desc = "Task action" },
+      { "<leader>os", "<cmd>OverseerShell<cr>",      desc = "Run shell command" },
     },
   },
   {


### PR DESCRIPTION
Fixes #6876

## Summary
This PR fixes: bug: Update Overseer config to 2.0.0

## Changes
```
lua/lazyvim/plugins/extras/editor/overseer.lua | 2 ++
 1 file changed, 2 insertions(+)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Haiku 4.5 by Anthropic | effort: high (extended thinking). Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).