### PR TITLE
feat(keymaps): add shortcuts to copy buffer file path to clipboard

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -112,7 +112,7 @@ map("n", "<leader>fY", function()
   end
   vim.fn.setreg("+", path)
   vim.notify("Copied: " .. path)
-end, { desc = "Copy Relative File Path" })
+end, { desc = "Copy Short File Path" })
 
 -- location list
 map("n", "<leader>xl", function()

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -94,6 +94,18 @@ map("n", "<leader>l", "<cmd>Lazy<cr>", { desc = "Lazy" })
 -- new file
 map("n", "<leader>fn", "<cmd>enew<cr>", { desc = "New File" })
 
+-- copy file path
+map("n", "<leader>fy", function()
+  local path = vim.fn.expand("%:p")
+  vim.fn.setreg("+", path)
+  vim.notify("Copied: " .. path)
+end, { desc = "Copy File Path" })
+map("n", "<leader>fY", function()
+  local path = vim.fn.expand("%:~:.")
+  vim.fn.setreg("+", path)
+  vim.notify("Copied: " .. path)
+end, { desc = "Copy Relative File Path" })
+
 -- location list
 map("n", "<leader>xl", function()
   local success, err = pcall(vim.fn.getloclist(0, { winid = 0 }).winid ~= 0 and vim.cmd.lclose or vim.cmd.lopen)

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -97,11 +97,19 @@ map("n", "<leader>fn", "<cmd>enew<cr>", { desc = "New File" })
 -- copy file path
 map("n", "<leader>fy", function()
   local path = vim.fn.expand("%:p")
+  if path == "" then
+    vim.notify("No file path available for the current buffer", vim.log.levels.WARN)
+    return
+  end
   vim.fn.setreg("+", path)
   vim.notify("Copied: " .. path)
 end, { desc = "Copy File Path" })
 map("n", "<leader>fY", function()
   local path = vim.fn.expand("%:~:.")
+  if path == "" then
+    vim.notify("No file path available for the current buffer", vim.log.levels.WARN)
+    return
+  end
   vim.fn.setreg("+", path)
   vim.notify("Copied: " .. path)
 end, { desc = "Copy Relative File Path" })

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -94,24 +94,22 @@ map("n", "<leader>l", "<cmd>Lazy<cr>", { desc = "Lazy" })
 -- new file
 map("n", "<leader>fn", "<cmd>enew<cr>", { desc = "New File" })
 
+local function copy_file_path(modifier)
+  local path = vim.fn.expand(modifier)
+  if path == "" then
+    vim.notify("No file path available for the current buffer", vim.log.levels.WARN)
+    return
+  end
+  vim.fn.setreg("+", path)
+  vim.notify("Copied: " .. path)
+end
+
 -- copy file path
 map("n", "<leader>fy", function()
-  local path = vim.fn.expand("%:p")
-  if path == "" then
-    vim.notify("No file path available for the current buffer", vim.log.levels.WARN)
-    return
-  end
-  vim.fn.setreg("+", path)
-  vim.notify("Copied: " .. path)
+  copy_file_path("%:p")
 end, { desc = "Copy File Path" })
 map("n", "<leader>fY", function()
-  local path = vim.fn.expand("%:~:.")
-  if path == "" then
-    vim.notify("No file path available for the current buffer", vim.log.levels.WARN)
-    return
-  end
-  vim.fn.setreg("+", path)
-  vim.notify("Copied: " .. path)
+  copy_file_path("%:~:.")
 end, { desc = "Copy Short File Path" })
 
 -- location list


### PR DESCRIPTION
## Description

Add keymaps to copy full file path and relative file path of the buffer.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

I can't find a keymap to copy the file path of the current buffer.
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
