### PR TITLE
feat(lsp): add support to builtin document color

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -161,6 +161,24 @@ if vim.lsp.inlay_hint then
   Snacks.toggle.inlay_hints():map("<leader>uh")
 end
 
+if vim.lsp.document_color then
+  if Snacks.toggle.document_color then
+    Snacks.toggle.document_color():map("<leader>uW") -- maybe other key?
+  else
+    -- TODO: remove this after the toggler is added to Snacks
+    Snacks.toggle.new({
+      id = "document_color",
+      name = "Document Color",
+      get = function()
+        return vim.lsp.document_color.is_enabled({ bufnr = 0 })
+      end,
+      set = function(state)
+        vim.lsp.document_color.enable(state, { bufnr = 0 })
+      end,
+    }):map("<leader>uW")
+  end
+end
+
 -- lazygit
 if vim.fn.executable("lazygit") == 1 then
   map("n", "<leader>gg", function() Snacks.lazygit( { cwd = LazyVim.root.git() }) end, { desc = "Lazygit (Root Dir)" })

--- a/lua/lazyvim/plugins/lsp/init.lua
+++ b/lua/lazyvim/plugins/lsp/init.lua
@@ -46,6 +46,15 @@ return {
         codelens = {
           enabled = false,
         },
+        -- Enable this to enable the builtin LSP document color on Neovim.
+        -- Be aware that you also will need to properly configure your LSP server to
+        -- provide the document color.
+        ---@type vim.lsp.document_color.Opts|{enabled:boolean, exclude:string[]}
+        document_color = {
+          enabled = true,
+          exclude = {}, -- filetypes for which you don't want to enable document color
+          style = "background",
+        },
         -- Enable this to enable the builtin LSP folding on Neovim.
         -- Be aware that you also will need to properly configure your LSP server to
         -- provide the folds.
@@ -185,6 +194,26 @@ return {
             and not vim.tbl_contains(opts.inlay_hints.exclude, vim.bo[buffer].filetype)
           then
             vim.lsp.inlay_hint.enable(true, { bufnr = buffer })
+          end
+        end)
+      end
+
+      -- document color
+      if vim.fn.has("nvim-0.12") == 1 then
+        Snacks.util.lsp.on({ method = "textDocument/documentColor" }, function(buffer)
+          if vim.api.nvim_buf_is_valid(buffer) and vim.bo[buffer].buftype == "" then
+            -- The document color is enabled by default. To make our config work,
+            -- we need to disable it first and then re-enable it depending on our config.
+            -- We also pass the style to the function at this time,
+            -- which will be stored in a local variable and used when the document color is enabled.
+            vim.lsp.document_color.enable(false, { bufnr = buffer }, { style = opts.document_color.style })
+
+            if
+              opts.document_color.enabled
+              and not vim.tbl_contains(opts.document_color.exclude, vim.bo[buffer].filetype)
+            then
+              vim.lsp.document_color.enable(true, { bufnr = buffer })
+            end
           end
         end)
       end


### PR DESCRIPTION
## Description

Add support to new document color API in nvim v0.12.

Not sure which keybinding should be used for toggling, as both `<leader>uc` (toggle conceal level) and `<leader>uC` (change colorschemes) are already used.

### Related PR

I have opened a PR to add document color toggler to Snacks.

https://github.com/folke/snacks.nvim/pull/2851

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
