### PR TITLE
fix(util.root): expand "." to cwd on Windows

### DIFF
--- a/lua/lazyvim/util/root.lua
+++ b/lua/lazyvim/util/root.lua
@@ -78,7 +78,11 @@ function M.realpath(path)
   if path == "" or path == nil then
     return nil
   end
-  path = vim.fn.has("win32") == 0 and vim.uv.fs_realpath(path) or path
+  if vim.fn.has("win32") == 0 then
+    path = vim.uv.fs_realpath(path)
+  elseif path == "." then
+    path = vim.uv.cwd()
+  end
   return LazyVim.norm(path)
 end
 


### PR DESCRIPTION
## Description

`LazyVim.root.detectors.pattern` returns `.` when the pattern matches in the current directory. If we do not expand the directory, Snacks will consider the current terminal window is for another directory. Instead of hiding the window, Snacks opens a new terminal window.

## Related Issue(s)

- #7048
- PR #6774

## Analysis

It seems that when `vim.fs.find` is given an invalid path, it will start from current working directory. And when a pattern is matched in the current working directory, `vim.fs.find` returns the relative path such as `.git`. Then `dirname` will return `.` as the result.

In commit 46e419d27efb5b7282a5ab17a49f4745ce23b55a, the result `.` is not expanded on Windows.

<details><summary>Debugging Trace FYI</summary>
<p>

I added print to inspect the internal variables:

```diff
@@ -52,6 +52,7 @@ end
 function M.detectors.pattern(buf, patterns)
   patterns = type(patterns) == "string" and { patterns } or patterns
   local path = M.bufpath(buf) or vim.uv.cwd()
+  print("path = " .. path)
   local pattern = vim.fs.find(function(name)
     for _, p in ipairs(patterns) do
       if name == p then
@@ -63,6 +64,8 @@ function M.detectors.pattern(buf, patterns)
     end
     return false
   end, { path = path, upward = true })[1]
+  print("pattern = " .. (pattern or "nil"))
+  print("dirname(pattern) = " .. (pattern and vim.fs.dirname(pattern) or "nil"))
   return pattern and { vim.fs.dirname(pattern) } or {}
 end
 
@@ -202,4 +205,4 @@ function M.pretty_path(opts)
   return ""
 end
 
-return M
+print("root = " .. M.get())
```

### Windows

Windows, No patterns matched, Blank buffer

```
path = C:\Users\me\Downloads
pattern = nil
dirname(pattern) = nil
root = C:\Users\me\Downloads
```

Windows, No patterns matched, Terminal buffer

```
path = term:/~/Downloads/8364:C:/Users/me/scoop/apps/pwsh/current/pwsh.EXE
pattern = nil
dirname(pattern) = nil
root = C:\Users\me\Downloads
```

Windows, Pattern .git matched, Blank buffer

```
path = C:\Users\me\Documents\PowerShell
pattern = C:/Users/me/Documents/PowerShell/.git
dirname(pattern) = C:/Users/me/Documents/PowerShell
root = C:\Users\me\Documents\PowerShell
```

Windows, Pattern .git matched, Terminal buffer

```
path = term:/~/Documents/PowerShell/32088:C:/Users/me/scoop/apps/pwsh/current/pwsh.EXE
pattern = .git
dirname(pattern) = .
root = .
```

If I launch Vim in a sub-directory of a Git repo:

```
path = C:\Users\me\Documents\PowerShell\bin
pattern = C:/Users/me/Documents/PowerShell/.git
dirname(pattern) = C:/Users/me/Documents/PowerShell
root = C:\Users\me\Documents\PowerShell
```

```
path = term:/~/Documents/PowerShell/32428:C:/Users/me/scoop/apps/pwsh/current/pwsh.EXE
pattern = nil
dirname(pattern) = nil
root = C:\Users\me\Documents\PowerShell\bin
```

### Linux

Linux, No patterns matched, Blank buffer

```
path = /home/ian
pattern = nil
dirname(pattern) = nil
root = /home/ian
```

Linux, No patterns matched, Terminal buffer

```
path = term:/~/506:/usr/bin/zsh
pattern = nil
dirname(pattern) = nil
root = /home/ian
```

Linux, Pattern .git matched, Blank buffer

```
path = /home/ian/codebase/fiber
pattern = /home/ian/codebase/fiber/.git
dirname(pattern) = /home/ian/codebase/fiber
root = /home/ian/codebase/fiber
```

Linux, Pattern .git matched, Terminal buffer

```
path = term:/~/codebase/fiber/665:/usr/bin/zsh
pattern = .git
dirname(pattern) = .
root = /home/ian/codebase/fiber
```

If I launch Vim in a sub-directory of a Git repo:

```
path = /home/ian/codebase/fiber/crates
pattern = /home/ian/codebase/fiber/.git
dirname(pattern) = /home/ian/codebase/fiber
root = /home/ian/codebase/fiber
```

```
path = term:/~/codebase/fiber/1028:/usr/bin/zsh
pattern = nil
dirname(pattern) = nil
root = /home/ian/codebase/fiber/crates
```


</p>
</details> 

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
