### PR TITLE
fix(tsgo): add vue-ls warning when tsgo is enabled

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/vue.lua
+++ b/lua/lazyvim/plugins/extras/lang/vue.lua
@@ -32,7 +32,7 @@ return {
       if not opts.servers.vtsls or opts.servers.vtsls.enabled == false then
         LazyVim.warn({
           "The `lang.vue` extra requires `vtsls` for TypeScript integration.",
-          "Enable the `lang.typescript.vtsls` extra, or set `vim.g.lazyvim_ts_lsp = \"vtsls\"`.",
+          'Enable the `lang.typescript.vtsls` extra, or set `vim.g.lazyvim_ts_lsp = "vtsls"`.',
           "If you are using `lang.typescript.tsgo`, disable it so `vtsls` can be used for `lang.vue`.",
         }, {
           title = "LazyVim",

--- a/lua/lazyvim/plugins/extras/lang/vue.lua
+++ b/lua/lazyvim/plugins/extras/lang/vue.lua
@@ -29,6 +29,17 @@ return {
   {
     "neovim/nvim-lspconfig",
     opts = function(_, opts)
+      if not opts.servers.vtsls or opts.servers.vtsls.enabled == false then
+        LazyVim.warn({
+          "The `lang.vue` extras requires `vtsls` for TypeScript integration.",
+          "Please enable `vtsls` so `lang.vue` works correctly.",
+        }, {
+          title = "LazyVim",
+          once = true,
+        })
+        return
+      end
+
       table.insert(opts.servers.vtsls.filetypes, "vue")
       LazyVim.extend(opts.servers.vtsls, "settings.vtsls.tsserver.globalPlugins", {
         {

--- a/lua/lazyvim/plugins/extras/lang/vue.lua
+++ b/lua/lazyvim/plugins/extras/lang/vue.lua
@@ -31,8 +31,9 @@ return {
     opts = function(_, opts)
       if not opts.servers.vtsls or opts.servers.vtsls.enabled == false then
         LazyVim.warn({
-          "The `lang.vue` extras requires `vtsls` for TypeScript integration.",
-          "Please enable `vtsls` so `lang.vue` works correctly.",
+          "The `lang.vue` extra requires `vtsls` for TypeScript integration.",
+          "Enable the `lang.typescript.vtsls` extra, or set `vim.g.lazyvim_ts_lsp = \"vtsls\"`.",
+          "If you are using `lang.typescript.tsgo`, disable it so `vtsls` can be used for `lang.vue`.",
         }, {
           title = "LazyVim",
           once = true,


### PR DESCRIPTION
## Description

When using the `lang.typescript.tsgo` and `lang.vue` extras, the later attempts to look for `lang.typescript.vtsls` which is not defined, causing an error on opening a buffer.

This PR adds a warning message when `lang.vue` is enabled, but `lang.typescript.vtsls` is not

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

[see this comment](https://github.com/LazyVim/LazyVim/discussions/6889#discussioncomment-16664426)
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
