### PR TITLE
fix(extras.util.gitui): revert deleting <leader>gf and <leader>gl keymaps when GitUI is enabled

### DIFF
--- a/lua/lazyvim/plugins/extras/util/gitui.lua
+++ b/lua/lazyvim/plugins/extras/util/gitui.lua
@@ -20,16 +20,5 @@ return {
         desc = "GitUi (Root Dir)",
       },
     },
-    init = function()
-      -- delete lazygit keymap for file history
-      vim.api.nvim_create_autocmd("User", {
-        pattern = "LazyVimKeymaps",
-        once = true,
-        callback = function()
-          pcall(vim.keymap.del, "n", "<leader>gf")
-          pcall(vim.keymap.del, "n", "<leader>gl")
-        end,
-      })
-    end,
   },
 }


### PR DESCRIPTION
## Description

Currently LazyVim has code to delete both `<leader>gf` and `<leader>gl` keymaps when GitUI is enabled.

These keymaps do not interfere with GitUI.

An older PR added one of them here https://github.com/LazyVim/LazyVim/pull/3371.

Also @dpetka2001 discovered this commit https://github.com/LazyVim/LazyVim/commit/aa53cd47c45ad4a087a35ab9150807d1dfef65ed which is back before Snacks had a `git` module. They're thinking it's safe to delete this init function so the key maps are present.

The outcome would be LazyVim's keymaps will be defined and usable with and without GitUI: https://github.com/LazyVim/LazyVim/blob/83d90f339defdb109a6ede333865a66ffc7ef6aa/lua/lazyvim/config/keymaps.lua#L172-L173

## Related Issue(s)

It's related to this discussion https://github.com/LazyVim/LazyVim/discussions/7099.

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
