### PR TITLE
fix(terraform): disable semantic tokens to prevent editor hangs

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/terraform.lua
+++ b/lua/lazyvim/plugins/extras/lang/terraform.lua
@@ -16,6 +16,16 @@ return {
       servers = {
         terraformls = {},
       },
+      setup = {
+        terraformls = function(_, opts)
+          -- workaround for terraform-ls sending invalid semantic tokens
+          -- https://github.com/hashicorp/terraform-ls/issues/2094
+          Snacks.util.lsp.on({ name = "terraformls" }, function(_, client)
+            client.server_capabilities.semanticTokensProvider = nil
+          end)
+          -- end workaround
+        end,
+      },
     },
   },
   -- ensure terraform tools are installed


### PR DESCRIPTION
## Description
This PR adds a workaround to disable semantic tokens for `terraform-ls` to prevent editor hangs in Neovim 0.12.
The language server `terraform-ls` (v0.38.5) sends invalid `textDocument/semanticTokens/full` responses when parsing Terraform configurations with heredoc blocks (`<<-EOT`) containing string interpolations. The server calculates column deltas incorrectly within heredoc interpolations, causing negative integers that overflow when cast to `uint32`. Neovim 0.12 cannot process these values, leading to an editor hang during the LSP capability negotiation phase.
The fix follows the same pattern used in `go.lua` for the gopls semantic tokens workaround. By setting `client.server_capabilities.semanticTokensProvider = nil` in the LSP setup hook, we disable semantic token support for terraform-ls, preventing the freeze.

## Related Issue(s)
- Upstream issue: https://github.com/hashicorp/terraform-ls/issues/2094

## Screenshots
N/A - This is a stability fix that prevents editor hangs; no visual changes.

## Checklist
- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.