### PR TITLE
fix(config): correct typos in comments and keymap descriptions

### DIFF
--- a/lua/lazyvim/config/options.lua
+++ b/lua/lazyvim/config/options.lua
@@ -92,7 +92,7 @@ opt.sessionoptions = { "buffers", "curdir", "tabpages", "winsize", "help", "glob
 opt.shiftround = true -- Round indent
 opt.shiftwidth = 2 -- Size of an indent
 opt.shortmess:append({ W = true, I = true, c = true, C = true })
-opt.showmode = false -- Dont show mode since we have a statusline
+opt.showmode = false -- Don't show mode since we have a statusline
 opt.sidescrolloff = 8 -- Columns of context
 opt.signcolumn = "yes" -- Always show the signcolumn, otherwise it would shift the text each time
 opt.smartcase = true -- Don't ignore case with capitals

--- a/lua/lazyvim/plugins/extras/lang/clojure.lua
+++ b/lua/lazyvim/plugins/extras/lang/clojure.lua
@@ -78,13 +78,13 @@ return {
             { "n", "x" },
             "[c",
             "<CMD>call search('^; -\\+$', 'bw')<CR>",
-            { silent = true, buffer = true, desc = "Jumps to the begining of previous evaluation output." }
+            { silent = true, buffer = true, desc = "Jumps to the beginning of previous evaluation output." }
           )
           vim.keymap.set(
             { "n", "x" },
             "]c",
             "<CMD>call search('^; -\\+$', 'w')<CR>",
-            { silent = true, buffer = true, desc = "Jumps to the begining of next evaluation output." }
+            { silent = true, buffer = true, desc = "Jumps to the beginning of next evaluation output." }
           )
         end,
       })


### PR DESCRIPTION
## Description
Fix a couple of small typos found in source files:

- `lua/lazyvim/config/options.lua`: `Dont` → `Don't` in inline comment
- `lua/lazyvim/plugins/extras/lang/clojure.lua`: `begining` → `beginning` in two keymap `desc` strings

## Related Issue(s)
N/A

## Screenshots
N/A
## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
