### PR TITLE
fix(clojure): remove redundant on-filetype() call that leaks keymaps

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/clojure.lua
+++ b/lua/lazyvim/plugins/extras/lang/clojure.lua
@@ -52,7 +52,6 @@ return {
     event = "LazyFile",
     config = function(_, _)
       require("conjure.main").main()
-      require("conjure.mapping")["on-filetype"]()
     end,
     init = function()
       -- print color codes if baleia.nvim is available


### PR DESCRIPTION
## Summary

The Conjure spec calls `require("conjure.mapping")["on-filetype"]()` unconditionally in its `config` function. Because the plugin loads on `event = "LazyFile"` (any file open), this sets Conjure's buffer-local keymaps on whatever buffer triggered the load, regardless of filetype.

This call is redundant. `require("conjure.main").main()` internally calls `mapping.init(filetypes)`, which:

1. Registers a `FileType` autocmd scoped to supported filetypes.
2. Checks if the current buffer's filetype is in the list before calling `on-filetype()`.

From `conjure/mapping.lua`:

```lua
M.init = function(filetypes)
  local group = vim.api.nvim_create_augroup("conjure_init_filetypes", {})
  if (true == config["get-in"]({"mapping", "enable_ft_mappings"})) then
    vim.api.nvim_create_autocmd("FileType", {
      group = group, pattern = filetypes,
      callback = autocmd_callback(M["on-filetype"])
    })
    if core.some(function(x) return x == vim.bo.filetype end, filetypes) then
      vim.schedule(M["on-filetype"])
    end
  end
end
```

The extra `on-filetype()` bypasses this guard. Removing it restores the intended behavior: Conjure keymaps only appear in buffers whose filetype Conjure supports.

## Related Issue(s)

Fixes #7064

## Repro

Save as `repro.lua` and run with `nvim -u repro.lua`:

```lua
vim.env.LAZY_STDPATH = ".repro"
load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()

require("lazy.minit").repro({
  spec = {
    { "LazyVim/LazyVim", import = "lazyvim.plugins" },
    { import = "lazyvim.plugins.extras.lang.clojure" },
  },
})
```

Steps:
1. `nvim -u repro.lua`
2. `:e test.md`
3. `:nmap <localleader>` — observe 25+ Conjure keymaps on a markdown buffer

After this fix, `:nmap <localleader>` on `test.md` shows no Conjure keymaps.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.