### PR TITLE
refactor(keymaps): remove hardcoded diagnostic jump float option

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -124,7 +124,6 @@ local diagnostic_goto = function(next, severity)
     vim.diagnostic.jump({
       count = (next and 1 or -1) * vim.v.count1,
       severity = severity and vim.diagnostic.severity[severity] or nil,
-      float = true,
     })
   end
 end

--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -32,6 +32,9 @@ return {
               [vim.diagnostic.severity.INFO] = LazyVim.config.icons.diagnostics.Info,
             },
           },
+          jump = {
+            float = true,
+          },
         },
         -- Enable this to enable the builtin LSP inlay hints on Neovim.
         -- Be aware that you also will need to properly configure your LSP server to


### PR DESCRIPTION
## Description

Currently, the diagnostic jump keymap overrides the default float behavior defined in `vim.diagnostic.config`. This change ensures the keybinding respects the user's diagnostic configuration.

## Related Issue(s)
None

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
