### PR TITLE
fix(autocmds): replace `vim.hl.on_yank` with `vim.hl.hl_op` for `nvim-0.13` and above

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -18,7 +18,11 @@ vim.api.nvim_create_autocmd({ "FocusGained", "TermClose", "TermLeave" }, {
 vim.api.nvim_create_autocmd("TextYankPost", {
   group = augroup("highlight_yank"),
   callback = function()
-    (vim.hl or vim.highlight).on_yank()
+    if vim.fn.has("nvim-0.13") then
+      vim.hl.hl_op()
+    else
+      (vim.hl or vim.highlight).on_yank()
+    end
   end,
 })
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

A recent PR (https://github.com/neovim/neovim/pull/39777) replaced `vim.hl.on_yank` with a more generic `vim.hl.hl_op` and deprecated the former.

This PR simply checks for `nvim-0.13` support and uses the new interface if available.

This removes a deprecation warning and will avoid an error when `on_yank` gets deprecated in the nvim 0.14 release.

Thanks!

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
