### PR TITLE
fix(autocmds): correct version check for nvim-0.13

### DIFF
--- a/lua/lazyvim/config/autocmds.lua
+++ b/lua/lazyvim/config/autocmds.lua
@@ -18,7 +18,7 @@ vim.api.nvim_create_autocmd({ "FocusGained", "TermClose", "TermLeave" }, {
 vim.api.nvim_create_autocmd("TextYankPost", {
   group = augroup("highlight_yank"),
   callback = function()
-    if vim.fn.has("nvim-0.13") then
+    if vim.fn.has("nvim-0.13") == 1 then
       vim.hl.hl_op()
     else
       (vim.hl or vim.highlight).on_yank()


### PR DESCRIPTION
## Description
Fix the check for `nvim-0.13` for autocmd TextYankPost
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
