### PR TITLE
feat(keymaps): add <leader>; keymap to reopen dashboard

### DIFF
--- a/lua/lazyvim/config/keymaps.lua
+++ b/lua/lazyvim/config/keymaps.lua
@@ -88,8 +88,11 @@ map("x", ">", ">gv")
 map("n", "gco", "o<esc>Vcx<esc><cmd>normal gcc<cr>fxa<bs>", { desc = "Add Comment Below" })
 map("n", "gcO", "O<esc>Vcx<esc><cmd>normal gcc<cr>fxa<bs>", { desc = "Add Comment Above" })
 
--- lazy
+-- lazy / dashboard
 map("n", "<leader>l", "<cmd>Lazy<cr>", { desc = "Lazy" })
+map("n", "<leader>;", function()
+  Snacks.dashboard()
+end, { desc = "Dashboard" })
 
 -- new file
 map("n", "<leader>fn", "<cmd>enew<cr>", { desc = "New File" })


### PR DESCRIPTION
The dashboard is the primary entry screen in LazyVim, but once dismissed there is no built-in way to return to it. Users currently have to add their own mapping, exit and restart, or rely on `:Lazy` as a workaround.

`<leader>;` is available (no collision in normal mode) and fits the existing symbol-key cluster: `<leader>,` `.` `/` `:` — the semicolon mnemonic suggests "pause/reorient." The call `Snacks.dashboard()` uses the standard snacks.nvim API and respects the default preset configured in `ui.lua`.

No breaking changes. No existing mapping is overridden.