### PR TITLE
fix(keymaps): make search keymaps respect foldopen

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -62,10 +62,10 @@ map(
 )
 
 -- https://github.com/mhinz/vim-galore#saner-behavior-of-n-and-n
-map("n", "n", "'Nn'[v:searchforward].'zv'", { expr = true, desc = "Next Search Result" })
+map("n", "n", "'Nn'[v:searchforward].['','zv'][&fdo=~#'search']", { expr = true, desc = "Next Search Result" })
 map("x", "n", "'Nn'[v:searchforward]", { expr = true, desc = "Next Search Result" })
 map("o", "n", "'Nn'[v:searchforward]", { expr = true, desc = "Next Search Result" })
-map("n", "N", "'nN'[v:searchforward].'zv'", { expr = true, desc = "Prev Search Result" })
+map("n", "N", "'nN'[v:searchforward].['','zv'][&fdo=~#'search']", { expr = true, desc = "Prev Search Result" })
 map("x", "N", "'nN'[v:searchforward]", { expr = true, desc = "Prev Search Result" })
 map("o", "N", "'nN'[v:searchforward]", { expr = true, desc = "Prev Search Result" })
 


### PR DESCRIPTION
## Description

The previous keymaps for `n` and `N` forcibly open folds (with `zv`) that contains the search while the original behavior for `n` and `N` is to only open folds if `search` is in `foldopen` option (which by default it is).

From `:h 'foldopen'`:

```

'foldopen' 'fdo'	string	(default "block,hor,mark,percent,quickfix,search,tag,undo")
			global
	Specifies for which type of commands folds will be opened, if the
	command moves the cursor into a closed fold.  It is a comma-separated
	list of items.
	NOTE: When the command is part of a mapping this option is not used.
	Add the |zv| command to the mapping to get the same effect.
	(rationale: the mapping may want to control opening folds itself)

		item		commands ~
...
		search		search for a pattern: "/", "n", "*", "gd", etc.
				(not for a search pattern in a ":" command)
				Also for |[s| and |]s|.
...
```

This PR attempts to emulate the original behavior.

## Related Issue(s)

The previous behavior is introduced in this PR: https://github.com/LazyVim/LazyVim/pull/1298.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.