### PR TITLE
fix(nvim-lint): fix `prepend_args` logic

### DIFF
--- a/lua/lazyvim/plugins/linting.lua
+++ b/lua/lazyvim/plugins/linting.lua
@@ -32,13 +32,19 @@ return {
     config = function(_, opts)
       local M = {}
 
+      local function list_prepend(dst, src)
+        for i = 1, #src do
+          table.insert(dst, i, src[i])
+        end
+      end
+
       local lint = require("lint")
       for name, linter in pairs(opts.linters) do
         if type(linter) == "table" and type(lint.linters[name]) == "table" then
           lint.linters[name] = vim.tbl_deep_extend("force", lint.linters[name], linter)
           if type(linter.prepend_args) == "table" then
             lint.linters[name].args = lint.linters[name].args or {}
-            vim.list_extend(lint.linters[name].args, linter.prepend_args)
+            list_prepend(lint.linters[name].args, linter.prepend_args)
           end
         else
           lint.linters[name] = linter


### PR DESCRIPTION
## Description

`prepend_args` logic doesn't work as expected, as it appends the extra args rather than prepends them. This works for some linter configurations, but breaks other ones that use `-` as the last argument in the default configuration.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
- Fixes #7104

## Screenshots

N/A

## Testing

Manual testing done with some impacted linters (`selene`, `luacheck`):

* Args before:
  * selene: `{ "--display-style", "json", "-" }`
  * luacheck: `{ "--formatter", "plain", "--codes", "--ranges", "-" }`
* Args after:
  * selene: `{ "--config", "/some/path/selene.toml", "--display-style", "json", "-" }`
  * luacheck: `{ "--default-config", "/some/path/.luacheckrc", "--formatter", "plain", "--codes", "--ranges", "-" }`

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
