### PR TITLE
feat(lsp): update configs for codelens

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -161,6 +161,24 @@ if vim.lsp.inlay_hint then
   Snacks.toggle.inlay_hints():map("<leader>uh")
 end
 
+if vim.lsp.codelens.enable then
+  if Snacks.toggle.codelens then
+    Snacks.toggle.codelens():map("<leader>cC")
+  else
+    -- TODO: remove this after codelens toggler is added to Snacks
+    Snacks.toggle.new({
+      id = "codelens",
+      name = "Codelens",
+      get = function()
+        return vim.lsp.codelens.is_enabled({ bufnr = 0 })
+      end,
+      set = function(state)
+        vim.lsp.codelens.enable(state, { bufnr = 0 })
+      end,
+    }):map("<leader>cC")
+  end
+end
+
 -- lazygit
 if vim.fn.executable("lazygit") == 1 then
   map("n", "<leader>gg", function() Snacks.lazygit( { cwd = LazyVim.root.git() }) end, { desc = "Lazygit (Root Dir)" })

--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -161,7 +161,7 @@ if vim.lsp.inlay_hint then
   Snacks.toggle.inlay_hints():map("<leader>uh")
 end
 
-if vim.lsp.codelens.enable then
+if vim.fn.has("nvim-0.12") == 1 then
   if Snacks.toggle.codelens then
     Snacks.toggle.codelens():map("<leader>cC")
   else
@@ -177,6 +177,10 @@ if vim.lsp.codelens.enable then
       end,
     }):map("<leader>cC")
   end
+else
+  require("lazyvim.plugins.lsp.keymaps").set({}, {
+    { "<leader>cC", vim.lsp.codelens.refresh, desc = "Refresh & Display Codelens", mode = { "n" }, has = "codeLens" },
+  })
 end
 
 -- lazygit

--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -45,6 +45,7 @@ return {
         -- provide the code lenses.
         codelens = {
           enabled = false,
+          exclude = {}, -- filetypes for which you don't want to enable codelens
         },
         -- Enable this to enable the builtin LSP folding on Neovim.
         -- Be aware that you also will need to properly configure your LSP server to
@@ -87,7 +88,6 @@ return {
               { "<c-k>", function() return vim.lsp.buf.signature_help() end, mode = "i", desc = "Signature Help", has = "signatureHelp" },
               { "<leader>ca", vim.lsp.buf.code_action, desc = "Code Action", mode = { "n", "x" }, has = "codeAction" },
               { "<leader>cc", vim.lsp.codelens.run, desc = "Run Codelens", mode = { "n", "x" }, has = "codeLens" },
-              { "<leader>cC", vim.lsp.codelens.refresh, desc = "Refresh & Display Codelens", mode = { "n" }, has = "codeLens" },
               { "<leader>cR", function() Snacks.rename.rename_file() end, desc = "Rename File", mode ={"n"}, has = { "workspace/didRenameFiles", "workspace/willRenameFiles" } },
               { "<leader>cr", vim.lsp.buf.rename, desc = "Rename", has = "rename" },
               { "<leader>cA", LazyVim.lsp.action.source, desc = "Source Action", has = "codeAction" },
@@ -199,13 +199,27 @@ return {
       end
 
       -- code lens
-      if opts.codelens.enabled and vim.lsp.codelens then
+      if opts.codelens.enabled then
         Snacks.util.lsp.on({ method = "textDocument/codeLens" }, function(buffer)
-          vim.lsp.codelens.refresh()
-          vim.api.nvim_create_autocmd({ "BufEnter", "CursorHold", "InsertLeave" }, {
-            buffer = buffer,
-            callback = vim.lsp.codelens.refresh,
-          })
+          if vim.lsp.codelens.enable then
+            -- nvim v0.12
+            if
+              vim.api.nvim_buf_is_valid(buffer)
+              and vim.bo[buffer].buftype == ""
+              and not vim.tbl_contains(opts.codelens.exclude, vim.bo[buffer].filetype)
+            then
+              vim.lsp.codelens.enable(true, { bufnr = buffer })
+            end
+          else
+            -- nvim v0.11
+            if not vim.tbl_contains(opts.codelens.exclude, vim.bo[buffer].filetype) then
+              vim.lsp.codelens.refresh()
+              vim.api.nvim_create_autocmd({ "BufEnter", "CursorHold", "InsertLeave" }, {
+                buffer = buffer,
+                callback = vim.lsp.codelens.refresh,
+              })
+            end
+          end
         end)
       end
 

--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -201,18 +201,14 @@ return {
       -- code lens
       if opts.codelens.enabled then
         Snacks.util.lsp.on({ method = "textDocument/codeLens" }, function(buffer)
-          if vim.lsp.codelens.enable then
-            -- nvim v0.12
-            if
-              vim.api.nvim_buf_is_valid(buffer)
-              and vim.bo[buffer].buftype == ""
-              and not vim.tbl_contains(opts.codelens.exclude, vim.bo[buffer].filetype)
-            then
+          if
+            vim.api.nvim_buf_is_valid(buffer)
+            and vim.bo[buffer].buftype == ""
+            and not vim.tbl_contains(opts.codelens.exclude, vim.bo[buffer].filetype)
+          then
+            if vim.fn.has("nvim-0.12") == 1 then
               vim.lsp.codelens.enable(true, { bufnr = buffer })
-            end
-          else
-            -- nvim v0.11
-            if not vim.tbl_contains(opts.codelens.exclude, vim.bo[buffer].filetype) then
+            else
               vim.lsp.codelens.refresh()
               vim.api.nvim_create_autocmd({ "BufEnter", "CursorHold", "InsertLeave" }, {
                 buffer = buffer,


### PR DESCRIPTION
## Description

The legacy `vim.lsp.codelens.refresh` has been deprecated and will be removed in Neovim 0.13. 

This PR switches CodeLens using the new `vim.lsp.codelens.enable` interface. For configuration, it follows `inlay_hint` by introducing an `exclude` option to filter specific filetypes. 

This PR also adds a toggler for CodeLens.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
