### PR TITLE
fix(go): use semanticTokens if setup in gopls config init_options

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/go.lua
+++ b/lua/lazyvim/plugins/extras/lang/go.lua
@@ -14,6 +14,9 @@ return {
     opts = {
       servers = {
         gopls = {
+          init_options = {
+            semanticTokens = true,
+          },
           settings = {
             gopls = {
               gofumpt = true,
@@ -46,7 +49,6 @@ return {
               completeUnimported = true,
               staticcheck = true,
               directoryFilters = { "-.git", "-.vscode", "-.idea", "-.vscode-test", "-node_modules" },
-              semanticTokens = true,
             },
           },
         },
@@ -56,7 +58,12 @@ return {
           -- workaround for gopls not supporting semanticTokensProvider
           -- https://github.com/golang/go/issues/54531#issuecomment-1464982242
           Snacks.util.lsp.on({ name = "gopls" }, function(_, client)
-            if not client.server_capabilities.semanticTokensProvider then
+            if
+              client.config
+              and client.config.init_options
+              and client.config.init_options.semanticTokens
+              and not client.server_capabilities.semanticTokensProvider
+            then
               local semantic = client.config.capabilities.textDocument.semanticTokens
               client.server_capabilities.semanticTokensProvider = {
                 full = true,


### PR DESCRIPTION
## Description

Since upgrading to the go lsp (gopls) to version 0.22.0 we receive the following error on load of any Go file:

```
...nvim/lazy/LazyVim/lua/lazyvim/plugins/extras/lang/go.lua:64: attempt to index local 'semantic' (a nil value)
```

This PR adds a check to avoid this error.

If this causes degraded functionality, or a different fix around semantic tokens is needed, I do not know.

## Screenshots

<img width="1423" height="219" alt="image" src="https://github.com/user-attachments/assets/a4df1344-3e8f-4f29-9c8c-1257efed22b3" />

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
