### PR TITLE
fix(util.root): resolve bufpath for terminal windows

### DIFF
--- a/lua/lazyvim/util/root.lua
+++ b/lua/lazyvim/util/root.lua
@@ -69,7 +69,7 @@ end
 function M.bufpath(buf)
   local name = LazyVim.norm(vim.api.nvim_buf_get_name(assert(buf)))
   local path = name and name:match("^term:/(.+/%d+):") or name
-  -- fix duplicated driver letters for Windows
+  -- fix duplicated drive letters for Windows
   if vim.fn.has("win32") == 1 and path and path:find(":/.*:/") then
     path = path:gsub("^.-%:/", "", 1)
   end


### PR DESCRIPTION
## Description

Extract path from terminal window name such as `term:/~/.local/share/nvim/lazy/LazyVim/2062833:/usr/bin/zsh`. The path `~/.local/share/nvim/lazy/LazyVim/2062833` can locate the correct directory for the terminal windows.

## Related Issue(s)

- #7048
- PR #6774
- PR #7061 

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
