### PR TITLE
fix(scala): remove hardcoded telescope dependency for metals commands

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/scala.lua
+++ b/lua/lazyvim/plugins/extras/lang/scala.lua
@@ -18,7 +18,11 @@ return {
       {
         "<leader>me",
         function()
-          require("telescope").extensions.metals.commands()
+          if LazyVim.pick.picker.name == "telescope" then
+            require("telescope").extensions.metals.commands()
+          else
+            require("metals").commands()
+          end
         end,
         desc = "Metals commands",
       },


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

The [scala extra](https://github.com/LazyVim/LazyVim/blob/cdc47ae6152872ad09d588697906bf93cba3fcd9/lua/lazyvim/plugins/extras/lang/scala.lua#L21-L21) has a keymap with an unguarded [`require("telescope").extensions.metals.commands()`](https://github.com/scalameta/nvim-metals/blob/b914d3b963582109371d0949424c3cc6758d99b8/lua/telescope/_extensions/metals.lua) which causes an `module 'telescope' not found` if telescope is not installed.

Thankfully, there is an alternative command [`require("metals").commands()`](https://github.com/scalameta/nvim-metals/blob/b914d3b963582109371d0949424c3cc6758d99b8/lua/metals.lua#L576-L587) which uses `vim.ui.select` under the hood.

The `require("telescope").extensions.metals.commands()` differs from `require("metals").commands()` in that is shows `<command> - <description>` instead of just `<command>`, so it makes sense to keep using it if telescope is default picker.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

Before the change, if telescope is not installed

<img width="2050" height="1166" alt="error-before-fix" src="https://github.com/user-attachments/assets/7b72f196-79ff-4faa-9baa-7a9cc322db23" />

---

After the change, with `vim.g.vim.g.lazyvim_picker = "telescope"`

<img width="2050" height="1166" alt="telescope" src="https://github.com/user-attachments/assets/1067153e-d7f1-468e-b9f5-5d90176b2de9" />

---

After the change, with `vim.g.vim.g.lazyvim_picker = "snacks"` (or `"auto"`)

<img width="2050" height="1166" alt="snacks" src="https://github.com/user-attachments/assets/b96a0a4b-c07b-40d3-b58e-b25210ce4ec6" />

---

After the change, with `vim.g.vim.g.lazyvim_picker = "fzf"`

<img width="2050" height="1166" alt="fzf" src="https://github.com/user-attachments/assets/78db5032-1d7e-457d-ad8a-d8689a2aa049" />

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
