### PR TITLE
fix(scala): restrict metals keymaps to scala and sbt filetypes

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/scala.lua
+++ b/lua/lazyvim/plugins/extras/lang/scala.lua
@@ -21,6 +21,7 @@ return {
           require("telescope").extensions.metals.commands()
         end,
         desc = "Metals commands",
+        ft = { "scala", "sbt" },
       },
       {
         "<leader>mc",
@@ -28,6 +29,7 @@ return {
           require("metals").compile_cascade()
         end,
         desc = "Metals compile cascade",
+        ft = { "scala", "sbt" },
       },
       {
         "<leader>mh",
@@ -35,6 +37,7 @@ return {
           require("metals").hover_worksheet()
         end,
         desc = "Metals hover worksheet",
+        ft = { "scala", "sbt" },
       },
     },
     ft = { "scala", "sbt", "java" },


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
restrict Metals keymaps to scala and sbt filetypes 
add ` ft = { "scala", "sbt" }`

review(?): @isti115 @seakayone @gpwns3717 
(sorry for ping)

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
