### PR TITLE
fix(refactoring)!: conform to upstream breaking changes on 2.0 branch

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/refactoring.lua
+++ b/lua/lazyvim/plugins/extras/editor/refactoring.lua
@@ -1,95 +1,64 @@
-local pick = function()
-  local refactoring = require("refactoring")
-  if LazyVim.pick.picker.name == "telescope" then
-    return require("telescope").extensions.refactoring.refactors()
-  elseif LazyVim.pick.picker.name == "fzf" then
-    local fzf_lua = require("fzf-lua")
-    local results = refactoring.get_refactors()
-
-    local opts = {
-      fzf_opts = {},
-      fzf_colors = true,
-      actions = {
-        ["default"] = function(selected)
-          refactoring.refactor(selected[1])
-        end,
-      },
-    }
-    fzf_lua.fzf_exec(results, opts)
-  else
-    refactoring.select_refactor()
+if LazyVim.has_extra("editor.refactoring") then
+  if vim.fn.has("nvim-0.12") == 0 then
+    LazyVim.error("refactoring.nvim requires Neovim 0.12 or higher", { title = "refactoring.nvim" })
+    return {}
   end
 end
 
 return {
+  { "lewis6991/async.nvim", lazy = true },
+
   {
     "ThePrimeagen/refactoring.nvim",
     event = { "BufReadPre", "BufNewFile" },
-    dependencies = {
-      "nvim-lua/plenary.nvim",
-      "nvim-treesitter/nvim-treesitter",
-    },
     keys = {
       { "<leader>r", "", desc = "+refactor", mode = { "n", "x" } },
       {
         "<leader>rs",
-        pick,
+        function()
+          return require("refactoring").select_refactor()
+        end,
         mode = { "n", "x" },
-        desc = "Refactor",
+        desc = "Select Refactor",
       },
       {
         "<leader>ri",
         function()
-          return require("refactoring").refactor("Inline Variable")
+          return require("refactoring").inline_var()
         end,
         mode = { "n", "x" },
         desc = "Inline Variable",
         expr = true,
       },
       {
-        "<leader>rb",
-        function()
-          return require("refactoring").refactor("Extract Block")
-        end,
-        mode = { "n", "x" },
-        desc = "Extract Block",
-        expr = true,
-      },
-      {
-        "<leader>rf",
-        function()
-          return require("refactoring").refactor("Extract Block To File")
-        end,
-        mode = { "n", "x" },
-        desc = "Extract Block To File",
-        expr = true,
-      },
-      {
         "<leader>rP",
         function()
-          require("refactoring").debug.printf({ below = false })
+          return require("refactoring.debug").print_loc({ output_location = "below" })
         end,
-        desc = "Debug Print",
+        desc = "Debug Print Location",
+        expr = true,
       },
       {
         "<leader>rp",
         function()
-          require("refactoring").debug.print_var({ normal = true })
+          return require("refactoring.debug").print_var({ output_location = "below" }) .. "iw"
         end,
         mode = { "n", "x" },
         desc = "Debug Print Variable",
+        expr = true,
       },
       {
         "<leader>rc",
         function()
-          require("refactoring").debug.cleanup({})
+          return require("refactoring.debug").cleanup({ restore_view = true }) .. "ag"
         end,
         desc = "Debug Cleanup",
+        expr = true,
       },
       {
         "<leader>rf",
         function()
-          return require("refactoring").refactor("Extract Function")
+          return require("refactoring").extract_func()
         end,
         mode = { "n", "x" },
         desc = "Extract Function",
@@ -98,7 +67,7 @@ return {
       {
         "<leader>rF",
         function()
-          return require("refactoring").refactor("Extract Function To File")
+          return require("refactoring").extract_func_to_file()
         end,
         mode = { "n", "x" },
         desc = "Extract Function To File",
@@ -107,52 +76,13 @@ return {
       {
         "<leader>rx",
         function()
-          return require("refactoring").refactor("Extract Variable")
+          return require("refactoring").extract_var()
         end,
         mode = { "n", "x" },
         desc = "Extract Variable",
         expr = true,
       },
-      {
-        "<leader>rp",
-        function()
-          require("refactoring").debug.print_var()
-        end,
-        mode = { "n", "x" },
-        desc = "Debug Print Variable",
-      },
     },
-    opts = {
-      prompt_func_return_type = {
-        go = false,
-        java = false,
-        cpp = false,
-        c = false,
-        h = false,
-        hpp = false,
-        cxx = false,
-      },
-      prompt_func_param_type = {
-        go = false,
-        java = false,
-        cpp = false,
-        c = false,
-        h = false,
-        hpp = false,
-        cxx = false,
-      },
-      printf_statements = {},
-      print_var_statements = {},
-      show_success_message = true, -- shows a message with information about the refactor on success
-      -- i.e. [Refactor] Inlined 3 variable occurrences
-    },
-    config = function(_, opts)
-      require("refactoring").setup(opts)
-      if LazyVim.has("telescope.nvim") then
-        LazyVim.on_load("telescope.nvim", function()
-          require("telescope").load_extension("refactoring")
-        end)
-      end
-    end,
+    opts = {},
   },
 }


### PR DESCRIPTION
## Description
`refactoring.nvim` had a new 2.0 release with some breaking changes. Adjust the LazyVim Extra.

Left `opts` with everything default as there've been changes there as well, but I don't use the plugin.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #7122
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
