### PR TITLE
fix(haskell): prevent mason-lspconfig from starting hls

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/haskell.lua
+++ b/lua/lazyvim/plugins/extras/lang/haskell.lua
@@ -51,11 +51,6 @@ return {
   },
 
   {
-    "mason-org/mason.nvim",
-    opts = { ensure_installed = { "haskell-language-server" } },
-  },
-
-  {
     "mfussenegger/nvim-dap",
     optional = true,
     dependencies = {
@@ -132,13 +127,22 @@ return {
         haskell = { "hlint" },
       },
     },
+    dependencies = {
+      {
+        "mason-org/mason.nvim",
+        opts = { ensure_installed = { "hlint" } },
+      },
+    },
   },
 
-  -- Make sure lspconfig doesn't start hls,
+  -- Make sure neither lspconfig nor mason-lspconfig starts hls,
   -- as it conflicts with haskell-tools
   {
     "neovim/nvim-lspconfig",
     opts = {
+      servers = {
+        hls = {},
+      },
       setup = {
         hls = function()
           return true


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
The Haskell extra uses `haskell-tools.nvim`, which manages its own HLS client. The extra already defines a `setup.hls` handler that returns `true`, but `hls` was not present in `opts.servers`, so LazyVim never applied that handler. With `mason-lspconfig` automatic enable, this can cause a second `hls` client to start alongside `haskell-tools.nvim`.

This PR adds `hls = {}` to `opts.servers` so the existing `setup.hls` handler is applied and `hls` is excluded from the normal LSP/Mason automatic-enable path.

Since `hls` is now registered as an LSP server, `haskell-language-server` no longer needs to be explicitly listed in `mason.nvim`’s `ensure_installed`.

This also adds `hlint` to Mason when `nvim-lint` is enabled, since the extra configures `hlint` for Haskell files.

## Related Issue(s)

- Fixes #7146

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
