### PR TITLE
fix(fzf): solve duplicate registration `ui_select`

### DIFF
--- a/lua/lazyvim/plugins/extras/editor/fzf.lua
+++ b/lua/lazyvim/plugins/extras/editor/fzf.lua
@@ -193,6 +193,7 @@ return {
         opts = vim.tbl_deep_extend("force", fix(require("fzf-lua.profiles.default-title")), opts)
         opts[1] = nil
       end
+      opts.ui_select = nil
       require("fzf-lua").setup(opts)
     end,
     init = function()


### PR DESCRIPTION
## Description
`fzf-lua` registers its own `ui_select` implementation when `opts.ui_select` is a truthy value. See code [here](https://github.com/ibhagwan/fzf-lua/blob/774150bc05f774af1df614f55d156b3318c6decd/lua/fzf-lua/init.lua#L222-L231). 

On the first invocation of `ui_select` you get a notification about `vim.ui.select already registered to fzf-lua`, because our `init` function already registers it once and then also re-registers when plugin is setup.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None, just came across it due to #7212.
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
