### PR TITLE
fix(core): check buffer validity in autocmd to prevent `keymap.set()` throwing

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -74,6 +74,10 @@ vim.api.nvim_create_autocmd("FileType", {
   callback = function(event)
     vim.bo[event.buf].buflisted = false
     vim.schedule(function()
+      -- without this, vim.keymap.set below may throw on transient buffers
+      if not vim.api.nvim_buf_is_valid(event.buf) then
+        return
+      end
       vim.keymap.set("n", "q", function()
         vim.cmd("close")
         pcall(vim.api.nvim_buf_delete, event.buf, { force = true })


### PR DESCRIPTION
the buffer that triggered the autocmd could be gone by the time
`vim.schedule` runs `keymap.set`, e.g. with transient buffers created by
`nvim_get_option_value()`

i discovered this bug when using ultimate-autopairs in grug-far buffers. autopairs calls `nvim_get_option_value()` on certain keys, spawning a transient grug-far ft buffer and triggering this ft autocmd, but as vim.schedule delays the `keymap.set`, it throws on invalid buffer id

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
