### PR TITLE
fix(snacks.picker): flash with 2 snacks windows open

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/snacks_picker.lua
+++ b/lua/lazyvim/plugins/extras/editor/snacks_picker.lua
@@ -246,6 +246,14 @@ return {
                     mode = "search",
                     exclude = {
                       function(win)
+                        local source = picker.opts.source ~= "explorer" and picker.opts.source or nil
+                        local snacks_explorer = require("snacks").picker.get({ source = "explorer" })[1]
+                        local snacks_picker = source and require("snacks").picker.get({ source = source })[1]
+                        local picker_win = snacks_picker and snacks_picker.layout.wins["list"].win
+
+                        if snacks_explorer and snacks_picker then
+                          return win ~= picker_win
+                        end
                         return vim.bo[vim.api.nvim_win_get_buf(win)].filetype ~= "snacks_picker_list"
                       end,
                     },


### PR DESCRIPTION
## Description
Correctly show labels when 2 Snacks windows are open (explorer and some other picker).
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None, #7182 discussion.

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
