### PR TITLE
feat(lsp): wildcard disable mason

### DIFF
--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -254,7 +254,9 @@ return {
           return
         end
 
-        local use_mason = sopts.mason ~= false and vim.tbl_contains(mason_all, server)
+        local use_mason = sopts.mason ~= false
+          and opts.servers["*"].mason ~= false
+          and vim.tbl_contains(mason_all, server)
         local setup = opts.setup[server] or opts.setup["*"]
         if setup and setup(server, sopts) then
           mason_exclude[#mason_exclude + 1] = server


### PR DESCRIPTION
This PR adds the option to opt out all LSP servers from `mason-lspconfig` automatic installation. This is handy when the user wants to have total control over the `ensure_installed` list. To do so:

```lua
servers = {
  ["*"] = {
    mason = false,
  },
}
```