### PR TITLE
fix(formatting): add zsh formatter with shfmt

### DIFF
--- a/lua/lazyvim/plugins/formatting.lua
+++ b/lua/lazyvim/plugins/formatting.lua
@@ -74,6 +74,7 @@ return {
           lua = { "stylua" },
           fish = { "fish_indent" },
           sh = { "shfmt" },
+          zsh = { "shfmt" },
         },
         -- The options you set here will be merged with the builtin formatters.
         -- You can also define any custom formatters here.


### PR DESCRIPTION
## Description

`shfmt` natively supports `zsh` formatting nowadays. This is documented in https://github.com/mvdan/sh/releases/tag/v3.13.0.

I've done this in my [local config](https://github.com/nickjj/dotfriedrice/commit/5976fb03a27df5f1ee9f7752baef50f7885e993a) to demonstrate it works:

```lua
  {
    "stevearc/conform.nvim",
    opts = {
      formatters_by_ft = {
        zsh = { "shfmt" },
      },
    },
  },
```

I've been using `shfmt` to format zsh files since that version with zsh support was released.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
