### PR TITLE
feat(oxc): add option to require oxfmt config to enable formatting

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typescript/oxc.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript/oxc.lua
@@ -1,3 +1,11 @@
+if lazyvim_docs then
+  -- Enable the option to require an oxfmt config file
+  -- If no oxfmt config file is found, the formatter will not be used
+  vim.g.lazyvim_oxfmt_needs_config = false
+end
+
+local M = {}
+
 local supported = {
   "javascript",
   "javascriptreact",
@@ -10,17 +18,32 @@ local supported = {
   "astro",
 }
 
+local oxfmt_markers = {
+  ".oxfmtrc.json",
+  ".oxfmtrc.jsonc",
+  "oxfmt.config.ts",
+}
+
+local oxlint_markers = {
+  ".oxlintrc.json",
+  ".oxlintrc.jsonc",
+  "oxlint.config.ts",
+}
+
+--- Checks if a oxfmt config file exists for the given context
+---@module 'conform'
+---@param ctx conform.Context
+---@return boolean
+function M.has_oxfmt_config(ctx)
+  return vim.fs.root(ctx.buf, oxfmt_markers) ~= nil
+end
+
+M.has_oxfmt_config = LazyVim.memoize(M.has_oxfmt_config)
+
 return {
   recommended = function()
     return LazyVim.extras.wants({
-      root = {
-        ".oxlintrc.json",
-        ".oxlintrc.jsonc",
-        "oxlint.config.ts",
-        ".oxfmtrc.json",
-        ".oxfmtrc.jsonc",
-        "oxfmt.config.ts",
-      },
+      root = vim.list_extend(vim.list_extend({}, oxlint_markers), oxfmt_markers),
     })
   end,
 
@@ -33,8 +56,7 @@ return {
           root_dir = function(bufnr, on_dir)
             -- prefer the top-level oxlint config if it exists (monorepo support)
             local git = vim.fs.root(bufnr, ".git")
-            local markers = { ".oxlintrc.json", ".oxlintrc.jsonc", "oxlint.config.ts" }
-            local root = git and vim.fs.root(git, markers) or vim.fs.root(bufnr, markers)
+            local root = git and vim.fs.root(git, oxlint_markers) or vim.fs.root(bufnr, oxlint_markers)
             if root then
               on_dir(root)
             end
@@ -63,6 +85,13 @@ return {
         opts.formatters_by_ft[ft] = opts.formatters_by_ft[ft] or {}
         table.insert(opts.formatters_by_ft[ft], "oxfmt")
       end
+
+      opts.formatters = opts.formatters or {}
+      opts.formatters.oxfmt = {
+        condition = function(_, ctx)
+          return vim.g.lazyvim_oxfmt_needs_config ~= true or M.has_oxfmt_config(ctx)
+        end,
+      }
     end,
   },
 }


### PR DESCRIPTION
## Description

Adds `vim.g.lazyvim_oxfmt_needs_config`, which allows the use of the oxc extra even when working in projects that don't use oxfmt.

This is based on the existing `vim.g.lazyvim_prettier_needs_config` option in the prettier extra and follows the same pattern: a memoized `has_oxfmt_config(ctx)` helper wired in as a `conform` `formatters.oxfmt.condition`.

## Related Issue(s)

N/A

## Screenshots

N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
