### PR TITLE
feat(avante): add visual mode support for edit command

### DIFF
--- a/lua/lazyvim/plugins/extras/ai/avante.lua
+++ b/lua/lazyvim/plugins/extras/ai/avante.lua
@@ -31,7 +31,7 @@ return {
       "AvanteToggle",
     },
     keys = {
-      { "<leader>a", "", desc = "+ai", mode = { "n", "v" } },
+      { "<leader>a", "", desc = "+ai", mode = { "n", "x" } },
       { "<leader>aa", "<cmd>AvanteAsk<CR>", desc = "Ask Avante" },
       { "<leader>ac", "<cmd>AvanteChat<CR>", desc = "Chat with Avante" },
       { "<leader>ae", "<cmd>AvanteEdit<CR>", mode = { "n", "x" }, desc = "Edit Avante" },

--- a/lua/lazyvim/plugins/extras/ai/avante.lua
+++ b/lua/lazyvim/plugins/extras/ai/avante.lua
@@ -31,9 +31,10 @@ return {
       "AvanteToggle",
     },
     keys = {
+      { "<leader>a", "", desc = "+ai", mode = { "n", "v" } },
       { "<leader>aa", "<cmd>AvanteAsk<CR>", desc = "Ask Avante" },
       { "<leader>ac", "<cmd>AvanteChat<CR>", desc = "Chat with Avante" },
-      { "<leader>ae", "<cmd>AvanteEdit<CR>", desc = "Edit Avante" },
+      { "<leader>ae", "<cmd>AvanteEdit<CR>", mode = { "n", "v" }, desc = "Edit Avante" },
       { "<leader>af", "<cmd>AvanteFocus<CR>", desc = "Focus Avante" },
       { "<leader>ah", "<cmd>AvanteHistory<CR>", desc = "Avante History" },
       { "<leader>am", "<cmd>AvanteModels<CR>", desc = "Select Avante Model" },

--- a/lua/lazyvim/plugins/extras/ai/avante.lua
+++ b/lua/lazyvim/plugins/extras/ai/avante.lua
@@ -34,7 +34,7 @@ return {
       { "<leader>a", "", desc = "+ai", mode = { "n", "v" } },
       { "<leader>aa", "<cmd>AvanteAsk<CR>", desc = "Ask Avante" },
       { "<leader>ac", "<cmd>AvanteChat<CR>", desc = "Chat with Avante" },
-      { "<leader>ae", "<cmd>AvanteEdit<CR>", mode = { "n", "v" }, desc = "Edit Avante" },
+      { "<leader>ae", "<cmd>AvanteEdit<CR>", mode = { "n", "x" }, desc = "Edit Avante" },
       { "<leader>af", "<cmd>AvanteFocus<CR>", desc = "Focus Avante" },
       { "<leader>ah", "<cmd>AvanteHistory<CR>", desc = "Avante History" },
       { "<leader>am", "<cmd>AvanteModels<CR>", desc = "Select Avante Model" },


### PR DESCRIPTION
## Description

Added visual mode to keymap so it can be used on code selections

## Screenshots

<img width="797" height="695" alt="screenshot" src="https://github.com/user-attachments/assets/1832cc4f-37d8-4498-a3a6-ff27bf4d44dd" />

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
