### PR TITLE
feat(moonbit): add moonbit language extra

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/moonbit.lua
+++ b/lua/lazyvim/plugins/extras/lang/moonbit.lua
@@ -1,0 +1,49 @@
+return {
+  recommended = function()
+    return LazyVim.extras.wants({
+      ft = { "moonbit", "mbt" },
+      root = { "moon.mod.json" },
+    })
+  end,
+
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = { ensure_installed = { "moonbit" } },
+  },
+
+  -- TODO: Enable once moonbit LSP is available in mason registry
+  -- https://github.com/mason-org/mason-registry
+  -- {
+  --   "mason-org/mason.nvim",
+  --   optional = true,
+  --   opts = function(_, opts)
+  --     opts.ensure_installed = opts.ensure_installed or {}
+  --     vim.list_extend(opts.ensure_installed, { "moonbit-lsp" })
+  --   end,
+  -- },
+
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        moonbit = {
+          cmd = { "moonbit-lsp" },
+          filetypes = { "moonbit", "mbt" },
+          root_dir = function(fname)
+            return require("lspconfig.util").root_pattern("moon.mod.json")(fname)
+          end,
+        },
+      },
+    },
+  },
+
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        moonbit = { "moonfmt" },
+      },
+    },
+  },
+}

--- a/lua/lazyvim/plugins/extras/lang/moonbit.lua
+++ b/lua/lazyvim/plugins/extras/lang/moonbit.lua
@@ -11,7 +11,7 @@ return {
     opts = { ensure_installed = { "moonbit" } },
   },
 
-  -- TODO: Enable once moonbit LSP is available in mason registry
+  -- TODO: Enable once moonbit LSP is available in mason registry.
   -- https://github.com/mason-org/mason-registry
   -- {
   --   "mason-org/mason.nvim",


### PR DESCRIPTION
## Description

Add MoonBit language support:
- LSP (moonbit-lsp)
- Tree-sitter (moonbit)
- Formatting (moonfmt)
Follows the same structure as gleam/dart extras.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
- [x] Code style follows existing conventions
- [x] `recommended` section uses function pattern
- [x] No mason integration (not yet available)

