### PR TITLE
fix(rust): don't exclude bin/

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/rust.lua
+++ b/lua/lazyvim/plugins/extras/lang/rust.lua
@@ -93,7 +93,6 @@ return {
                 ".jj",
                 ".github",
                 ".gitlab",
-                "bin",
                 "node_modules",
                 "target",
                 "venv",


### PR DESCRIPTION
## Description

Having the following structure is pretty common for rust workspaces (speaking from experience at 2 very different companies):
- bin/
- lib/
- tests/
Other entries in this list are well-known but `bin` is very ambiguous & is silently breaking rust-analyzer for LazyVim users in my company.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
